### PR TITLE
Added Omise-Version into the cURL request header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+Change Log
+==========
+
+An [unreleased] version is not available on `master` branch and is subject to changes and must not be considered final. Elements of unreleased list may be edited or removed at any time.
+[unreleased]
+------------
+- *`Added`* Added Omise-Version into the cURL request header.
+
+[1.1.0] - 2015-09-24
+--------------------
+- *`Added`* Adds support for 3-D Secure.
+
+[1.0.2] - 2015-03-23
+--------------------
+- *`Fixed`* Fix create token issue.
+
+[1.0.1] - 2015-03-10
+--------------------
+- *`Added`* Support fund transfers.
+
+[1.0.0] - 2015-01-20
+--------------------
+- *`Added`* First version supports.
+  - Charge a card
+  - Save a card
+  - Delete a card
+
+

--- a/omise-api-wrapper.php
+++ b/omise-api-wrapper.php
@@ -99,6 +99,7 @@ if(!class_exists('Omise')){
 			
 			$headers = array(
 					'Authorization'  => 'Basic ' . base64_encode( $apiKey.':' ),
+					'Omise-Version' => '2014-07-27',
 					'User-Agent' => 'OmiseWooCommerce/'.OMISE_WOOCOMMERCE_PLUGIN_VERSION.' WooCommerce/'.WC_VERSION.' Wordpress/'.$wp_version
 			);
 			


### PR DESCRIPTION
## PR Purpose
- Added Omise-Version into the cURL request header for support the day that the new Omise APIs comes.

(I've already tested on staging. I got `paid` when didn't pass `Omise-Version` and `captured` when pass `Omise-Version: 2014-07-27` properly.)