### PR TITLE
Remove vault url config on Omise.js client

### DIFF
--- a/assets/javascripts/omise-myaccount-card-handler.js
+++ b/assets/javascripts/omise-myaccount-card-handler.js
@@ -82,7 +82,6 @@
 		}else{
 			hideError();
 			if(Omise){
-				Omise.config.defaultHost = omise_params.vault_url;
 				Omise.setPublicKey(omise_params.key);
 				Omise.createToken("card", card, function (statusCode, response) {
 				    if (statusCode == 200) {
@@ -107,7 +106,9 @@
 							}, "json"
 						);
 				    } else {
-				    	if(response.responseJSON && response.responseJSON.message){
+				    	if(response.message){
+				    		showError( "Unable to create a card. " + response.message, $form );
+				    	}else if(response.responseJSON && response.responseJSON.message){
 				    		showError( "Unable to create a card. " + response.responseJSON.message, $form );
 				    	}else if(response.status==0){
 				    		showError( "Unable to create a card. No response from Omise Api.", $form );

--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -93,7 +93,6 @@
 				}else{
 					hideError();
 					if(Omise){
-						Omise.config.defaultHost = omise_params.vault_url;
 						Omise.setPublicKey(omise_params.key);
 						Omise.createToken("card", card, function (statusCode, response) {
 						    if (statusCode == 200) {
@@ -105,7 +104,9 @@
 						    	$( '#omise_card_security_code' ).val("");
 								$form.submit();
 						    } else {
-						    	if(response.responseJSON && response.responseJSON.message){
+						    	if(response.message){
+						    		showError( "Unable to process payment with Omise. " + response.message );
+						    	}else if(response.responseJSON && response.responseJSON.message){
 						    		showError( "Unable to process payment with Omise. " + response.responseJSON.message );
 						    	}else if(response.status==0){
 						    		showError( "Unable to process payment with Omise. No response from Omise Api." );

--- a/omise-gateway.php
+++ b/omise-gateway.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die("No direct script access allowed.");
  * Plugin Name: Omise Gateway Wordpress plugin
  * Plugin URI: http://docs.omise.co/omise-wp
  * Description: Allows easy integrating the Omise Payment gateway
- * Version: 1.0
+ * Version: 1.0.2
  * Author: Omise Team
  * Author URI: https://www.omise.co
  * License: Copyright 2014. Omise Co.,Ltd.
@@ -14,7 +14,7 @@ defined('ABSPATH') or die("No direct script access allowed.");
 define("OMISE_PROTOCOL_PREFIX", "https://");
 define("OMISE_VAULT_HOST", "vault.omise.co");
 define("OMISE_API_HOST", "api.omise.co");
-define("OMISE_WOOCOMMERCE_PLUGIN_VERSION", "1.0.1");
+define("OMISE_WOOCOMMERCE_PLUGIN_VERSION", "1.0.2");
 
 require_once 'omise-util.php';
 require_once 'omise-api-wrapper.php';


### PR DESCRIPTION
This fixes the issue that cannot create a token after new Omise.js is released