### PR TITLE
Integrate 3D Secure feature

### DIFF
--- a/omise-api-wrapper.php
+++ b/omise-api-wrapper.php
@@ -20,10 +20,10 @@ if(!class_exists('Omise')){
 		/**
 		 * Retrieve a charge
 		 * @param string $apiKey
-		 * @param Array $chargeInfo
+		 * @param Array $charge_id
 		 * @return mixed
 		 */
-		public static function get_charges($apiKey, $charge_id=""){
+		public static function get_charge($apiKey, $charge_id){
 			$result = self::call_api($apiKey, "GET", "/charges/{$charge_id}");
 			return json_decode($result);
 		}

--- a/omise-api-wrapper.php
+++ b/omise-api-wrapper.php
@@ -16,6 +16,17 @@ if(!class_exists('Omise')){
 			$result = self::call_api($apiKey, "POST", "/charges", $chargeInfo);
 			return json_decode($result);
 		}
+
+		/**
+		 * Retrieve a charge
+		 * @param string $apiKey
+		 * @param Array $chargeInfo
+		 * @return mixed
+		 */
+		public static function get_charges($apiKey, $charge_id=""){
+			$result = self::call_api($apiKey, "GET", "/charges/{$charge_id}");
+			return json_decode($result);
+		}
 		
 		/**
 		 * Creates a customer

--- a/omise-gateway.php
+++ b/omise-gateway.php
@@ -22,6 +22,7 @@ require_once 'omise-wc-gateway.php';
 require_once 'omise-wc-myaccount.php';
 require_once 'omise-wp-admin.php';
 
+add_action ( 'init', 'register_omise_wc_gateway_post_type' );
 add_action ( 'plugins_loaded', 'register_omise_wc_gateway_plugin', 0 );
 add_action ( 'plugins_loaded', 'prepare_omise_myaccount_panel', 0 );
 add_action ( 'plugins_loaded', array ( Omise_Admin::get_instance(), 'register_admin_page_and_actions' ) );

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -64,9 +64,9 @@ function register_omise_wc_gateway_plugin() {
 								'default' => 'yes' 
 						),
 						'omise_3ds' => array (
-								'title' => __ ( '3DS Support', $this->gateway_name ),
+								'title' => __ ( '3DSecure Support', $this->gateway_name ),
 								'type' => 'checkbox',
-								'label' => __ ( 'Enable the 3DS support', $this->gateway_name ),
+								'label' => __ ( 'Enables 3DSecure on this account', $this->gateway_name ),
 								'default' => 'no'
 						),
 						'title' => array (

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -31,7 +31,7 @@ function register_omise_wc_gateway_plugin() {
 				$this->public_key = $this->sandbox ? $this->test_public_key : $this->live_public_key;
 				$this->private_key = $this->sandbox ? $this->test_private_key : $this->live_private_key;
 				
-				add_action( 'woocommerce_api_wc_gateway_omise', array( $this, 'omise_3ds_handler' ) );
+				add_action( 'woocommerce_api_wc_gateway_' . $this->id, array( $this, 'omise_3ds_handler' ) );
 
 				add_action ( 'woocommerce_update_options_payment_gateways_' . $this->id, array (
 						&$this,
@@ -214,6 +214,8 @@ function register_omise_wc_gateway_plugin() {
 					$result = Omise::create_charge($this->private_key, $data);
 					if ($result->object === "error") {
 						throw new Exception ($result->message);
+					} if ($result->failure_code) {
+						throw new Exception ($result->failure_message);
 					} else {
 						$post_id = wp_insert_post(array(
 							'post_title' 	=> 'Omise Charge Id '.$result->id,

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -320,7 +320,7 @@ function register_omise_wc_gateway_plugin() {
 			public function omise_3ds_handler()
 			{
 				if (!$_GET['order_id'])
-					die("order_id");
+					wp_die( "Order was not found", "Omise Payment Gateway: Checkout", array( 'response' => 500 ) );
 
 				$order_id 	= $_GET['order_id'];
 
@@ -329,16 +329,16 @@ function register_omise_wc_gateway_plugin() {
 					'meta_query' 	=> array(array(
 						'key' 		=> '_wc_order_id',
 						'value' 	=> $order_id,
-						'compare'	=> 'LIKE'
+						'compare'	=> '='
 					))
 				));
 
 				if (empty($posts))
-					die("charge was not found");
+					wp_die( "Charge was not found", "Omise Payment Gateway: Checkout", array( 'response' => 500 ) );
 
 				$order = wc_get_order($order_id);
 				if (!$order)
-					die("order was not found");
+					wp_die( "Order was not found", "Omise Payment Gateway: Checkout", array( 'response' => 500 ) );
 
 				$confirmed_url 	= get_post_custom_values('_wc_confirmed_url', $posts[0]->ID);
 				$confirmed_url 	= $confirmed_url[0];
@@ -358,6 +358,7 @@ function register_omise_wc_gateway_plugin() {
 					header("Location: ".$confirmed_url);
 				}
 
+				wp_die( "Access denied", "Access Denied", array( 'response' => 401 ) );
 				die();
 			}
 		}

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -218,7 +218,7 @@ function register_omise_wc_gateway_plugin() {
 						throw new Exception ($result->failure_message);
 					} else {
 						$post_id = wp_insert_post(array(
-							'post_title' 	=> 'Omise Charge Id '.$result->id,
+							'post_title'	=> 'Omise Charge Id '.$result->id,
 							'post_type'		=> 'omise_charge_items',
 							'post_status'	=> 'publish'
 						));
@@ -346,7 +346,7 @@ function register_omise_wc_gateway_plugin() {
 				$charge_id 		= get_post_custom_values('_omise_charge_id', $posts[0]->ID);
 				$charge_id 		= $charge_id[0];
 
-				$result = Omise::get_charges($this->private_key, $charge_id);
+				$result = Omise::get_charge($this->private_key, $charge_id);
 
 				if ($this->is_charge_success($result)) {
 					$order->payment_complete();
@@ -379,7 +379,6 @@ function register_omise_wc_gateway_post_type() {
 			'name' => 'Omise Charge Items',
 			'singular_name' => 'Omise Charge Item'
 		),
-		'public'	=> true,
 		'supports'	=> array('title','custom-fields')
 	));
 }


### PR DESCRIPTION
## PR Purpose
Add 3D Secure feature into checkout step of WooCommerce checkout page.

#### What's this PR do?
After merge this PR. User will be able to enable the 3D Secure feature in their site from their admin page).

It will change a little bit of the checkout process. From white label to 3D secure means, after you click "checkout button" it will redirect to a page that coming from 3D secure feature. Then, if everything pass. It will be redirected back to a merchant's site for continue a checkout process of WooCommerce.