### PR TITLE
Support JPY currency 

### DIFF
--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -195,12 +195,18 @@ function register_omise_wc_gateway_plugin() {
 						}
 					}
 					
-					$success = false;
+					$success        = false;
+					$order_currency = $order->get_order_currency();
+					if ( 'THB' === strtoupper( $order_currency ) )
+						$amount = $order->get_total() * 100;
+					else
+						$amount = $order->get_total();
+
 					$data = array (
-						"amount" => $order->get_total () * 100,
-						"currency" => $order->get_order_currency (),
+						"amount"      => $amount,
+						"currency"    => $order_currency,
 						"description" => "WooCommerce Order id " . $order_id,
-						"return_uri" => add_query_arg( 'order_id', $order_id, site_url()."?wc-api=wc_gateway_omise" )
+						"return_uri"  => add_query_arg( 'order_id', $order_id, site_url()."?wc-api=wc_gateway_omise" )
 					);
 					
 					if (! empty ( $card_id ) && ! empty ( $omise_customer_id )) {
@@ -293,6 +299,7 @@ function register_omise_wc_gateway_plugin() {
 			public function get_icon() {
 				$icon = '<img src="' . WC_HTTPS::force_https_url ( WC ()->plugin_url () . '/assets/images/icons/credit-cards/visa.png' ) . '" alt="Visa" />';
 				$icon .= '<img src="' . WC_HTTPS::force_https_url ( WC ()->plugin_url () . '/assets/images/icons/credit-cards/mastercard.png' ) . '" alt="Mastercard" />';
+				$icon .= '<img src="' . WC_HTTPS::force_https_url ( WC ()->plugin_url () . '/assets/images/icons/credit-cards/jcb.png' ) . '" alt="JCB" />';
 				
 				return apply_filters ( 'woocommerce_gateway_icon', $icon, $this->id );
 			}

--- a/omise-wp-admin.php
+++ b/omise-wp-admin.php
@@ -86,11 +86,11 @@ if (! class_exists ( 'Omise_Admin' )) {
         }
         
         $balance = Omise::get_balance( $this->private_key );
-        if ( $balance->currency === "thb" ) {
+        if ( strtoupper( $balance->currency ) === "THB" ) {
           $transfer_amount = $transfer_amount * 100;
         }
 
-        $transfer = Omise::create_transfer ( $this->private_key, empty ( $transfer_amount ) ? null : $transfer_amount ); // transfer in satangs
+        $transfer = Omise::create_transfer ( $this->private_key, empty ( $transfer_amount ) ? null : $transfer_amount );
         
         if ($this->is_transfer_success($transfer)) {
           $result_message_type = 'updated';


### PR DESCRIPTION
#### 1. Objective reason

Supported JPY currency

#### 2. Description of change

1. From the previous version, at the charge process, we always multiply total amount with 100 for `satang`. So, I added 1 condition to check multiply 100 only when `order currency` is `thb`
2. Added `JCB` logo to the Omise payment method.
  <img width="852" alt="screen shot 2559-05-23 at 6 34 35 am" src="https://cloud.githubusercontent.com/assets/2154669/15457270/78caebd6-20b0-11e6-8bce-1f3ec8d99125.png">


#### 3. Developers affected by the change

`-`

#### 4. Impact of the change

You have to match between your WooCommerce's currency config and Omise account.
i.e. if you want to proceed payment with `JPY` currency.
You have to
1. Set your WooCommerce's currency to JPY (WooCommerce > Settings > General > Currency Options)
2. Use public/secret key from Omise Japan account.

otherwise you will get an error `Payment error:currency is currently not supported`

**noted** You cannot do something like show `JPY` currency sign at the store (product page) but proceed payment with another currency. 

#### 5. Priority of change

:star2: :star2: :star:

#### 6. Alternate solution (if any)**

`-`
