### PR TITLE
Implement manual capture feature and enhance various things

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -56,8 +56,8 @@ input[name='card_id']:checked ~ #new_card_form {
 .Omise-Account                            { margin: 8px 0; }
 .Omise-Account dl dt,
 .Omise-Account dl dd                      { display: inline; }
-.Omise-Account dl dt                      { display: inline; font-weight: 700; margin-left: 30px; }
-.Omise-Account dl dt:first-child          { margin-left: 0; }
+.Omise-Account dl dt                      { display: inline; font-weight: 700; margin-left: 14px; padding-left: 15px; border-left: 1px solid #ececec; }
+.Omise-Account dl dt:first-child          { margin-left: 0; padding-left: 0; border: none; }
 .Omise-Account dl dd                      { margin-left: 5px; }
 
 .Omise-Balance                            { margin: 8px 0 0; background: #60c0e1; color: #106986; padding: 25px 0; border-bottom: 1px solid #8dd7f0; }

--- a/includes/classes/class-omise-charge.php
+++ b/includes/classes/class-omise-charge.php
@@ -1,0 +1,99 @@
+<?php
+defined( 'ABSPATH' ) or die ( "No direct script access allowed." );
+
+if ( ! class_exists( 'Omise_Charge' ) ) {
+	class Omise_Charge {
+		/**
+		 * @param integer $order_id  WooCommerce's order id
+		 * @return WP_Post object | boolean
+		 */
+		public static function get_post_charge( $order_id ) {
+			$query_field = '_wc_order_id';
+
+			$post_type   = 'omise_charge_items';
+			$post_meta   = array( 'key' => $query_field, 'value' => $order_id, 'compare' => '=' );
+
+			$posts = get_posts( array(
+				'post_type'  => $post_type,
+				'meta_query' => array( $post_meta )
+			) );
+
+			if ( empty( $posts ) )
+				return false;
+
+			return $posts[0];
+		}
+
+		/**
+		 * @param WC_Post $post  WordPress's post object
+		 * @return string
+		 */
+		public static function get_charge_id_from_post( $post ) {
+			$query_field = '_omise_charge_id';
+
+			$value = get_post_custom_values( $query_field, $post->ID );
+			if ( ! is_null( $value ) && ! empty( $value ) )
+				return $value[0];
+
+			return '';
+		}
+
+		/**
+		 * @param WC_Post $post  WordPress's post object
+		 * @return string
+		 */
+		public static function get_confirmed_url_from_post( $post ) {
+			$query_field = '_wc_confirmed_url';
+
+			$value = get_post_custom_values( $query_field, $post->ID );
+			if ( ! is_null( $value ) && ! empty( $value ) )
+				return $value[0];
+
+			return '';
+		}
+
+		/**
+		 * @param OmiseCharge $charge  Omise's charge object
+		 * @return boolean
+		 */
+		public static function is_charge_object( $charge ) {
+			return OmisePluginHelperCharge::isChargeObject( $charge );
+		}
+
+		/**
+		 * @param OmiseCharge $charge  Omise's charge object
+		 * @return boolean
+		 */
+		public static function is_authorized( $charge ) {
+			return OmisePluginHelperCharge::isAuthorized( $charge );
+		}
+
+		/**
+		 * @param OmiseCharge $charge  Omise's charge object
+		 * @return boolean
+		 */
+		public static function is_paid( $charge ) {
+			return OmisePluginHelperCharge::isPaid( $charge );
+		}
+
+		/**
+		 * @param OmiseCharge $charge  Omise's charge object
+		 * @return boolean
+		 */
+		public static function is_failed( $charge ) {
+			return OmisePluginHelperCharge::isFailed( $charge );
+		}
+
+		/**
+		 * @param OmiseCharge $charge  Omise's charge object
+		 * @return string | boolean
+		 */
+		public static function get_error_message( $charge ) {
+			if ( '' !== $charge['failure_code'] ) {
+				return '(' . $charge['failure_code'] . ') ' . $charge['failure_message'];
+			}
+
+			return '';
+		}
+	}
+}

--- a/includes/classes/class-omise-charges-table.php
+++ b/includes/classes/class-omise-charges-table.php
@@ -98,10 +98,6 @@ if ( ! class_exists( 'Omise_Charges_Table' ) ) {
         }
 
         function column_chrg_action( $record ) {
-            if ( true === $record['authorized'] && false === $record['captured'] ) {
-                echo "<button>capture</button>";
-            }
-
             echo "<a href='" . OmisePluginHelperTransaction::url( $record ) . "'>view detail</a>";
         }
     }

--- a/includes/classes/class-omise-charges-table.php
+++ b/includes/classes/class-omise-charges-table.php
@@ -52,6 +52,7 @@ if ( ! class_exists( 'Omise_Charges_Table' ) ) {
                 'chrg_paid'       => __( 'Paid' ),
                 'chrg_failure'    => __( 'Failure Message' ),
                 'chrg_datetime'   => __( 'Created' ),
+                'chrg_action'     => '',
             );
         }
 
@@ -94,6 +95,14 @@ if ( ! class_exists( 'Omise_Charges_Table' ) ) {
 
         function column_chrg_datetime( $record ) {
             echo Omise_Util::date_format( $record['created'] );
+        }
+
+        function column_chrg_action( $record ) {
+            if ( true === $record['authorized'] && false === $record['captured'] ) {
+                echo "<button>capture</button>";
+            }
+
+            echo "<a href='" . OmisePluginHelperTransaction::url( $record ) . "'>view detail</a>";
         }
     }
 }

--- a/includes/classes/class-omise-hooks.php
+++ b/includes/classes/class-omise-hooks.php
@@ -1,0 +1,161 @@
+<?php
+defined( 'ABSPATH' ) or die ( "No direct script access allowed." );
+
+if ( ! class_exists( 'Omise_Hooks' ) ) {
+	class Omise_Hooks {
+
+		private static $instance;
+
+		/**
+		 * @var boolean
+		 */
+		private $test_mode;
+
+		/**
+		 * @var string
+		 */
+		private $payment_action;
+
+		/**
+		 * @var boolean
+		 */
+		private $support_3dsecure;
+
+		/**
+		 * @var string
+		 */
+		private $secret_key;
+
+		/**
+		 * @return void
+		 */
+		private function __construct() {
+			$settings = get_option( 'woocommerce_omise_settings', null );
+
+			if ( is_null( $settings ) || ! is_array( $settings ) )
+				return;
+
+			$this->test_mode        = isset( $settings['sandbox'] ) && $settings['sandbox'] === 'yes';
+			$this->payment_action   = $settings['payment_action'];
+			$this->support_3dsecure = isset( $settings['omise_3ds'] ) && $settings['omise_3ds'] === 'yes';
+			$this->secret_key       = $this->test_mode ? $settings['test_private_key'] : $settings['live_private_key'];
+		}
+
+		public static function get_instance() {
+			if ( ! self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Capture an authorized charge.
+		 * @param WC_Order $order  WooCommerce's order object
+		 * @return void
+		 */
+		public function charge_capture( $order ) {
+			try {
+				$post = Omise_Charge::get_post_charge( $order->id );
+				if ( ! $post )
+					throw new Exception( 'Order id was not found' );
+
+				$id = Omise_Charge::get_charge_id_from_post( $post );
+				if ( $id === '' )
+					throw new Exception( 'Charge id was not found' );
+
+				$charge = OmiseCharge::retrieve( $id, '', $this->secret_key );
+				$charge->capture();
+
+				if ( ! OmisePluginHelperCharge::isPaid( $charge ) )
+					throw new Exception( $charge['failure_message'] );
+
+				$order->payment_complete();
+				$order->add_order_note( 'Payment with Omise successful (manual captured)' );
+			} catch ( Exception $e ) {
+				$order->add_order_note( $e->getMessage() );
+			}
+		}
+
+		/**
+		 * Callback method after redirect back from the 3D-Secure page
+		 * @return void
+		 */
+		public function charge_3ds_callback() {
+			try {
+				if ( ! isset( $_GET['order_id'] ) )
+					throw new Exception( "Order was not found. Please check carefully, your card might be charged already, contact our support if possible." );
+
+				$order_id = $_GET['order_id'];
+
+				// Looking for WC_Order object
+				$order = wc_get_order( $order_id );
+				if ( ! $order )
+					throw new Exception( "Order was not found. Please check carefully, your card might be charged already, contact our support if possible." );
+
+				// Looking for WP_Post object
+				$post = Omise_Charge::get_post_charge( $order_id );
+				if ( ! $post )
+					throw new Exception( "Order id was not found" );
+
+				// Looking for Omise's charge id
+				$charge_id = Omise_Charge::get_charge_id_from_post( $post );
+				if ( $charge_id === '' )
+					throw new Exception( "Charge id was not found" );
+
+				// Looking for WC's confirm url
+				$confirmed_url = Omise_Charge::get_confirmed_url_from_post( $post );
+				if ( $confirmed_url === '' )
+					throw new Exception( "Confirm url was not found" );
+
+				$charge = OmiseCharge::retrieve( $charge_id, '', $this->secret_key );
+				switch ( strtoupper( $this->payment_action ) ) {
+					case 'MANUAL_CAPTURE':
+						$success = Omise_Charge::is_authorized( $charge );
+						if ( $success ) {
+							$order->add_order_note( "Authorize with Omise successful" );
+						}
+
+						break;
+
+					case 'AUTO_CAPTURE':
+						$success = Omise_Charge::is_paid( $charge );
+						if ( $success ) {
+							$order->payment_complete();
+							$order->add_order_note( "Payment with Omise successful" );
+						}
+
+						break;
+
+					default:
+						// Default behaviour is, check if it paid first.
+						$success = Omise_Charge::is_paid( $charge );
+
+						// Then, check is authorized after if the first condition is false.
+						if ( ! $success )
+							$success = Omise_Charge::is_authorized( $charge );
+
+						break;
+				}
+
+				if ( ! $success )
+					throw new Exception( Omise_Charge::get_error_message( $charge ) );
+
+				// Remove cart
+				WC()->cart->empty_cart();
+				header( "Location: " . $confirmed_url );
+				die();
+			} catch ( Exception $e ) {
+				if ( isset( $order ) )
+					$order->add_order_note( 'Charge was not completed, ' . $e->getMessage() );
+
+				wc_add_notice( __( 'Payment error: ', 'woothemes' ) . $e->getMessage() , 'error' );
+				header( "Location: " . WC()->cart->get_checkout_url() );
+				die();
+			}
+
+			wp_die( "Access denied", "Access Denied", array( 'response' => 401 ) );
+			die();
+		}
+	}
+}

--- a/includes/classes/class-omise-hooks.php
+++ b/includes/classes/class-omise-hooks.php
@@ -55,13 +55,15 @@ if ( ! class_exists( 'Omise_Hooks' ) ) {
 		 * @return void
 		 */
 		public function charge_capture( $order ) {
+			Omise_Hooks::set_omise_user_agent();
+
 			try {
 				$post = Omise_Charge::get_post_charge( $order->id );
 				if ( ! $post )
 					throw new Exception( 'Order id was not found' );
 
 				$id = Omise_Charge::get_charge_id_from_post( $post );
-				if ( $id === '' )
+				if ( is_null( $id ) || $id === '' )
 					throw new Exception( 'Charge id was not found' );
 
 				$charge = OmiseCharge::retrieve( $id, '', $this->secret_key );
@@ -82,6 +84,8 @@ if ( ! class_exists( 'Omise_Hooks' ) ) {
 		 * @return void
 		 */
 		public function charge_3ds_callback() {
+			Omise_Hooks::set_omise_user_agent();
+
 			try {
 				if ( ! isset( $_GET['order_id'] ) )
 					throw new Exception( "Order was not found. Please check carefully, your card might be charged already, contact our support if possible." );
@@ -156,6 +160,16 @@ if ( ! class_exists( 'Omise_Hooks' ) ) {
 
 			wp_die( "Access denied", "Access Denied", array( 'response' => 401 ) );
 			die();
+		}
+
+		public static function set_omise_user_agent() {
+			// Set OMISE_USER_AGENT_SUFFIX
+			global $wp_version;
+
+			$user_agent  = "OmiseWooCommerce/" . OMISE_WOOCOMMERCE_PLUGIN_VERSION;
+			$user_agent .= " WordPress/" . $wp_version;
+			$user_agent .= " WooCommerce/" . WC_VERSION;
+			defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', $user_agent );
 		}
 	}
 }

--- a/includes/libraries/omise-plugin/Omise.php
+++ b/includes/libraries/omise-plugin/Omise.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once dirname(__FILE__).'/helpers/charge.php';
+require_once dirname(__FILE__).'/helpers/currency.php';
+require_once dirname(__FILE__).'/helpers/transaction.php';

--- a/includes/libraries/omise-plugin/helpers/charge.php
+++ b/includes/libraries/omise-plugin/helpers/charge.php
@@ -24,5 +24,37 @@ if (! class_exists('OmisePluginHelperCharge')) {
 
             return $amount;
         }
+
+        /**
+         * @param \omise-php\OmiseCharge $charge
+         * @return boolean
+         */
+        public static function isAuthorized($charge)
+        {
+            if (! isset($charge['object']) || $charge['object'] !== 'charge')
+                return false;
+
+            if ($charge['authorized'] === true)
+                return true;
+
+            return false;
+        }
+
+        /**
+         * @param \omise-php\OmiseCharge $charge
+         * @return boolean
+         */
+        public static function isPaid($charge)
+        {
+            if (! isset($charge['object']) || $charge['object'] !== 'charge')
+                return false;
+
+            // support Omise API version '2014-07-27' by checking if 'captured' exist.
+            $paid = isset($charge['captured']) ? $charge['captured'] : $charge['paid'];
+            if ($paid === true)
+                return true;
+
+            return false;
+        }
     }
 }

--- a/includes/libraries/omise-plugin/helpers/charge.php
+++ b/includes/libraries/omise-plugin/helpers/charge.php
@@ -1,0 +1,28 @@
+<?php
+if (! class_exists('OmisePluginHelperCharge')) {
+    class OmisePluginHelperCharge
+    {
+        /**
+         * @param string  $currency
+         * @param integer $amount
+         * @return string
+         */
+        public static function amount($currency, $amount)
+        {
+            switch (strtoupper($currency)) {
+                case 'THB':
+                    // Convert to satang unit
+                    $amount = $amount * 100;
+                    break;
+
+                case 'JPY':
+                    break;
+
+                default:
+                    break;
+            }
+
+            return $amount;
+        }
+    }
+}

--- a/includes/templates/omise-wp-admin-page.php
+++ b/includes/templates/omise-wp-admin-page.php
@@ -38,6 +38,14 @@
 				<!-- Current Currency -->
 				<dt>Currency: </dt>
 				<dd><?php echo strtoupper( $omise['balance']['currency'] ); ?></dd>
+
+				<!-- Payment Action -->
+				<dt>Auto Capture: </dt>
+				<dd><?php echo $viewData['auto_capture']; ?></dd>
+
+				<!-- 3D Secure enabled? -->
+				<dt>3D-Secure: </dt>
+				<dd><?php echo $viewData['support_3dsecure']; ?></dd>
 			</dl>
 		</div>
 

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -98,7 +98,7 @@ function register_omise_wc_gateway_plugin() {
 					'omise_3ds' => array(
 						'title'       => __( '3DSecure Support', $this->gateway_name ),
 						'type'        => 'checkbox',
-						'label'       => __( 'Enables 3DSecure on this account', $this->gateway_name ),
+						'label'       => __( 'Enables 3DSecure on this account (does not support for Japan account)', $this->gateway_name ),
 						'default'     => 'no'
 					),
 					'description' => array(
@@ -148,6 +148,8 @@ function register_omise_wc_gateway_plugin() {
 			 * @see WC_Payment_Gateway::process_payment()
 			 */
 			public function process_payment( $order_id ) {
+				Omise_Hooks::set_omise_user_agent();
+
 				$order   = wc_get_order( $order_id );
 				$token   = isset( $_POST['omise_token'] ) ? wc_clean( $_POST['omise_token'] ) : '';
 				$card_id = isset( $_POST['card_id'] ) ? wc_clean( $_POST['card_id'] ) : '';
@@ -298,16 +300,16 @@ function register_omise_wc_gateway_plugin() {
 				}
 			}
 
-			private function register_omise_charge_post( $result, $order, $order_id ) {
+			private function register_omise_charge_post( $charge, $order, $order_id ) {
 				$post_id = wp_insert_post(
 					array(
-						'post_title'  => 'Omise Charge Id ' . $result->id,
+						'post_title'  => 'Omise Charge Id ' . $charge['id'],
 						'post_type'   => 'omise_charge_items',
 						'post_status' => 'publish'
 					)
 				);
 
-				add_post_meta( $post_id, '_omise_charge_id', $result->id );
+				add_post_meta( $post_id, '_omise_charge_id', $charge['id'] );
 				add_post_meta( $post_id, '_wc_order_id', $order_id );
 				add_post_meta( $post_id, '_wc_confirmed_url', $this->get_return_url( $order ) );
 			}

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -156,10 +156,10 @@ function register_omise_wc_gateway_plugin() {
 						throw new Exception( "Please select a card or enter new payment information." );
 					}
 
-					$user = $order->get_user ();
+					$user              = $order->get_user();
 					$omise_customer_id = $this->sandbox ? $user->test_omise_customer_id : $user->live_omise_customer_id;
 
-					if (isset ( $_POST ['omise_save_customer_card'] ) && empty($card_id)) {
+					if ( isset( $_POST['omise_save_customer_card'] ) && empty( $card_id ) ) {
 						if (empty($token)){
 							throw new Exception ( "Omise card token is required." );
 						}
@@ -223,6 +223,13 @@ function register_omise_wc_gateway_plugin() {
 						$data["card"] = $token;
 					} else {
 						throw new Exception ( "Please select a card or enter new payment information." );
+					}
+
+					// Auto capture or not?
+					if ( "auto_capture" === $this->payment_action ) {
+						$data['capture'] = true;
+					} else if ( "manual_capture" === $this->payment_action ) {
+						$data['capture'] = false;
 					}
 
 					$result = Omise::create_charge($this->private_key, $data);

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -23,6 +23,7 @@ function register_omise_wc_gateway_plugin() {
 				$this->title            = $this->settings['title'];
 				$this->description      = $this->settings['description'];
 				$this->sandbox          = isset( $this->settings['sandbox'] ) && $this->settings['sandbox'] == 'yes';
+				$this->payment_action   = $this->settings['payment_action'];
 				$this->omise_3ds        = isset( $this->settings['omise_3ds'] ) && $this->settings['omise_3ds'] == 'yes';
 				$this->test_private_key = $this->settings['test_private_key'];
 				$this->test_public_key  = $this->settings['test_public_key'];
@@ -43,54 +44,68 @@ function register_omise_wc_gateway_plugin() {
 			function init_form_fields() {
 				$this->form_fields = array(
 					'enabled' => array(
-							'title'       => __( 'Enable/Disable', $this->gateway_name ),
-							'type'        => 'checkbox',
-							'label'       => __( 'Enable Omise Payment Module.', $this->gateway_name ),
-							'default'     => 'no'
+						'title'       => __( 'Enable/Disable', $this->gateway_name ),
+						'type'        => 'checkbox',
+						'label'       => __( 'Enable Omise Payment Module.', $this->gateway_name ),
+						'default'     => 'no'
 					),
 					'sandbox' => array(
-							'title'       => __( 'Sandbox', $this->gateway_name ),
-							'type'        => 'checkbox',
-							'label'       => __( 'Sandbox mode means everything is in TEST mode', $this->gateway_name ),
-							'default'     => 'yes'
+						'title'       => __( 'Sandbox', $this->gateway_name ),
+						'type'        => 'checkbox',
+						'label'       => __( 'Sandbox mode means everything is in TEST mode', $this->gateway_name ),
+						'default'     => 'yes'
 					),
-					'omise_3ds' => array(
-							'title'       => __( '3DSecure Support', $this->gateway_name ),
-							'type'        => 'checkbox',
-							'label'       => __( 'Enables 3DSecure on this account', $this->gateway_name ),
-							'default'     => 'no'
-					),
-					'title' => array(
-							'title'       => __( 'Title:', $this->gateway_name ),
-							'type'        => 'text',
-							'description' => __( 'This controls the title which the user sees during checkout.', $this->gateway_name ),
-							'default'     => __( 'Omise payment gateway', $this->gateway_name )
-					),
-					'description' => array(
-							'title'       => __( 'Description:', $this->gateway_name ),
-							'type'        => 'textarea',
-							'description' => __( 'This controls the description which the user sees during checkout.', $this->gateway_name ),
-							'default'     => __( 'Omise payment gateway.', $this->gateway_name )
-					),
-					'test_public_key'     => array(
-							'title'       => __( 'Public key for test', $this->gateway_name ),
-							'type'        => 'text',
-							'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard' )
+					'test_public_key' => array(
+						'title'       => __( 'Public key for test', $this->gateway_name ),
+						'type'        => 'text',
+						'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard' )
 					),
 					'test_private_key' => array(
-							'title'       => __( 'Secret key for test', $this->gateway_name ),
-							'type'        => 'password',
-							'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard' )
+						'title'       => __( 'Secret key for test', $this->gateway_name ),
+						'type'        => 'password',
+						'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard' )
 					),
 					'live_public_key' => array(
-							'title'       => __( 'Public key for live', $this->gateway_name ),
-							'type'        => 'text',
-							'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard' )
+						'title'       => __( 'Public key for live', $this->gateway_name ),
+						'type'        => 'text',
+						'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard' )
 					),
 					'live_private_key' => array(
-							'title'       => __( 'Secret key for live', $this->gateway_name ),
-							'type'        => 'password',
-							'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard' )
+						'title'       => __( 'Secret key for live', $this->gateway_name ),
+						'type'        => 'password',
+						'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard' )
+					),
+					'advanced' => array(
+						'title'       => __( 'Advanced options', 'woocommerce' ),
+						'type'        => 'title',
+						'description' => '',
+					),
+					'title' => array(
+						'title'       => __( 'Title:', $this->gateway_name ),
+						'type'        => 'text',
+						'description' => __( 'This controls the title which the user sees during checkout.', $this->gateway_name ),
+						'default'     => __( 'Omise Payment Gateway', $this->gateway_name )
+					),
+					'payment_action' => array(
+						'title'       => __( 'Payment Action', $this->gateway_name ),
+						'type'        => 'select',
+						'description' => __( 'Manual Capture or Capture Automatically', $this->gateway_name ),
+						'default'     => 'auto_capture',
+						'class'       => 'wc-enhanced-select',
+						'options'     => $this->form_field_payment_actions(),
+						'desc_tip'    => true
+					),
+					'omise_3ds' => array(
+						'title'       => __( '3DSecure Support', $this->gateway_name ),
+						'type'        => 'checkbox',
+						'label'       => __( 'Enables 3DSecure on this account', $this->gateway_name ),
+						'default'     => 'no'
+					),
+					'description' => array(
+						'title'       => __( 'Description:', $this->gateway_name ),
+						'type'        => 'textarea',
+						'description' => __( 'This controls the description which the user sees during checkout.', $this->gateway_name ),
+						'default'     => __( 'Omise payment gateway.', $this->gateway_name )
 					)
 				);
 			}
@@ -368,6 +383,16 @@ function register_omise_wc_gateway_plugin() {
 
 				wp_die( "Access denied", "Access Denied", array( 'response' => 401 ) );
 				die();
+			}
+
+			/**
+			 * @return array
+			 */
+			public function form_field_payment_actions() {
+				return array(
+					'auto_capture'   => __( "Auto Capture", $this->gateway_name ),
+					'manual_capture' => __( "Manual Capture", $this->gateway_name )
+				);
 			}
 		}
 	}

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -154,6 +154,8 @@ function register_omise_wc_gateway_plugin() {
 				$token   = isset( $_POST['omise_token'] ) ? wc_clean( $_POST['omise_token'] ) : '';
 				$card_id = isset( $_POST['card_id'] ) ? wc_clean( $_POST['card_id'] ) : '';
 				try {
+					$order->add_order_note( "Starting to process payment with Omise" );
+
 					if ( empty( $token ) && empty( $card_id ) ) {
 						throw new Exception( "Please select a card or enter new payment information." );
 					}
@@ -245,6 +247,7 @@ function register_omise_wc_gateway_plugin() {
 						throw new Exception( Omise_Charge::get_error_message( $charge ) );
 
 					if ( $this->omise_3ds ) {
+						$order->add_order_note( "Processing payment with Omise 3D-Secure" );
 						return array (
 							'result'   => 'success',
 							'redirect' => $charge['authorize_uri'],

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -409,7 +409,13 @@ function register_omise_wc_gateway_plugin() {
 		return $methods;
 	}
 
+	function add_omise_capture_action( $order_actions ) {
+		$order_actions['omise_charge_capture'] = __( "Capture charge (via Omise)" );
+		return $order_actions;
+	}
+
 	add_filter( 'woocommerce_payment_gateways', 'add_omise_gateway' );
+	add_filter( 'woocommerce_order_actions', 'add_omise_capture_action' );
 }
 
 function register_omise_wc_gateway_post_type() {

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -1,48 +1,39 @@
 <?php
-defined ( 'ABSPATH' ) or die ( "No direct script access allowed." );
+defined( 'ABSPATH' ) or die ( "No direct script access allowed." );
 
 function register_omise_wc_gateway_plugin() {
 	// prevent running directly without wooCommerce
-	if (! class_exists ( 'WC_Payment_Gateway' ))
+	if ( ! class_exists ( 'WC_Payment_Gateway' ) )
 		return;
-	
-	if (! class_exists ( 'WC_Gateway_Omise' )) {
-		
+
+	if ( ! class_exists ( 'WC_Gateway_Omise' ) ) {
+
 		class WC_Gateway_Omise extends WC_Payment_Gateway {
 			var $gateway_name = "Omise";
 
 			public function __construct() {
-				$this->id = 'omise';
-				$this->method_title = "Omise";
-				$this->has_fields = true;
+				$this->id               = 'omise';
+				$this->method_title     = "Omise";
+				$this->has_fields       = true;
 				
 				// call base functions required for WooCommerce gateway
-				$this->init_form_fields ();
-				$this->init_settings ();
-				
-				$this->title = $this->settings ['title'];
-				$this->description = $this->settings ['description'];
-				$this->sandbox = isset($this->settings ['sandbox']) && $this->settings ['sandbox'] == 'yes';
-				$this->omise_3ds = isset($this->settings ['omise_3ds']) && $this->settings ['omise_3ds'] == 'yes';
-				$this->test_private_key = $this->settings ['test_private_key'];
-				$this->test_public_key = $this->settings ['test_public_key'];
-				$this->live_private_key = $this->settings ['live_private_key'];
-				$this->live_public_key = $this->settings ['live_public_key'];
-				$this->public_key = $this->sandbox ? $this->test_public_key : $this->live_public_key;
-				$this->private_key = $this->sandbox ? $this->test_private_key : $this->live_private_key;
-				
+				$this->init_form_fields();
+				$this->init_settings();
+
+				$this->title            = $this->settings['title'];
+				$this->description      = $this->settings['description'];
+				$this->sandbox          = isset( $this->settings['sandbox'] ) && $this->settings['sandbox'] == 'yes';
+				$this->omise_3ds        = isset( $this->settings['omise_3ds'] ) && $this->settings['omise_3ds'] == 'yes';
+				$this->test_private_key = $this->settings['test_private_key'];
+				$this->test_public_key  = $this->settings['test_public_key'];
+				$this->live_private_key = $this->settings['live_private_key'];
+				$this->live_public_key  = $this->settings['live_public_key'];
+				$this->public_key       = $this->sandbox ? $this->test_public_key : $this->live_public_key;
+				$this->private_key      = $this->sandbox ? $this->test_private_key : $this->live_private_key;
+
 				add_action( 'woocommerce_api_wc_gateway_' . $this->id, array( $this, 'omise_3ds_handler' ) );
-
-				add_action ( 'woocommerce_update_options_payment_gateways_' . $this->id, array (
-						&$this,
-						'process_admin_options' 
-				));
-				
-				add_action ( 'wp_enqueue_scripts', array (
-						$this,
-						'omise_scripts' 
-				));
-
+				add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( &$this, 'process_admin_options' ) );
+				add_action( 'wp_enqueue_scripts', array( $this, 'omise_scripts' ) );
 			}
 
 			/**
@@ -50,122 +41,122 @@ function register_omise_wc_gateway_plugin() {
 			 * @see WC_Settings_API::init_form_fields()
 			 */
 			function init_form_fields() {
-				$this->form_fields = array (
-						'enabled' => array (
-								'title' => __ ( 'Enable/Disable', $this->gateway_name ),
-								'type' => 'checkbox',
-								'label' => __ ( 'Enable Omise Payment Module.', $this->gateway_name ),
-								'default' => 'no' 
-						),
-						'sandbox' => array (
-								'title' => __ ( 'Sandbox', $this->gateway_name ),
-								'type' => 'checkbox',
-								'label' => __ ( 'Sandbox mode means everything is in TEST mode', $this->gateway_name ),
-								'default' => 'yes' 
-						),
-						'omise_3ds' => array (
-								'title' => __ ( '3DSecure Support', $this->gateway_name ),
-								'type' => 'checkbox',
-								'label' => __ ( 'Enables 3DSecure on this account', $this->gateway_name ),
-								'default' => 'no'
-						),
-						'title' => array (
-								'title' => __ ( 'Title:', $this->gateway_name ),
-								'type' => 'text',
-								'description' => __ ( 'This controls the title which the user sees during checkout.', $this->gateway_name ),
-								'default' => __ ( 'Omise payment gateway', $this->gateway_name ) 
-						),
-						'description' => array (
-								'title' => __ ( 'Description:', $this->gateway_name ),
-								'type' => 'textarea',
-								'description' => __ ( 'This controls the description which the user sees during checkout.', $this->gateway_name ),
-								'default' => __ ( 'Omise payment gateway.', $this->gateway_name ) 
-						),
-						'test_public_key' => array (
-								'title' => __ ( 'Public key for test', $this->gateway_name ),
-								'type' => 'text',
-								'description' => __ ( 'The "Test" mode public key which can be found in Omise Dashboard' ) 
-						),
-						'test_private_key' => array (
-								'title' => __ ( 'Secret key for test', $this->gateway_name ),
-								'type' => 'password',
-								'description' => __ ( 'The "Test" mode secret key which can be found in Omise Dashboard' ) 
-						),
-						'live_public_key' => array (
-								'title' => __ ( 'Public key for live', $this->gateway_name ),
-								'type' => 'text',
-								'description' => __ ( 'The "Live" mode public key which can be found in Omise Dashboard' ) 
-						),
-						'live_private_key' => array (
-								'title' => __ ( 'Secret key for live', $this->gateway_name ),
-								'type' => 'password',
-								'description' => __ ( 'The "Live" mode secret key which can be found in Omise Dashboard' ) 
-						)
+				$this->form_fields = array(
+					'enabled' => array(
+							'title'       => __( 'Enable/Disable', $this->gateway_name ),
+							'type'        => 'checkbox',
+							'label'       => __( 'Enable Omise Payment Module.', $this->gateway_name ),
+							'default'     => 'no'
+					),
+					'sandbox' => array(
+							'title'       => __( 'Sandbox', $this->gateway_name ),
+							'type'        => 'checkbox',
+							'label'       => __( 'Sandbox mode means everything is in TEST mode', $this->gateway_name ),
+							'default'     => 'yes'
+					),
+					'omise_3ds' => array(
+							'title'       => __( '3DSecure Support', $this->gateway_name ),
+							'type'        => 'checkbox',
+							'label'       => __( 'Enables 3DSecure on this account', $this->gateway_name ),
+							'default'     => 'no'
+					),
+					'title' => array(
+							'title'       => __( 'Title:', $this->gateway_name ),
+							'type'        => 'text',
+							'description' => __( 'This controls the title which the user sees during checkout.', $this->gateway_name ),
+							'default'     => __( 'Omise payment gateway', $this->gateway_name )
+					),
+					'description' => array(
+							'title'       => __( 'Description:', $this->gateway_name ),
+							'type'        => 'textarea',
+							'description' => __( 'This controls the description which the user sees during checkout.', $this->gateway_name ),
+							'default'     => __( 'Omise payment gateway.', $this->gateway_name )
+					),
+					'test_public_key'     => array(
+							'title'       => __( 'Public key for test', $this->gateway_name ),
+							'type'        => 'text',
+							'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard' )
+					),
+					'test_private_key' => array(
+							'title'       => __( 'Secret key for test', $this->gateway_name ),
+							'type'        => 'password',
+							'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard' )
+					),
+					'live_public_key' => array(
+							'title'       => __( 'Public key for live', $this->gateway_name ),
+							'type'        => 'text',
+							'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard' )
+					),
+					'live_private_key' => array(
+							'title'       => __( 'Secret key for live', $this->gateway_name ),
+							'type'        => 'password',
+							'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard' )
+					)
 				);
 			}
-			
+
 			/**
 			 * Settings on Admin page
 			 * @see WC_Settings_API::admin_options()
 			 */
 			public function admin_options() {
-				echo '<h3>' . __ ( 'Omise Payment Gateway', $this->gateway_name ) . '</h3>';
-				echo '<p>' . __ ( 'Omise payment gateway. The first PCI 3.0 certified payment gateway in Thailand' ) . '</p>';
+				echo '<h3>' . __( 'Omise Payment Gateway', $this->gateway_name ) . '</h3>';
+				echo '<p>' . __( 'Omise payment gateway. The first PCI 3.0 certified payment gateway in Thailand' ) . '</p>';
 				echo '<table class="form-table">';
-				$this->generate_settings_html ();
+				$this->generate_settings_html();
 				echo '</table>';
 			}
-			
+
 			/**
 			 * Payment fields which will be rendered on checkout page
 			 * @see WC_Payment_Gateway::payment_fields()
 			 */
 			function payment_fields() {
-				if (is_user_logged_in ()) {
-					$viewData ["user_logged_in"] = true;
-					$current_user = wp_get_current_user ();
+				if ( is_user_logged_in() ) {
+					$viewData["user_logged_in"] = true;
+					$current_user = wp_get_current_user();
 					$omise_customer_id = $this->sandbox ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
-					if (! empty ( $omise_customer_id )) {
-						$cards = Omise::get_customer_cards ( $this->private_key, $omise_customer_id );
-						$viewData ["existingCards"] = $cards;
+					if ( ! empty( $omise_customer_id ) ) {
+						$cards = Omise::get_customer_cards( $this->private_key, $omise_customer_id );
+						$viewData["existingCards"] = $cards;
 					}
 				} else {
 					$viewData["user_logged_in"] = false;
 				}
 
-				Omise_Util::render_view ( 'includes/templates/omise-payment-form.php', $viewData );
+				Omise_Util::render_view( 'includes/templates/omise-payment-form.php', $viewData );
 			}
-			
+
 			/**
 			 * Process payment
 			 * 
 			 * @see WC_Payment_Gateway::process_payment()
 			 */
-			public function process_payment($order_id) {				
-				$order = wc_get_order ( $order_id );
-				$token = isset ( $_POST ['omise_token'] ) ? wc_clean ( $_POST ['omise_token'] ) : '';
-				$card_id = isset ( $_POST ['card_id'] ) ? wc_clean ( $_POST ['card_id'] ) : '';
-				try{
-					if (empty ( $token ) && empty ( $card_id )) {
-						throw new Exception ( "Please select a card or enter new payment information." );
+			public function process_payment( $order_id ) {				
+				$order   = wc_get_order( $order_id );
+				$token   = isset( $_POST['omise_token'] ) ? wc_clean( $_POST['omise_token'] ) : '';
+				$card_id = isset( $_POST['card_id'] ) ? wc_clean( $_POST['card_id'] ) : '';
+				try {
+					if ( empty( $token ) && empty( $card_id ) ) {
+						throw new Exception( "Please select a card or enter new payment information." );
 					}
 
 					$user = $order->get_user ();
 					$omise_customer_id = $this->sandbox ? $user->test_omise_customer_id : $user->live_omise_customer_id;
-					
+
 					if (isset ( $_POST ['omise_save_customer_card'] ) && empty($card_id)) {
 						if (empty($token)){
 							throw new Exception ( "Omise card token is required." );
 						}
-						
+
 						if (! empty ( $omise_customer_id )) {
 							// attach a new card to customer
 							$omise_customer = Omise::create_card ( $this->private_key, $omise_customer_id, $token );
-							
+
 							if($omise_customer->object=="error"){
 								throw new Exception($omise_customer->message);
 							}
-							
+
 							$card_id = $omise_customer->cards->data [$omise_customer->cards->total - 1]->id;
 						} else {
 							$description = "WooCommerce customer " . $user->id;
@@ -173,20 +164,20 @@ function register_omise_wc_gateway_plugin() {
 									"description" => $description,
 									"card" => $token 
 							);
-							
+
 							$omise_customer = Omise::create_customer ( $this->private_key, $customer_data );
-							
+
 							if($omise_customer->object=="error"){
 								throw new Exception($omise_customer->message);
 							}
-							
+
 							$omise_customer_id = $omise_customer->id;
 							if($this->sandbox){
 								update_user_meta ( $user->ID, 'test_omise_customer_id', $omise_customer_id );
 							}else{
 								update_user_meta ( $user->ID, 'live_omise_customer_id', $omise_customer_id );
 							}
-							
+
 							if (0 == sizeof ( $omise_customer->cards->data )) {
 								throw new Exception ( "Something wrong with Omise gateway. No card available for creating a charge." );
 							}
@@ -194,7 +185,7 @@ function register_omise_wc_gateway_plugin() {
 							$card_id = $card->id;
 						}
 					}
-					
+
 					$success        = false;
 					$order_currency = $order->get_order_currency();
 					if ( 'THB' === strtoupper( $order_currency ) )
@@ -235,7 +226,7 @@ function register_omise_wc_gateway_plugin() {
 						add_post_meta($post_id, '_wc_order_id', $order_id);
 						add_post_meta($post_id, '_wc_confirmed_url', $this->get_return_url($order));
 					}
-					
+
 					$success = false;
 					if ($this->omise_3ds) {
 						return array (
@@ -269,26 +260,26 @@ function register_omise_wc_gateway_plugin() {
 					);
 				}
 			}
-			
+
 			private function is_charge_success($result){
 				return isset ( $result->id ) && isset( $result->object ) && $result->object == 'charge' && $result->captured == true;
 			}
-			
+
 			private function get_charge_error_message($result){
 				$message = "";
 				
 				if(isset($result->message) && !empty($result->message)){
 					$message .= $result->message." ";
 				}
-				
+
 				if(isset($result->failure_code) && !empty($result->failure_code)){
 					$message .= "[".$result-> failure_code."] ";
 				}
-				
+
 				if(isset($result->failure_message) && !empty($result->failure_message)){
 					$message .= $result-> failure_message;
 				}
-				
+
 				return trim($message);
 			}
 
@@ -381,12 +372,12 @@ function register_omise_wc_gateway_plugin() {
 		}
 	}
 
-	function add_omise_gateway($methods) {
+	function add_omise_gateway( $methods ) {
 		$methods [] = 'WC_Gateway_Omise';
 		return $methods;
 	}
-	
-	add_filter ( 'woocommerce_payment_gateways', 'add_omise_gateway' );
+
+	add_filter( 'woocommerce_payment_gateways', 'add_omise_gateway' );
 }
 
 function register_omise_wc_gateway_post_type() {

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -32,7 +32,7 @@ function register_omise_wc_gateway_plugin() {
 				$this->public_key       = $this->sandbox ? $this->test_public_key : $this->live_public_key;
 				$this->private_key      = $this->sandbox ? $this->test_private_key : $this->live_private_key;
 
-				add_action( 'woocommerce_api_wc_gateway_' . $this->id, array( $this, 'omise_3ds_handler' ) );
+				add_action( 'woocommerce_api_wc_gateway_' . $this->id, array( $this, 'omise_3ds_callback' ) );
 				add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( &$this, 'process_admin_options' ) );
 				add_action( 'wp_enqueue_scripts', array( $this, 'omise_scripts' ) );
 			}
@@ -147,7 +147,7 @@ function register_omise_wc_gateway_plugin() {
 			 * 
 			 * @see WC_Payment_Gateway::process_payment()
 			 */
-			public function process_payment( $order_id ) {				
+			public function process_payment( $order_id ) {
 				$order   = wc_get_order( $order_id );
 				$token   = isset( $_POST['omise_token'] ) ? wc_clean( $_POST['omise_token'] ) : '';
 				$card_id = isset( $_POST['card_id'] ) ? wc_clean( $_POST['card_id'] ) : '';
@@ -160,43 +160,43 @@ function register_omise_wc_gateway_plugin() {
 					$omise_customer_id = $this->sandbox ? $user->test_omise_customer_id : $user->live_omise_customer_id;
 
 					if ( isset( $_POST['omise_save_customer_card'] ) && empty( $card_id ) ) {
-						if (empty($token)){
-							throw new Exception ( "Omise card token is required." );
+						if ( empty( $token ) ) {
+							throw new Exception( "Omise card token is required." );
 						}
 
-						if (! empty ( $omise_customer_id )) {
+						if ( ! empty ( $omise_customer_id ) ) {
 							// attach a new card to customer
-							$omise_customer = Omise::create_card ( $this->private_key, $omise_customer_id, $token );
+							$omise_customer = Omise::create_card( $this->private_key, $omise_customer_id, $token );
 
-							if($omise_customer->object=="error"){
-								throw new Exception($omise_customer->message);
+							if ( $omise_customer->object == "error" ) {
+								throw new Exception( $omise_customer->message );
 							}
 
-							$card_id = $omise_customer->cards->data [$omise_customer->cards->total - 1]->id;
+							$card_id = $omise_customer->cards->data[$omise_customer->cards->total - 1]->id;
 						} else {
-							$description = "WooCommerce customer " . $user->id;
-							$customer_data = array (
-									"description" => $description,
-									"card" => $token 
+							$description   = "WooCommerce customer " . $user->id;
+							$customer_data = array(
+								"description" => $description,
+								"card"        => $token
 							);
 
-							$omise_customer = Omise::create_customer ( $this->private_key, $customer_data );
+							$omise_customer = Omise::create_customer( $this->private_key, $customer_data );
 
-							if($omise_customer->object=="error"){
-								throw new Exception($omise_customer->message);
+							if ( $omise_customer->object == "error" ) {
+								throw new Exception( $omise_customer->message );
 							}
 
 							$omise_customer_id = $omise_customer->id;
-							if($this->sandbox){
-								update_user_meta ( $user->ID, 'test_omise_customer_id', $omise_customer_id );
+							if( $this->sandbox ) {
+								update_user_meta( $user->ID, 'test_omise_customer_id', $omise_customer_id );
 							}else{
-								update_user_meta ( $user->ID, 'live_omise_customer_id', $omise_customer_id );
+								update_user_meta( $user->ID, 'live_omise_customer_id', $omise_customer_id );
 							}
 
-							if (0 == sizeof ( $omise_customer->cards->data )) {
-								throw new Exception ( "Something wrong with Omise gateway. No card available for creating a charge." );
+							if ( 0 == sizeof( $omise_customer->cards->data ) ) {
+								throw new Exception( "Something wrong with Omise gateway. No card available for creating a charge." );
 							}
-							$card = $omise_customer->cards->data [0]; //use the latest card
+							$card    = $omise_customer->cards->data [0]; //use the latest card
 							$card_id = $card->id;
 						}
 					}
@@ -208,98 +208,169 @@ function register_omise_wc_gateway_plugin() {
 					else
 						$amount = $order->get_total();
 
-					$data = array (
+					$data = array(
 						"amount"      => $amount,
 						"currency"    => $order_currency,
 						"description" => "WooCommerce Order id " . $order_id,
 						"return_uri"  => add_query_arg( 'order_id', $order_id, site_url()."?wc-api=wc_gateway_omise" )
 					);
 					
-					if (! empty ( $card_id ) && ! empty ( $omise_customer_id )) {
+					if ( ! empty( $card_id ) && ! empty( $omise_customer_id ) ) {
 						// create charge with a specific card of customer
-						$data["customer"] =  $omise_customer_id;
-						$data["card"] = $card_id;
-					} else if (! empty ( $token )) {
+						$data["customer"] = $omise_customer_id;
+						$data["card"]     = $card_id;
+					} else if ( ! empty( $token ) ) {
 						$data["card"] = $token;
 					} else {
 						throw new Exception ( "Please select a card or enter new payment information." );
 					}
 
 					// Auto capture or not?
-					if ( "auto_capture" === $this->payment_action ) {
-						$data['capture'] = true;
-					} else if ( "manual_capture" === $this->payment_action ) {
-						$data['capture'] = false;
-					}
+					if ( 'auto_capture' === $this->payment_action )
+						$result = $this->process_charge_authorize_and_capture( $this->private_key, $data );
 
-					$result = Omise::create_charge($this->private_key, $data);
-					if ($result->object === "error") {
-						throw new Exception ($result->message);
-					} if ($result->failure_code) {
-						throw new Exception ($result->failure_message);
-					} else {
-						$post_id = wp_insert_post(array(
-							'post_title'	=> 'Omise Charge Id '.$result->id,
-							'post_type'		=> 'omise_charge_items',
-							'post_status'	=> 'publish'
-						));
+					if ( 'manual_capture' === $this->payment_action )
+						$result = $this->process_charge_authorize( $this->private_key, $data );
 
-						add_post_meta($post_id, '_omise_charge_id', $result->id);
-						add_post_meta($post_id, '_wc_order_id', $order_id);
-						add_post_meta($post_id, '_wc_confirmed_url', $this->get_return_url($order));
-					}
+					if ( ! isset( $result ) )
+						throw new Exception( 'Method not found' );
 
-					$success = false;
-					if ($this->omise_3ds) {
+					if ( is_array( $result ) && isset( $result['object'] ) && 'error' === $result['object'] )
+						throw new Exception( $result['message'] );
+
+					// Register new post
+					$this->register_omise_charge_post( $result, $order, $order );
+
+					// Check 3D-Secure enabled
+					if ( $this->omise_3ds ) {
 						return array (
-							'result' => 'success',
+							'result'   => 'success',
 							'redirect' => $result->authorize_uri
 						);
 					} else {
 						// Auto capture or not?
-						if ( "auto_capture" === $this->payment_action ) {
-							$success = $this->is_charge_success( $result );
-						} else if ( "manual_capture" === $this->payment_action ) {
-							$success = $this->is_authorized_success( $result );
+						if ( 'auto_capture' === $this->payment_action ) {
+							$success = $this->is_charge_paid( $result );
+							if ( $success ) {
+								$order->payment_complete();
+								$order->add_order_note( 'Payment with Omise successful' );
+							}
 						}
-					}
 
-					if ($success) {
-						$order->payment_complete ();
-						$order->add_order_note ( 'Payment with Omise successful' );
+						if ( 'manual_capture' === $this->payment_action ) {
+							$success = $this->is_charge_authorized( $result );
+							if ( $success ) {
+								$order->add_order_note( 'Authorize with Omise successful' );
+							}
+						}
+
+						if ( ! $success )
+							throw new Exception( $this->get_charge_error_message( $result ) );
+
 						// Remove cart
 						WC()->cart->empty_cart();
 						return array (
-								'result' => 'success',
-								'redirect' => $this->get_return_url ( $order ) 
+							'result'   => 'success',
+							'redirect' => $this->get_return_url( $order )
 						);
-					} else {
-						throw new Exception($this->get_charge_error_message($result));
 					}
-				}
-				catch( Exception $e ){
+				} catch( Exception $e ) {
 					$error_message = $e->getMessage();
-					wc_add_notice( __('Payment error:', 'woothemes') . $error_message , 'error' );
-					$order->add_order_note ( 'Payment with Omise error : '. $error_message );
+					wc_add_notice( __( 'Payment error:', 'woothemes' ) . $error_message , 'error' );
+					$order->add_order_note( 'Payment with Omise error : '. $error_message );
 					return array(
-							'result'   => 'fail',
-							'redirect' => ''
+						'result'   => 'fail',
+						'redirect' => ''
 					);
 				}
 			}
 
-			private function is_authorized_success( $result ) {
-				if ( ! isset( $result->object ) || 'charge' !== $result->object )
-				    return false;
+			private function process_charge_authorize( $omise_skey, $data ) {
+				$data['capture'] = false;
 
-				if ( true === $charge['authorized'] )
-				    return true;
+				try {
+					$charge = Omise::create_charge( $omise_skey, $data );
+
+					if ( $charge->object === 'error' )
+						throw new Exception( $result->message );
+
+					if ( $charge->failure_code )
+						throw new Exception( $result->failure_message );
+
+				} catch ( Exception $e ) {
+					$charge = array(
+						'object'  => 'error',
+						'message' => $e->getMessage()
+					);
+				}
+
+				return $charge;
+			}
+
+			private function process_charge_authorize_and_capture( $omise_skey, $data ) {
+				$data['capture'] = true;
+
+				try {
+					$charge = Omise::create_charge( $omise_skey, $data );
+
+					if ( $charge->object === 'error' )
+						throw new Exception( $result->message );
+
+					if ( $charge->failure_code )
+						throw new Exception( $result->failure_message );
+
+				} catch ( Exception $e ) {
+					$charge = array(
+						'object'  => 'error',
+						'message' => $e->getMessage()
+					);
+				}
+
+				return $charge;
+			}
+
+			private function register_omise_charge_post( $result, $order, $order_id ) {
+				$post_id = wp_insert_post(
+					array(
+						'post_title'  => 'Omise Charge Id ' . $result->id,
+						'post_type'   => 'omise_charge_items',
+						'post_status' => 'publish'
+					)
+				);
+
+				add_post_meta( $post_id, '_omise_charge_id', $result->id );
+				add_post_meta( $post_id, '_wc_order_id', $order_id );
+				add_post_meta( $post_id, '_wc_confirmed_url', $this->get_return_url( $order ) );
+			}
+
+			/**
+			 * @param object $result
+			 * @return boolean
+			 */
+			private function is_charge_authorized( $result ) {
+				if ( ! isset( $result->object ) || 'charge' !== $result->object )
+					return false;
+
+				if ( true == $result->authorized )
+					return true;
 
 				return false;
 			}
 
-			private function is_charge_success($result){
-				return isset ( $result->id ) && isset( $result->object ) && $result->object == 'charge' && $result->captured == true;
+			/**
+			 * @param object $result
+			 * @return boolean
+			 */
+			private function is_charge_paid( $result ) {
+				if ( ! isset( $result->object ) || 'charge' !== $result->object )
+					return false;
+
+				// support Omise API version '2014-07-27' by checking if 'captured' exist.
+				$paid = isset( $result->captured ) ? $result->captured : $result->paid;
+				if ( isset( $result->id ) && true === $paid )
+					return true;
+
+				return false;
 			}
 
 			private function get_charge_error_message($result){
@@ -354,53 +425,63 @@ function register_omise_wc_gateway_plugin() {
 				) );
 			}
 
-			public function omise_3ds_handler()
-			{
-				if (!$_GET['order_id'])
+			public function omise_3ds_callback() {
+				if ( ! $_GET['order_id'] )
 					wp_die( "Order was not found", "Omise Payment Gateway: Checkout", array( 'response' => 500 ) );
 
-				$order_id 	= $_GET['order_id'];
+				$order_id = $_GET['order_id'];
+				$posts    = get_posts(array(
+					'post_type'   => 'omise_charge_items',
+					'meta_query'  => array( array(
+						'key'     => '_wc_order_id',
+						'value'   => $order_id,
+						'compare' => '='
+					) )
+				) );
 
-				$posts = get_posts(array(
-					'post_type'		=> 'omise_charge_items',
-					'meta_query' 	=> array(array(
-						'key' 		=> '_wc_order_id',
-						'value' 	=> $order_id,
-						'compare'	=> '='
-					))
-				));
-
-				if (empty($posts))
+				if ( empty( $posts ) )
 					wp_die( "Charge was not found", "Omise Payment Gateway: Checkout", array( 'response' => 500 ) );
 
 				$order = wc_get_order($order_id);
-				if (!$order)
+				if ( ! $order )
 					wp_die( "Order was not found", "Omise Payment Gateway: Checkout", array( 'response' => 500 ) );
 
-				$confirmed_url 	= get_post_custom_values('_wc_confirmed_url', $posts[0]->ID);
-				$confirmed_url 	= $confirmed_url[0];
+				$charge_id     = get_post_custom_values( '_omise_charge_id', $posts[0]->ID );
+				$charge_id     = $charge_id[0];
+				$confirmed_url = get_post_custom_values( '_wc_confirmed_url', $posts[0]->ID );
+				$confirmed_url = $confirmed_url[0];
 
-				$charge_id 		= get_post_custom_values('_omise_charge_id', $posts[0]->ID);
-				$charge_id 		= $charge_id[0];
+				$result = Omise::get_charge( $this->private_key, $charge_id );
 
-				$result = Omise::get_charge($this->private_key, $charge_id);
+				// Auto capture or not?
+				if ( "auto_capture" === $this->payment_action ) {
+					if ( $this->is_charge_paid( $result ) ) {
+						$order->payment_complete();
+						$order->add_order_note( 'Payment with Omise successful' );
 
-				if ($this->is_charge_success($result)) {
-					$order->payment_complete();
-					$order->add_order_note('Payment with Omise successful');
+						// Remove cart
+						WC()->cart->empty_cart();
 
-					// Remove cart
-					WC()->cart->empty_cart();
-
-					header("Location: ".$confirmed_url);
-					die();
-				} else {
-					if ($result->failure_code && $result->failure_message) {
-						$order->add_order_note('Charge was not completed, '.$result->failure_message);
-						wp_die($result->failure_message, "Charge was not completed", array( 'response' => 500 ));
-					} else {
-						wp_die("Charge still in progress", "Charge still in progress", array( 'response' => 500 ));
+						header( "Location: " . $confirmed_url );
+						die();
 					}
+				} else if ( "manual_capture" === $this->payment_action ) {
+					if ( $this->is_charge_authorized( $result ) ) {
+						$order->add_order_note( 'Payment with Omise - authorized' );
+
+						// Remove cart
+						WC()->cart->empty_cart();
+
+						header( "Location: " . $confirmed_url );
+						die();
+					}
+				}
+
+				if ( $result->failure_code && $result->failure_message ) {
+					$order->add_order_note( 'Charge was not completed, ' . $result->failure_message );
+					wp_die( $result->failure_message, "Charge was not completed", array( 'response' => 500 ) );
+				} else {
+					wp_die( "Charge still in progress", "Charge still in progress", array( 'response' => 500 ) );
 				}
 
 				wp_die( "Access denied", "Access Denied", array( 'response' => 401 ) );
@@ -420,7 +501,7 @@ function register_omise_wc_gateway_plugin() {
 	}
 
 	function add_omise_gateway( $methods ) {
-		$methods [] = 'WC_Gateway_Omise';
+		$methods[] = 'WC_Gateway_Omise';
 		return $methods;
 	}
 

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -256,7 +256,12 @@ function register_omise_wc_gateway_plugin() {
 							'redirect' => $result->authorize_uri
 						);
 					} else {
-						$success = $this->is_charge_success($result);
+						// Auto capture or not?
+						if ( "auto_capture" === $this->payment_action ) {
+							$success = $this->is_charge_success( $result );
+						} else if ( "manual_capture" === $this->payment_action ) {
+							$success = $this->is_authorized_success( $result );
+						}
 					}
 
 					if ($success) {
@@ -281,6 +286,16 @@ function register_omise_wc_gateway_plugin() {
 							'redirect' => ''
 					);
 				}
+			}
+
+			private function is_authorized_success( $result ) {
+				if ( ! isset( $result->object ) || 'charge' !== $result->object )
+				    return false;
+
+				if ( true === $charge['authorized'] )
+				    return true;
+
+				return false;
 			}
 
 			private function is_charge_success($result){

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -19,8 +19,7 @@ defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) || define( "OMISE_WOOCOMMERCE_PLUG
 defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2014-07-27' );
 
 require_once dirname( __FILE__ ) . '/includes/libraries/omise-php/lib/Omise.php';
-require_once dirname( __FILE__ ) . '/includes/libraries/omise-plugin/helpers/currency.php';
-require_once dirname( __FILE__ ) . '/includes/libraries/omise-plugin/helpers/transaction.php';
+require_once dirname( __FILE__ ) . '/includes/libraries/omise-plugin/Omise.php';
 
 require_once 'omise-util.php';
 require_once 'omise-api-wrapper.php';

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -20,6 +20,8 @@ defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2014-07-27' );
 
 require_once dirname( __FILE__ ) . '/includes/libraries/omise-php/lib/Omise.php';
 require_once dirname( __FILE__ ) . '/includes/libraries/omise-plugin/Omise.php';
+require_once dirname( __FILE__ ) . '/includes/classes/class-omise-charge.php';
+require_once dirname( __FILE__ ) . '/includes/classes/class-omise-hooks.php';
 
 require_once 'omise-util.php';
 require_once 'omise-api-wrapper.php';

--- a/omise-wp-admin.php
+++ b/omise-wp-admin.php
@@ -1,220 +1,201 @@
 <?php
-defined ( 'ABSPATH' ) or die ( "No direct script access allowed." );
+defined( 'ABSPATH' ) or die ( "No direct script access allowed." );
 
-if (! class_exists ( 'Omise_Admin' )) {
-  
-  class Omise_Admin {
-    
-    private static $instance;
+if ( ! class_exists( 'Omise_Admin' ) ) {
+	class Omise_Admin {
 
-    /**
-     * @var string
-     */
-    private $private_key;
+		private static $instance;
 
-    /**
-     * @var string
-     */
-    private $payment_action;
+		/**
+		 * @var string
+		 */
+		private $private_key;
 
-    /**
-     * @var string ('yes' or 'no')
-     */
-    private $support_3dsecure;
+		/**
+		 * @var string
+		 */
+		private $payment_action;
 
-    public static function get_instance() {
-      if (! self::$instance) {
-        self::$instance = new self ();
-      }
-      return self::$instance;
-    }
+		/**
+		 * @var string ('yes' or 'no')
+		 */
+		private $support_3dsecure;
 
-    public function register_admin_page_and_actions() {
-      if ( ! current_user_can( 'manage_options' ) ) {
-        return;
-      }
+		public static function get_instance() {
+			if ( ! self::$instance ) {
+				self::$instance = new self();
+			}
 
-      add_action ( 'admin_post_omise_create_transfer', array (
-          $this,
-          'create_transfer' 
-      ) );
+			return self::$instance;
+		}
 
-      add_action ( 'admin_post_nopriv_omise_create_transfer', array (
-          $this,
-          'no_op' 
-      ) );
+		public function register_admin_page_and_actions() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
 
-      add_action ( 'admin_menu', array (
-          $this,
-          'add_dashboard_omise_menu' 
-      ) );
-    }
+			add_action( 'admin_post_omise_create_transfer', array( $this, 'create_transfer' ) );
+			add_action( 'admin_post_nopriv_omise_create_transfer', array( $this, 'no_op' ) );
+			add_action( 'admin_menu', array( $this, 'add_dashboard_omise_menu' ) );
+		}
 
-    public function add_dashboard_omise_menu() {
-      add_menu_page( 'Omise', 'Omise', 'manage_options', 'omise-plugin-admin-page', array( $this, 'init_dashboard' ) );
-      add_submenu_page( 'omise-plugin-admin-page', 'Omise Dashboard', 'Dashboard', 'manage_options', 'omise-plugin-admin-page' );
-      add_submenu_page( 'omise-plugin-admin-page', 'Omise Setting', 'Setting', 'manage_options', 'wc-settings&tab=checkout&section=wc_gateway_omise' , function(){} );
-    }
+		public function add_dashboard_omise_menu() {
+			add_menu_page( 'Omise', 'Omise', 'manage_options', 'omise-plugin-admin-page', array( $this, 'init_dashboard' ) );
+			add_submenu_page( 'omise-plugin-admin-page', 'Omise Dashboard', 'Dashboard', 'manage_options', 'omise-plugin-admin-page' );
+			add_submenu_page( 'omise-plugin-admin-page', 'Omise Setting', 'Setting', 'manage_options', 'wc-settings&tab=checkout&section=wc_gateway_omise' , function(){} );
+		}
 
-    private function __construct() {
-      
-      $settings = get_option ( "woocommerce_omise_settings", null );
-      
-      if (is_null ( $settings ) || ! is_array ( $settings )) {
-        return;
-      }
-      
-      $this->test_mode = isset ( $settings ["sandbox"] ) && $settings ["sandbox"] == 'yes';
+		private function __construct() {
+			$settings = get_option( "woocommerce_omise_settings", null );
 
-      if(empty ( $settings ["test_private_key"] ) && $this->test_mode){
-        return;
-      }
+			if ( is_null( $settings ) || ! is_array( $settings ) ) {
+				return;
+			}
 
-      if(empty ( $settings ["live_private_key"] ) && !$this->test_mode ){
-        return;
-      }
+			$this->test_mode = isset( $settings["sandbox"] ) && $settings["sandbox"] == 'yes';
 
-      $this->private_key      = $this->test_mode ? $settings ["test_private_key"] : $settings ["live_private_key"];
-      $this->payment_action   = $settings['payment_action'];
-      $this->support_3dsecure = $settings['omise_3ds'];
-      
-      if (empty ( $this->private_key )) {
-        return;
-      }
-    }
+			if ( empty( $settings["test_private_key"] ) && $this->test_mode ) {
+				return;
+			}
 
-    public function no_op(){
-      exit("Not permitted");
-    }
+			if ( empty( $settings["live_private_key"] ) && ! $this->test_mode ) {
+				return;
+			}
 
-    public function create_transfer() {
-      if (! wp_verify_nonce ( $_POST ['omise_create_transfer_nonce'], 'omise_create_transfer' ))
-        die ( 'Nonce verification failure' );
-      
-      if (! isset ( $_POST ['_wp_http_referer'] ))
-        die ( 'Missing target' );
-      
-      $transfer_amount = isset ( $_POST ['omise_transfer_amount'] ) ? $_POST ['omise_transfer_amount'] : '';
-      $result_message = '';
-      try {
-        if (! empty ( $transfer_amount ) && ! is_numeric ( $transfer_amount )) {
-          throw new Exception ( "Transfer amount must be a numeric" );
-        }
-        
-        $balance = Omise::get_balance( $this->private_key );
-        if ( strtoupper( $balance->currency ) === "THB" ) {
-          $transfer_amount = $transfer_amount * 100;
-        }
+			$this->private_key      = $this->test_mode ? $settings ["test_private_key"] : $settings ["live_private_key"];
+			$this->payment_action   = $settings['payment_action'];
+			$this->support_3dsecure = $settings['omise_3ds'];
 
-        $transfer = Omise::create_transfer ( $this->private_key, empty ( $transfer_amount ) ? null : $transfer_amount );
-        
-        if ($this->is_transfer_success($transfer)) {
-          $result_message_type = 'updated';
-          $result_message      = "A fund transfer request has been sent.";
-        } else {
-          $result_message_type = 'error';
-          $result_message      = $this->get_transfer_error_message($transfer);
-        }
-      
-      } catch ( Exception $e ) {
-        $result_message_type = 'error';
-        $result_message      = $e->getMessage();
-      }
-      
-      $url = add_query_arg(
-        array(
-          'omise_result_msg_type' => $result_message_type,
-          'omise_result_msg'      => urlencode( $result_message )
-        ),
-        urldecode( $_POST['_wp_http_referer'] )
-      );
-      
-      wp_safe_redirect( $url );
-      exit();
-    }
-    
-    private function is_transfer_success($transfer){
-      return isset ( $transfer->id ) && isset( $transfer->object ) && $transfer->object == 'transfer' && $transfer->failure_code==null && $transfer->failure_message==null;
-    }
-    
-    private function get_transfer_error_message($transfer){
-      $message = "";
-    
-      if(isset($transfer->message) && !empty($transfer->message)){
-        $message .= $transfer->message." ";
-      }
-    
-      if(isset($transfer->failure_code) && !empty($transfer->failure_code)){
-        $message .= "[".$transfer-> failure_code."] ";
-      }
-    
-      if(isset($transfer->failure_message) && !empty($transfer->failure_message)){
-        $message .= $transfer-> failure_message;
-      }
-    
-      return trim($message);
-    }
+			if ( empty( $this->private_key ) ) {
+				return;
+			}
+		}
 
-    public function init_dashboard() {
-      
-      try {
-        $balance = Omise::get_balance ( $this->private_key );
-        if ($balance->object == 'balance') {
-          $paged  = isset( $_GET['paged'] ) ? $_GET['paged'] : 1;
-          $limit  = 10;
-          $offset = $paged > 1 ? ( $paged - 1 ) * $limit : 0;
-          $order  = 'reverse_chronological';
+		public function no_op() {
+			exit( "Not permitted" );
+		}
 
-          $charge_filters = '?' . http_build_query( array(
-            'limit'  => $limit,
-            'offset' => $offset,
-            'order'  => $order
-          ) );
+		public function create_transfer() {
+			if ( ! wp_verify_nonce( $_POST['omise_create_transfer_nonce'], 'omise_create_transfer' ) )
+				die( 'Nonce verification failure' );
 
-          $omise_account = OmiseAccount::retrieve( '', $this->private_key );
+			if ( ! isset( $_POST['_wp_http_referer'] ) )
+				die( 'Missing target' );
 
-          $viewData['auto_capture']     = $this->payment_action === 'auto_capture' ? 'YES' : 'NO';
-          $viewData['support_3dsecure'] = $this->support_3dsecure === 'yes' ? 'ENABLED' : 'DISABLED';
-          $viewData['balance']          = $balance;
-          $viewData['email']            = $omise_account['email'];
-          $viewData['charges']          = OmiseCharge::retrieve( $charge_filters, '', $this->private_key );
-          
-          $this->extract_result_message ( $viewData );
-          
-          Omise_Util::render_view ( 'includes/templates/omise-wp-admin-page.php', $viewData );
-          
-          $this->register_dashboard_script ();
-        } else {
-          echo "<div class='wrap'><div class='error'>Unable to get the balance information. Please verify that your private key is valid. [" . esc_html ( $balance->message ) . "]</div></div>";
-        }
-      } catch ( Exception $e ) {
-        echo "<div class='wrap'><div class='error'>" . esc_html ( $e->getMessage () ) . "</div></div>";
-      }
-    
-    }
+			$transfer_amount = isset( $_POST['omise_transfer_amount'] ) ? $_POST['omise_transfer_amount'] : '';
+			$result_message  = '';
 
-    function extract_result_message(&$viewData) {
-      if ( isset( $_GET['omise_result_msg'] ) ) {
-        $viewData["message"]      = $_GET['omise_result_msg'];
-        $viewData["message_type"] = isset( $_GET['omise_result_msg_type'] ) ? $_GET['omise_result_msg_type'] : 'updated';
-      } else {
-        $viewData["message"]      = '';
-        $viewData["message_type"] = '';
-      }
-    }
+			try {
+				if ( ! empty( $transfer_amount ) && ! is_numeric( $transfer_amount ) ) {
+					throw new Exception ( "Transfer amount must be a numeric" );
+				}
 
-    function register_dashboard_script() {
-      
-      wp_enqueue_script ( 'omise-dashboard-js', plugins_url ( '/assets/javascripts/omise-dashboard-handler.js', __FILE__ ), array (
-          'jquery' 
-      ), OMISE_WOOCOMMERCE_PLUGIN_VERSION, true );
-      
-      wp_enqueue_style ( 'omise-css', plugins_url ( '/assets/css/omise-css.css', __FILE__ ), array (), OMISE_WOOCOMMERCE_PLUGIN_VERSION );
-    
-    }
-  
-  }
+				$balance = Omise::get_balance( $this->private_key );
+				if ( strtoupper( $balance->currency ) === "THB" ) {
+					$transfer_amount = $transfer_amount * 100;
+				}
 
+				$transfer = Omise::create_transfer( $this->private_key, empty( $transfer_amount ) ? null : $transfer_amount );
+
+				if ( $this->is_transfer_success( $transfer ) ) {
+					$result_message_type = 'updated';
+					$result_message      = "A fund transfer request has been sent.";
+				} else {
+					$result_message_type = 'error';
+					$result_message      = $this->get_transfer_error_message($transfer);
+				}
+		  	} catch ( Exception $e ) {
+				$result_message_type = 'error';
+				$result_message      = $e->getMessage();
+			}
+
+			$url = add_query_arg(
+				array(
+					'omise_result_msg_type' => $result_message_type,
+					'omise_result_msg'      => urlencode( $result_message )
+				),
+				urldecode( $_POST['_wp_http_referer'] )
+			);
+
+			wp_safe_redirect( $url );
+			exit();
+		}
+
+		private function is_transfer_success( $transfer ) {
+			return isset( $transfer->id ) && isset( $transfer->object ) && $transfer->object == 'transfer' && $transfer->failure_code == null && $transfer->failure_message == null;
+		}
+
+		private function get_transfer_error_message( $transfer ) {
+			$message = "";
+
+			if( isset( $transfer->message ) && ! empty( $transfer->message ) ) {
+				$message .= $transfer->message." ";
+			}
+
+			if ( isset( $transfer->failure_code ) && ! empty( $transfer->failure_code ) ) {
+				$message .= "[" . $transfer->failure_code . "] ";
+			}
+
+			if ( isset( $transfer->failure_message ) && ! empty( $transfer->failure_message ) ) {
+				$message .= $transfer->failure_message;
+			}
+
+			return trim($message);
+		}
+
+		public function init_dashboard() {
+			try {
+				$balance = Omise::get_balance( $this->private_key );
+				if ( $balance->object == 'balance' ) {
+					$paged  = isset( $_GET['paged'] ) ? $_GET['paged'] : 1;
+					$limit  = 10;
+					$offset = $paged > 1 ? ( $paged - 1 ) * $limit : 0;
+					$order  = 'reverse_chronological';
+
+					$charge_filters = '?' . http_build_query(
+						array(
+							'limit'  => $limit,
+							'offset' => $offset,
+							'order'  => $order
+						)
+					);
+
+					$omise_account = OmiseAccount::retrieve( '', $this->private_key );
+
+					$viewData['auto_capture']     = $this->payment_action === 'auto_capture' ? 'YES' : 'NO';
+					$viewData['support_3dsecure'] = $this->support_3dsecure === 'yes' ? 'ENABLED' : 'DISABLED';
+					$viewData['balance']          = $balance;
+					$viewData['email']            = $omise_account['email'];
+					$viewData['charges']          = OmiseCharge::retrieve( $charge_filters, '', $this->private_key );
+
+					$this->extract_result_message( $viewData );
+
+					Omise_Util::render_view ( 'includes/templates/omise-wp-admin-page.php', $viewData );
+
+					$this->register_dashboard_script ();
+				} else {
+					echo "<div class='wrap'><div class='error'>Unable to get the balance information. Please verify that your private key is valid. [" . esc_html( $balance->message ) . "]</div></div>";
+				}
+			} catch( Exception $e ) {
+				echo "<div class='wrap'><div class='error'>" . esc_html( $e->getMessage () ) . "</div></div>";
+			}
+		}
+
+		function extract_result_message( &$viewData ) {
+			if ( isset( $_GET['omise_result_msg'] ) ) {
+				$viewData["message"]      = $_GET['omise_result_msg'];
+				$viewData["message_type"] = isset( $_GET['omise_result_msg_type'] ) ? $_GET['omise_result_msg_type'] : 'updated';
+			} else {
+				$viewData["message"]      = '';
+				$viewData["message_type"] = '';
+			}
+		}
+
+		function register_dashboard_script() {
+			wp_enqueue_script( 'omise-dashboard-js', plugins_url( '/assets/javascripts/omise-dashboard-handler.js', __FILE__ ), array( 'jquery' ), OMISE_WOOCOMMERCE_PLUGIN_VERSION, true );
+			wp_enqueue_style( 'omise-css', plugins_url( '/assets/css/omise-css.css', __FILE__ ), array(), OMISE_WOOCOMMERCE_PLUGIN_VERSION );
+		}
+	}
 }
 
 ?>

--- a/omise-wp-admin.php
+++ b/omise-wp-admin.php
@@ -34,6 +34,7 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 				return;
 			}
 
+			add_action( 'woocommerce_order_action_omise_charge_capture', array( $this, 'charge_capture' ) );
 			add_action( 'admin_post_omise_create_transfer', array( $this, 'create_transfer' ) );
 			add_action( 'admin_post_nopriv_omise_create_transfer', array( $this, 'no_op' ) );
 			add_action( 'admin_menu', array( $this, 'add_dashboard_omise_menu' ) );
@@ -73,6 +74,37 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 
 		public function no_op() {
 			exit( "Not permitted" );
+		}
+
+		public function charge_capture( $order ) {
+			$posts = get_posts( array(
+				'post_type'   => 'omise_charge_items',
+				'meta_query'  => array( array(
+					'key'     => '_wc_order_id',
+					'value'   => $order->id,
+					'compare' => '='
+				) )
+			) );
+
+			if ( empty( $posts ) )
+				return;
+
+			$charge_id  = get_post_custom_values( '_omise_charge_id', $posts[0]->ID );
+			$charge_id  = $charge_id[0];
+
+			try {
+				$charge_obj = OmiseCharge::retrieve( $charge_id, '', $this->private_key );
+				$charge_obj->capture();
+
+				if ( OmisePluginHelperCharge::isPaid( $charge_obj ) ) {
+					$order->payment_complete();
+					$order->add_order_note( 'Payment with Omise successful (manual captured)' );
+				} else {
+					throw new Exception( "Error Processing Request", 1 );
+				}
+			} catch ( Exception $e ) {
+				$order->add_order_note( $e->getMessage() );
+			}
 		}
 
 		public function create_transfer() {

--- a/omise-wp-admin.php
+++ b/omise-wp-admin.php
@@ -6,7 +6,21 @@ if (! class_exists ( 'Omise_Admin' )) {
   class Omise_Admin {
     
     private static $instance;
+
+    /**
+     * @var string
+     */
     private $private_key;
+
+    /**
+     * @var string
+     */
+    private $payment_action;
+
+    /**
+     * @var string ('yes' or 'no')
+     */
+    private $support_3dsecure;
 
     public static function get_instance() {
       if (! self::$instance) {
@@ -60,7 +74,9 @@ if (! class_exists ( 'Omise_Admin' )) {
         return;
       }
 
-      $this->private_key = $this->test_mode ? $settings ["test_private_key"] : $settings ["live_private_key"];
+      $this->private_key      = $this->test_mode ? $settings ["test_private_key"] : $settings ["live_private_key"];
+      $this->payment_action   = $settings['payment_action'];
+      $this->support_3dsecure = $settings['omise_3ds'];
       
       if (empty ( $this->private_key )) {
         return;
@@ -157,9 +173,11 @@ if (! class_exists ( 'Omise_Admin' )) {
 
           $omise_account = OmiseAccount::retrieve( '', $this->private_key );
 
-          $viewData['balance'] = $balance;
-          $viewData['email']   = $omise_account['email'];
-          $viewData['charges'] = OmiseCharge::retrieve( $charge_filters, '', $this->private_key );
+          $viewData['auto_capture']     = $this->payment_action === 'auto_capture' ? 'YES' : 'NO';
+          $viewData['support_3dsecure'] = $this->support_3dsecure === 'yes' ? 'ENABLED' : 'DISABLED';
+          $viewData['balance']          = $balance;
+          $viewData['email']            = $omise_account['email'];
+          $viewData['charges']          = OmiseCharge::retrieve( $charge_filters, '', $this->private_key );
           
           $this->extract_result_message ( $viewData );
           


### PR DESCRIPTION
#### 1. Objective reason

This PR gonna add more feature for do manual capture within WooCommerce environment.
Enhanced, refactoring and cleaned bunch of code.
Also, implemented Omise Dashboard and re-ordered fields in Omise Setting page.

#### 2. Description of change

- Revised PHP code to following the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php) (I just did only the files that I have to refactoring, fix. still need another PR to revise every files after)
- Implemented `includes/classes/class-omise-hooks.php` class and moved some hook methods to here.
- Added more information to the Omise Dashboard page.
  <img width="1242" alt="screen shot 2559-06-01 at 3 29 30 am" src="https://cloud.githubusercontent.com/assets/2154669/15689421/18ef49f0-27a9-11e6-8939-87ef083851bd.png">
- re-ordered fields in Omise Setting page. (moved public/secret key fields to top of the page, grouped another setting fields under the `Advanced Options` topic)
  <img width="965" alt="006 omise setting page first time" src="https://cloud.githubusercontent.com/assets/2154669/15689470/4dc65d30-27a9-11e6-8ac6-41bd64fde917.png">
- Better handle error cases (error messages)
- Fixed/Improved various things.
- Changed logic inside `process_payment()` method
- Enhanced `user-agent` when request to Omise's services.
  For example 👇   
  `OmisePHP/2.4.1 OmiseAPI/2014-07-27 OmiseWooCommerce/1.1.1 WordPress/4.5.2 WooCommerce/2.5.5`
- Refactored code, try to make it more testable (separated logic code to be functions/methods instead of put everything in the same function/method)
- Manual Capture !
- Admin be able to capture an authorized charge within the WooCommerce's order detail page.
  ![030 try to capture](https://cloud.githubusercontent.com/assets/2154669/15689737/a12698b8-27aa-11e6-8940-86a138cfe83b.png)
- Better handle WC order note to trace Omise's actions back.
  <img width="306" alt="screen shot 2559-06-01 at 3 54 14 am" src="https://cloud.githubusercontent.com/assets/2154669/15690245/dab3fe2a-27ac-11e6-9a8f-f26a7f704e70.png">

#### 3. Developers affected by the change

`-`

#### 4. Impact of the change

writing...

#### 5. Priority of change

:star2: :star2: :star:

#### 6. Alternate solution (if any)**

`-`

Noted: tested on `WordPress/4.5.2` - `WooCommerce/2.5.5`