### PR TITLE
Implement a feature, the configuration for display image of card brands

### DIFF
--- a/includes/classes/class-omise-card-image.php
+++ b/includes/classes/class-omise-card-image.php
@@ -124,9 +124,9 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 		public static function is_amex_enabled( $setting ) {
 			if ( isset( $setting['accept_amex'] ) && $setting['accept_amex'] == 'yes' ) {
 				return true;
-			} else {
-				return false;
 			}
+
+			return false;
 		}
 
 		/**
@@ -138,9 +138,9 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 		public static function is_diners_enabled( $setting ) {
 			if ( isset( $setting['accept_diners'] ) && $setting['accept_diners'] == 'yes' ) {
 				return true;
-			} else {
-				return false;
 			}
+
+			return false;
 		}
 
 		/**
@@ -152,9 +152,9 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 		public static function is_jcb_enabled( $setting ) {
 			if ( isset( $setting['accept_jcb'] ) && $setting['accept_jcb'] == 'yes' ) {
 				return true;
-			} else {
-				return false;
 			}
+
+			return false;
 		}
 
 		/**
@@ -166,14 +166,14 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 		public static function is_mastercard_enabled( $setting ) {
 			// Make it backward compatible. If the setting is not configured, the MasterCard logo is display by default.
 			if ( ! isset( $setting['accept_mastercard'] ) ) {
-				return true;
-			} else {
-				if ( $setting['accept_mastercard'] == 'yes' ) {
-					return true;
-				} else {
-					return false;
-				}
+				return self::get_mastercard_default_display();
 			}
+
+			if ( $setting['accept_mastercard'] == 'yes' ) {
+				return true;
+			}
+
+			return false;
 		}
 
 		/**
@@ -185,14 +185,14 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 		public static function is_visa_enabled( $setting ) {
 			// Make it backward compatible. If the setting is not configured, the Visa logo is display by default.
 			if ( ! isset( $setting['accept_visa'] ) ) {
-				return true;
-			} else {
-				if ( $setting['accept_visa'] == 'yes' ) {
-					return true;
-				} else {
-					return false;
-				}
+				return self::get_visa_default_display();
 			}
+
+			if ( $setting['accept_visa'] == 'yes' ) {
+				return true;
+			}
+
+			return false;
 		}
 	}
 }

--- a/includes/classes/class-omise-card-image.php
+++ b/includes/classes/class-omise-card-image.php
@@ -1,0 +1,104 @@
+<?php
+defined( 'ABSPATH' ) or die( "No direct script access allowed." );
+
+if ( ! class_exists( 'Omise_Card_Image' ) ) {
+	class Omise_Card_Image {
+
+		private static function get_html_img($file, $alternate_text) {
+			$url = WC_HTTPS::force_https_url ( WC()->plugin_url() . '/assets/images/icons/credit-cards/' );
+			return "<img src='$url/$file' width='38px' alt='$alternate_text' />";
+		}
+
+		public static function get_amex_default_display() {
+			return 'no';
+		}
+
+		public static function get_amex_image() {
+			return self::get_html_img( 'amex.svg', 'American Express' );
+		}
+
+		public static function get_css() {
+			return 'vertical-align: 5px;';
+		}
+
+		public static function get_diners_default_display() {
+			return 'no';
+		}
+
+		public static function get_diners_image() {
+			return self::get_html_img( 'diners.svg', 'Diners Club' );
+		}
+
+		public static function get_jcb_default_display() {
+			return 'no';
+		}
+
+		public static function get_jcb_image() {
+			return self::get_html_img( 'jcb.svg', 'JCB' );
+		}
+
+		public static function get_mastercard_default_display() {
+			return 'yes';
+		}
+
+		public static function get_mastercard_image() {
+			return self::get_html_img( 'mastercard.svg', 'MasterCard' );
+		}
+
+		public static function get_visa_default_display() {
+			return 'yes';
+		}
+
+		public static function get_visa_image() {
+			return self::get_html_img( 'visa.svg', 'Visa' );
+		}
+
+		public static function is_amex_enabled( $setting ) {
+			if ( isset( $setting['accept_amex'] ) && $setting['accept_amex'] == 'yes' ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		public static function is_diners_enabled( $setting ) {
+			if ( isset( $setting['accept_diners'] ) && $setting['accept_diners'] == 'yes' ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		public static function is_jcb_enabled( $setting ) {
+			if ( isset( $setting['accept_jcb'] ) && $setting['accept_jcb'] == 'yes' ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		public static function is_mastercard_enabled( $setting ) {
+			if ( ! isset( $setting['accept_mastercard'] ) ) {
+				return true;
+			} else {
+				if ( $setting['accept_mastercard'] == 'yes' ) {
+					return true;
+				} else {
+					return false;
+				}
+			}
+		}
+
+		public static function is_visa_enabled( $setting ) {
+			if ( ! isset( $setting['accept_visa'] ) ) {
+				return true;
+			} else {
+				if ( $setting['accept_visa'] == 'yes' ) {
+					return true;
+				} else {
+					return false;
+				}
+			}
+		}
+	}
+}

--- a/includes/classes/class-omise-card-image.php
+++ b/includes/classes/class-omise-card-image.php
@@ -3,56 +3,124 @@ defined( 'ABSPATH' ) or die( "No direct script access allowed." );
 
 if ( ! class_exists( 'Omise_Card_Image' ) ) {
 	class Omise_Card_Image {
-
-		private static function get_html_img($file, $alternate_text) {
-			$url = WC_HTTPS::force_https_url ( WC()->plugin_url() . '/assets/images/icons/credit-cards/' );
+		/**
+		 * Compose the given parameters into the string of HTML &lt;img&gt; element
+		 * 
+		 * @param string $file Image file name with extension such as image.jpg
+		 * @param string $alternate_text Alternate text for the image
+		 * @return string HTML &lt;img&gt; element
+		 */
+		private static function get_image( $file, $alternate_text ) {
+			$url = WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/' );
 			return "<img src='$url/$file' width='38px' alt='$alternate_text' />";
 		}
 
+		/**
+		 * Return the default setting of display the American Express logo
+		 * 
+		 * @return string
+		 */
 		public static function get_amex_default_display() {
 			return 'no';
 		}
 
+		/**
+		 * Return the HTML &lt;img&gt; element of American Express logo
+		 * 
+		 * @return string
+		 */
 		public static function get_amex_image() {
-			return self::get_html_img( 'amex.svg', 'American Express' );
+			return self::get_image( 'amex.svg', 'American Express' );
 		}
 
+		/**
+		 * Return the CSS used to format the image to be displayed vertical center align with checkbox
+		 * at the back-end setting page
+		 * 
+		 * @return string
+		 */
 		public static function get_css() {
 			return 'vertical-align: 5px;';
 		}
 
+		/**
+		 * Return the default setting of display the Diners Club logo
+		 * 
+		 * @return string
+		 */
 		public static function get_diners_default_display() {
 			return 'no';
 		}
 
+		/**
+		 * Return the HTML &lt;img&gt; element of Diners Club logo
+		 * 
+		 * @return string
+		 */
 		public static function get_diners_image() {
-			return self::get_html_img( 'diners.svg', 'Diners Club' );
+			return self::get_image( 'diners.svg', 'Diners Club' );
 		}
 
+		/**
+		 * Return the default setting of display the JCB logo
+		 * 
+		 * @return string
+		 */
 		public static function get_jcb_default_display() {
 			return 'no';
 		}
 
+		/**
+		 * Return the HTML &lt;img&gt; element of JCB logo
+		 * 
+		 * @return string
+		 */
 		public static function get_jcb_image() {
-			return self::get_html_img( 'jcb.svg', 'JCB' );
+			return self::get_image( 'jcb.svg', 'JCB' );
 		}
 
+		/**
+		 * Return the default setting of display the MasterCard logo
+		 *
+		 * @return string
+		 */
 		public static function get_mastercard_default_display() {
 			return 'yes';
 		}
 
+		/**
+		 * Return the HTML &lt;img&gt; element of MasterCard logo
+		 * 
+		 * @return string
+		 */
 		public static function get_mastercard_image() {
-			return self::get_html_img( 'mastercard.svg', 'MasterCard' );
+			return self::get_image( 'mastercard.svg', 'MasterCard' );
 		}
 
+		/**
+		 * Return the default setting of display the Visa logo
+		 *
+		 * @return string
+		 */
 		public static function get_visa_default_display() {
 			return 'yes';
 		}
 
-		public static function get_visa_image() {
-			return self::get_html_img( 'visa.svg', 'Visa' );
+		/**
+		 * Return the HTML &lt;img&gt; element of Visa logo
+		 * 
+		 * @return string
+		 */
+		 public static function get_visa_image() {
+			return self::get_image( 'visa.svg', 'Visa' );
 		}
 
+		/**
+		 * Check whether the setting for American Express logo is configured and it was set to display or not display
+		 * 
+		 * @param mixed $setting The array that contains key for checking the flag
+		 * @return boolean
+		 */
 		public static function is_amex_enabled( $setting ) {
 			if ( isset( $setting['accept_amex'] ) && $setting['accept_amex'] == 'yes' ) {
 				return true;
@@ -61,6 +129,12 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 			}
 		}
 
+		/**
+		 * Check whether the setting for Diners Club logo is configured and it was set to display or not display
+		 * 
+		 * @param mixed $setting The array that contains key for checking the flag
+		 * @return boolean
+		 */
 		public static function is_diners_enabled( $setting ) {
 			if ( isset( $setting['accept_diners'] ) && $setting['accept_diners'] == 'yes' ) {
 				return true;
@@ -69,6 +143,12 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 			}
 		}
 
+		/**
+		 * Check whether the setting for JCB logo is configured and it was set to display or not display
+		 * 
+		 * @param mixed $setting The array that contains key for checking the flag
+		 * @return boolean
+		 */
 		public static function is_jcb_enabled( $setting ) {
 			if ( isset( $setting['accept_jcb'] ) && $setting['accept_jcb'] == 'yes' ) {
 				return true;
@@ -77,7 +157,14 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 			}
 		}
 
+		/**
+		 * Check whether the setting for MasterCard logo is configured and it was set to display or not display
+		 * 
+		 * @param mixed $setting The array that contains key for checking the flag
+		 * @return boolean
+		 */
 		public static function is_mastercard_enabled( $setting ) {
+			// Make it backward compatible. If the setting is not configured, the MasterCard logo is display by default.
 			if ( ! isset( $setting['accept_mastercard'] ) ) {
 				return true;
 			} else {
@@ -89,7 +176,14 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 			}
 		}
 
+		/**
+		 * Check whether the setting for Visa logo is configured and it was set to display or not display
+		 * 
+		 * @param mixed $setting The array that contains key for checking the flag
+		 * @return boolean
+		 */
 		public static function is_visa_enabled( $setting ) {
+			// Make it backward compatible. If the setting is not configured, the Visa logo is display by default.
 			if ( ! isset( $setting['accept_visa'] ) ) {
 				return true;
 			} else {

--- a/includes/omise-wc-setting.php
+++ b/includes/omise-wc-setting.php
@@ -39,7 +39,7 @@ return array(
 		'type'        => 'title'
 	),
 	'accept_visa' => array(
-		'title'       => 'Supported cards icons',
+		'title'       => 'Supported card icons',
 		'type'        => 'checkbox',
 		'label'       => Omise_Card_Image::get_visa_image(),
 		'css'         => Omise_Card_Image::get_css(),
@@ -68,7 +68,7 @@ return array(
 		'label'       => Omise_Card_Image::get_amex_image(),
 		'css'         => Omise_Card_Image::get_css(),
 		'default'     => Omise_Card_Image::get_amex_default_display(),
-		'description' => __( 'This controls the card icons to display on checkout.<br />It is not related to card processing on Omise payment gateway.' )
+		'description' => __( 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.' )
 	),
 	'title' => array(
 		'title'       => __( 'Title:', $this->gateway_name ),

--- a/includes/omise-wc-setting.php
+++ b/includes/omise-wc-setting.php
@@ -3,34 +3,34 @@ defined( 'ABSPATH' ) or die( "No direct script access allowed." );
 
 return array(
 	'enabled' => array(
-		'title'       => __( 'Enable/Disable', $this->gateway_name ),
+		'title'       => __( 'Enable/Disable' ),
 		'type'        => 'checkbox',
-		'label'       => __( 'Enable Omise Payment Module.', $this->gateway_name ),
+		'label'       => __( 'Enable Omise Payment Module.' ),
 		'default'     => 'no'
 	),
 	'sandbox' => array(
-		'title'       => __( 'Sandbox', $this->gateway_name ),
+		'title'       => __( 'Sandbox' ),
 		'type'        => 'checkbox',
-		'label'       => __( 'Sandbox mode means everything is in TEST mode', $this->gateway_name ),
+		'label'       => __( 'Sandbox mode means everything is in TEST mode' ),
 		'default'     => 'yes'
 	),
 	'test_public_key' => array(
-		'title'       => __( 'Public key for test', $this->gateway_name ),
+		'title'       => __( 'Public key for test' ),
 		'type'        => 'text',
 		'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard' )
 	),
 	'test_private_key' => array(
-		'title'       => __( 'Secret key for test', $this->gateway_name ),
+		'title'       => __( 'Secret key for test' ),
 		'type'        => 'password',
 		'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard' )
 	),
 	'live_public_key' => array(
-		'title'       => __( 'Public key for live', $this->gateway_name ),
+		'title'       => __( 'Public key for live' ),
 		'type'        => 'text',
 		'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard' )
 	),
 	'live_private_key' => array(
-		'title'       => __( 'Secret key for live', $this->gateway_name ),
+		'title'       => __( 'Secret key for live' ),
 		'type'        => 'password',
 		'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard' )
 	),
@@ -71,30 +71,30 @@ return array(
 		'description' => __( 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.' )
 	),
 	'title' => array(
-		'title'       => __( 'Title:', $this->gateway_name ),
+		'title'       => __( 'Title:' ),
 		'type'        => 'text',
-		'description' => __( 'This controls the title which the user sees during checkout.', $this->gateway_name ),
-		'default'     => __( 'Omise Payment Gateway', $this->gateway_name )
+		'description' => __( 'This controls the title which the user sees during checkout.' ),
+		'default'     => __( 'Omise Payment Gateway' )
 	),
 	'payment_action' => array(
-		'title'       => __( 'Payment Action', $this->gateway_name ),
+		'title'       => __( 'Payment Action' ),
 		'type'        => 'select',
-		'description' => __( 'Manual Capture or Capture Automatically', $this->gateway_name ),
+		'description' => __( 'Manual Capture or Capture Automatically' ),
 		'default'     => 'auto_capture',
 		'class'       => 'wc-enhanced-select',
 		'options'     => $this->form_field_payment_actions(),
 		'desc_tip'    => true
 	),
 	'omise_3ds' => array(
-		'title'       => __( '3DSecure Support', $this->gateway_name ),
+		'title'       => __( '3DSecure Support' ),
 		'type'        => 'checkbox',
-		'label'       => __( 'Enables 3DSecure on this account (does not support for Japan account)', $this->gateway_name ),
+		'label'       => __( 'Enables 3DSecure on this account (does not support for Japan account)' ),
 		'default'     => 'no'
 	),
 	'description' => array(
-		'title'       => __( 'Description:', $this->gateway_name ),
+		'title'       => __( 'Description:' ),
 		'type'        => 'textarea',
-		'description' => __( 'This controls the description which the user sees during checkout.', $this->gateway_name ),
-		'default'     => __( 'Omise payment gateway.', $this->gateway_name )
+		'description' => __( 'This controls the description which the user sees during checkout.' ),
+		'default'     => __( 'Omise payment gateway.' )
 	)
 );

--- a/includes/omise-wc-setting.php
+++ b/includes/omise-wc-setting.php
@@ -68,7 +68,7 @@ return array(
 		'label'       => Omise_Card_Image::get_amex_image(),
 		'css'         => Omise_Card_Image::get_css(),
 		'default'     => Omise_Card_Image::get_amex_default_display(),
-		'description' => __( 'This controls the credit card icons to display on checkout.<br />It is not related to card processing on Omise payment gateway.' )
+		'description' => __( 'This controls the card icons to display on checkout.<br />It is not related to card processing on Omise payment gateway.' )
 	),
 	'title' => array(
 		'title'       => __( 'Title:', $this->gateway_name ),

--- a/includes/omise-wc-setting.php
+++ b/includes/omise-wc-setting.php
@@ -1,45 +1,47 @@
 <?php
 defined( 'ABSPATH' ) or die( "No direct script access allowed." );
 
+$text_domain = 'Omise';
+
 return array(
 	'enabled' => array(
-		'title'       => 'Enable/Disable',
+		'title'       => __( 'Enable/Disable', $text_domain ),
 		'type'        => 'checkbox',
-		'label'       => 'Enable Omise Payment Module.',
+		'label'       => __( 'Enable Omise Payment Module.', $text_domain ),
 		'default'     => 'no'
 	),
 	'sandbox' => array(
-		'title'       => 'Sandbox',
+		'title'       => __( 'Sandbox', $text_domain ),
 		'type'        => 'checkbox',
-		'label'       => 'Sandbox mode means everything is in TEST mode',
+		'label'       => __( 'Sandbox mode means everything is in TEST mode', $text_domain ),
 		'default'     => 'yes'
 	),
 	'test_public_key' => array(
-		'title'       => 'Public key for test',
+		'title'       => __( 'Public key for test', $text_domain ),
 		'type'        => 'text',
-		'description' => 'The "Test" mode public key which can be found in Omise Dashboard'
+		'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard', $text_domain )
 	),
 	'test_private_key' => array(
-		'title'       => 'Secret key for test',
+		'title'       => __( 'Secret key for test', $text_domain ),
 		'type'        => 'password',
-		'description' => 'The "Test" mode secret key which can be found in Omise Dashboard'
+		'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard', $text_domain )
 	),
 	'live_public_key' => array(
-		'title'       => 'Public key for live',
+		'title'       => __( 'Public key for live', $text_domain ),
 		'type'        => 'text',
-		'description' => 'The "Live" mode public key which can be found in Omise Dashboard'
+		'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard', $text_domain )
 	),
 	'live_private_key' => array(
-		'title'       => 'Secret key for live',
+		'title'       => __( 'Secret key for live', $text_domain ),
 		'type'        => 'password',
-		'description' => 'The "Live" mode secret key which can be found in Omise Dashboard'
+		'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard', $text_domain )
 	),
 	'advanced' => array(
-		'title'       => 'Advanced options', 'woocommerce',
+		'title'       => __( 'Advanced options', $text_domain ),
 		'type'        => 'title'
 	),
 	'accept_visa' => array(
-		'title'       => 'Supported card icons',
+		'title'       => __( 'Supported card icons', $text_domain ),
 		'type'        => 'checkbox',
 		'label'       => Omise_Card_Image::get_visa_image(),
 		'css'         => Omise_Card_Image::get_css(),
@@ -68,33 +70,33 @@ return array(
 		'label'       => Omise_Card_Image::get_amex_image(),
 		'css'         => Omise_Card_Image::get_css(),
 		'default'     => Omise_Card_Image::get_amex_default_display(),
-		'description' => 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.'
+		'description' => __( 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.', $text_domain )
 	),
 	'title' => array(
-		'title'       => 'Title',
+		'title'       => __( 'Title', $text_domain ),
 		'type'        => 'text',
-		'description' => 'This controls the title which the user sees during checkout.',
-		'default'     => 'Omise Payment Gateway'
+		'description' => __( 'This controls the title which the user sees during checkout.', $text_domain ),
+		'default'     => __( 'Omise Payment Gateway', $text_domain )
 	),
 	'payment_action' => array(
-		'title'       => 'Payment Action',
+		'title'       => __( 'Payment Action', $text_domain ),
 		'type'        => 'select',
-		'description' => 'Manual Capture or Capture Automatically',
+		'description' => __( 'Manual Capture or Capture Automatically', $text_domain ),
 		'default'     => 'auto_capture',
 		'class'       => 'wc-enhanced-select',
 		'options'     => $this->form_field_payment_actions(),
 		'desc_tip'    => true
 	),
 	'omise_3ds' => array(
-		'title'       => '3DSecure Support',
+		'title'       => __( '3DSecure Support', $text_domain ),
 		'type'        => 'checkbox',
-		'label'       => 'Enables 3DSecure on this account (does not support for Japan account)',
+		'label'       => __( 'Enables 3DSecure on this account (does not support for Japan account)', $text_domain ),
 		'default'     => 'no'
 	),
 	'description' => array(
-		'title'       => 'Description',
+		'title'       => __( 'Description', $text_domain ),
 		'type'        => 'textarea',
-		'description' => 'This controls the description which the user sees during checkout.',
-		'default'     => 'Omise payment gateway.'
+		'description' => __( 'This controls the description which the user sees during checkout.', $text_domain ),
+		'default'     => __( 'Omise payment gateway.', $text_domain )
 	)
 );

--- a/includes/omise-wc-setting.php
+++ b/includes/omise-wc-setting.php
@@ -3,39 +3,39 @@ defined( 'ABSPATH' ) or die( "No direct script access allowed." );
 
 return array(
 	'enabled' => array(
-		'title'       => __( 'Enable/Disable' ),
+		'title'       => 'Enable/Disable',
 		'type'        => 'checkbox',
-		'label'       => __( 'Enable Omise Payment Module.' ),
+		'label'       => 'Enable Omise Payment Module.',
 		'default'     => 'no'
 	),
 	'sandbox' => array(
-		'title'       => __( 'Sandbox' ),
+		'title'       => 'Sandbox',
 		'type'        => 'checkbox',
-		'label'       => __( 'Sandbox mode means everything is in TEST mode' ),
+		'label'       => 'Sandbox mode means everything is in TEST mode',
 		'default'     => 'yes'
 	),
 	'test_public_key' => array(
-		'title'       => __( 'Public key for test' ),
+		'title'       => 'Public key for test',
 		'type'        => 'text',
-		'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard' )
+		'description' => 'The "Test" mode public key which can be found in Omise Dashboard'
 	),
 	'test_private_key' => array(
-		'title'       => __( 'Secret key for test' ),
+		'title'       => 'Secret key for test',
 		'type'        => 'password',
-		'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard' )
+		'description' => 'The "Test" mode secret key which can be found in Omise Dashboard'
 	),
 	'live_public_key' => array(
-		'title'       => __( 'Public key for live' ),
+		'title'       => 'Public key for live',
 		'type'        => 'text',
-		'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard' )
+		'description' => 'The "Live" mode public key which can be found in Omise Dashboard'
 	),
 	'live_private_key' => array(
-		'title'       => __( 'Secret key for live' ),
+		'title'       => 'Secret key for live',
 		'type'        => 'password',
-		'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard' )
+		'description' => 'The "Live" mode secret key which can be found in Omise Dashboard'
 	),
 	'advanced' => array(
-		'title'       => __( 'Advanced options', 'woocommerce' ),
+		'title'       => 'Advanced options', 'woocommerce',
 		'type'        => 'title'
 	),
 	'accept_visa' => array(
@@ -68,33 +68,33 @@ return array(
 		'label'       => Omise_Card_Image::get_amex_image(),
 		'css'         => Omise_Card_Image::get_css(),
 		'default'     => Omise_Card_Image::get_amex_default_display(),
-		'description' => __( 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.' )
+		'description' => 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.'
 	),
 	'title' => array(
-		'title'       => __( 'Title:' ),
+		'title'       => 'Title',
 		'type'        => 'text',
-		'description' => __( 'This controls the title which the user sees during checkout.' ),
-		'default'     => __( 'Omise Payment Gateway' )
+		'description' => 'This controls the title which the user sees during checkout.',
+		'default'     => 'Omise Payment Gateway'
 	),
 	'payment_action' => array(
-		'title'       => __( 'Payment Action' ),
+		'title'       => 'Payment Action',
 		'type'        => 'select',
-		'description' => __( 'Manual Capture or Capture Automatically' ),
+		'description' => 'Manual Capture or Capture Automatically',
 		'default'     => 'auto_capture',
 		'class'       => 'wc-enhanced-select',
 		'options'     => $this->form_field_payment_actions(),
 		'desc_tip'    => true
 	),
 	'omise_3ds' => array(
-		'title'       => __( '3DSecure Support' ),
+		'title'       => '3DSecure Support',
 		'type'        => 'checkbox',
-		'label'       => __( 'Enables 3DSecure on this account (does not support for Japan account)' ),
+		'label'       => 'Enables 3DSecure on this account (does not support for Japan account)',
 		'default'     => 'no'
 	),
 	'description' => array(
-		'title'       => __( 'Description:' ),
+		'title'       => 'Description',
 		'type'        => 'textarea',
-		'description' => __( 'This controls the description which the user sees during checkout.' ),
-		'default'     => __( 'Omise payment gateway.' )
+		'description' => 'This controls the description which the user sees during checkout.',
+		'default'     => 'Omise payment gateway.'
 	)
 );

--- a/includes/omise-wc-setting.php
+++ b/includes/omise-wc-setting.php
@@ -1,0 +1,100 @@
+<?php
+defined( 'ABSPATH' ) or die( "No direct script access allowed." );
+
+return array(
+	'enabled' => array(
+		'title'       => __( 'Enable/Disable', $this->gateway_name ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Enable Omise Payment Module.', $this->gateway_name ),
+		'default'     => 'no'
+	),
+	'sandbox' => array(
+		'title'       => __( 'Sandbox', $this->gateway_name ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Sandbox mode means everything is in TEST mode', $this->gateway_name ),
+		'default'     => 'yes'
+	),
+	'test_public_key' => array(
+		'title'       => __( 'Public key for test', $this->gateway_name ),
+		'type'        => 'text',
+		'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard' )
+	),
+	'test_private_key' => array(
+		'title'       => __( 'Secret key for test', $this->gateway_name ),
+		'type'        => 'password',
+		'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard' )
+	),
+	'live_public_key' => array(
+		'title'       => __( 'Public key for live', $this->gateway_name ),
+		'type'        => 'text',
+		'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard' )
+	),
+	'live_private_key' => array(
+		'title'       => __( 'Secret key for live', $this->gateway_name ),
+		'type'        => 'password',
+		'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard' )
+	),
+	'advanced' => array(
+		'title'       => __( 'Advanced options', 'woocommerce' ),
+		'type'        => 'title'
+	),
+	'accept_visa' => array(
+		'title'       => 'Supported cards icons',
+		'type'        => 'checkbox',
+		'label'       => Omise_Card_Image::get_visa_image(),
+		'css'         => Omise_Card_Image::get_css(),
+		'default'     => Omise_Card_Image::get_visa_default_display()
+	),
+	'accept_mastercard' => array(
+		'type'        => 'checkbox',
+		'label'       => Omise_Card_Image::get_mastercard_image(),
+		'css'         => Omise_Card_Image::get_css(),
+		'default'     => Omise_Card_Image::get_mastercard_default_display()
+	),
+	'accept_jcb' => array(
+		'type'        => 'checkbox',
+		'label'       => Omise_Card_Image::get_jcb_image(),
+		'css'         => Omise_Card_Image::get_css(),
+		'default'     => Omise_Card_Image::get_jcb_default_display()
+	),
+	'accept_diners' => array(
+		'type'        => 'checkbox',
+		'label'       => Omise_Card_Image::get_diners_image(),
+		'css'         => Omise_Card_Image::get_css(),
+		'default'     => Omise_Card_Image::get_diners_default_display()
+	),
+	'accept_amex' => array(
+		'type'        => 'checkbox',
+		'label'       => Omise_Card_Image::get_amex_image(),
+		'css'         => Omise_Card_Image::get_css(),
+		'default'     => Omise_Card_Image::get_amex_default_display(),
+		'description' => __( 'This controls the credit card icons to display on checkout.<br />It is not related to card processing on Omise payment gateway.' )
+	),
+	'title' => array(
+		'title'       => __( 'Title:', $this->gateway_name ),
+		'type'        => 'text',
+		'description' => __( 'This controls the title which the user sees during checkout.', $this->gateway_name ),
+		'default'     => __( 'Omise Payment Gateway', $this->gateway_name )
+	),
+	'payment_action' => array(
+		'title'       => __( 'Payment Action', $this->gateway_name ),
+		'type'        => 'select',
+		'description' => __( 'Manual Capture or Capture Automatically', $this->gateway_name ),
+		'default'     => 'auto_capture',
+		'class'       => 'wc-enhanced-select',
+		'options'     => $this->form_field_payment_actions(),
+		'desc_tip'    => true
+	),
+	'omise_3ds' => array(
+		'title'       => __( '3DSecure Support', $this->gateway_name ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Enables 3DSecure on this account (does not support for Japan account)', $this->gateway_name ),
+		'default'     => 'no'
+	),
+	'description' => array(
+		'title'       => __( 'Description:', $this->gateway_name ),
+		'type'        => 'textarea',
+		'description' => __( 'This controls the description which the user sees during checkout.', $this->gateway_name ),
+		'default'     => __( 'Omise payment gateway.', $this->gateway_name )
+	)
+);

--- a/includes/omise-wc-setting.php
+++ b/includes/omise-wc-setting.php
@@ -84,7 +84,10 @@ return array(
 		'description' => __( 'Manual Capture or Capture Automatically', $text_domain ),
 		'default'     => 'auto_capture',
 		'class'       => 'wc-enhanced-select',
-		'options'     => $this->form_field_payment_actions(),
+		'options'     => array(
+			'auto_capture'   => __( 'Auto Capture', $text_domain ),
+			'manual_capture' => __( 'Manual Capture', $text_domain )
+		),
 		'desc_tip'    => true
 	),
 	'omise_3ds' => array(

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -20,17 +20,22 @@ function register_omise_wc_gateway_plugin() {
 				$this->init_form_fields();
 				$this->init_settings();
 
-				$this->title            = $this->settings['title'];
-				$this->description      = $this->settings['description'];
-				$this->sandbox          = isset( $this->settings['sandbox'] ) && $this->settings['sandbox'] == 'yes';
-				$this->payment_action   = $this->settings['payment_action'];
-				$this->omise_3ds        = isset( $this->settings['omise_3ds'] ) && $this->settings['omise_3ds'] == 'yes';
-				$this->test_private_key = $this->settings['test_private_key'];
-				$this->test_public_key  = $this->settings['test_public_key'];
-				$this->live_private_key = $this->settings['live_private_key'];
-				$this->live_public_key  = $this->settings['live_public_key'];
-				$this->public_key       = $this->sandbox ? $this->test_public_key : $this->live_public_key;
-				$this->private_key      = $this->sandbox ? $this->test_private_key : $this->live_private_key;
+				$this->title             = $this->settings['title'];
+				$this->description       = $this->settings['description'];
+				$this->sandbox           = isset( $this->settings['sandbox'] ) && $this->settings['sandbox'] == 'yes';
+				$this->payment_action    = $this->settings['payment_action'];
+				$this->omise_3ds         = isset( $this->settings['omise_3ds'] ) && $this->settings['omise_3ds'] == 'yes';
+				$this->test_private_key  = $this->settings['test_private_key'];
+				$this->test_public_key   = $this->settings['test_public_key'];
+				$this->live_private_key  = $this->settings['live_private_key'];
+				$this->live_public_key   = $this->settings['live_public_key'];
+				$this->public_key        = $this->sandbox ? $this->test_public_key : $this->live_public_key;
+				$this->private_key       = $this->sandbox ? $this->test_private_key : $this->live_private_key;
+				$this->accept_amex       = isset( $this->settings['accept_amex'] ) && $this->settings['accept_amex'] == 'yes';
+				$this->accept_diners     = isset( $this->settings['accept_diners'] ) && $this->settings['accept_diners'] == 'yes';
+				$this->accept_jcb        = isset( $this->settings['accept_jcb'] ) && $this->settings['accept_jcb'] == 'yes';
+				$this->accept_mastercard = isset( $this->settings['accept_mastercard'] ) && $this->settings['accept_mastercard'] == 'yes';
+				$this->accept_visa       = isset( $this->settings['accept_visa'] ) && $this->settings['accept_visa'] == 'yes';
 
 				add_action( 'woocommerce_api_wc_gateway_' . $this->id, array( Omise_Hooks::get_instance(), 'charge_3ds_callback' ) );
 				add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( &$this, 'process_admin_options' ) );
@@ -42,72 +47,7 @@ function register_omise_wc_gateway_plugin() {
 			 * @see WC_Settings_API::init_form_fields()
 			 */
 			function init_form_fields() {
-				$this->form_fields = array(
-					'enabled' => array(
-						'title'       => __( 'Enable/Disable', $this->gateway_name ),
-						'type'        => 'checkbox',
-						'label'       => __( 'Enable Omise Payment Module.', $this->gateway_name ),
-						'default'     => 'no'
-					),
-					'sandbox' => array(
-						'title'       => __( 'Sandbox', $this->gateway_name ),
-						'type'        => 'checkbox',
-						'label'       => __( 'Sandbox mode means everything is in TEST mode', $this->gateway_name ),
-						'default'     => 'yes'
-					),
-					'test_public_key' => array(
-						'title'       => __( 'Public key for test', $this->gateway_name ),
-						'type'        => 'text',
-						'description' => __( 'The "Test" mode public key which can be found in Omise Dashboard' )
-					),
-					'test_private_key' => array(
-						'title'       => __( 'Secret key for test', $this->gateway_name ),
-						'type'        => 'password',
-						'description' => __( 'The "Test" mode secret key which can be found in Omise Dashboard' )
-					),
-					'live_public_key' => array(
-						'title'       => __( 'Public key for live', $this->gateway_name ),
-						'type'        => 'text',
-						'description' => __( 'The "Live" mode public key which can be found in Omise Dashboard' )
-					),
-					'live_private_key' => array(
-						'title'       => __( 'Secret key for live', $this->gateway_name ),
-						'type'        => 'password',
-						'description' => __( 'The "Live" mode secret key which can be found in Omise Dashboard' )
-					),
-					'advanced' => array(
-						'title'       => __( 'Advanced options', 'woocommerce' ),
-						'type'        => 'title',
-						'description' => '',
-					),
-					'title' => array(
-						'title'       => __( 'Title:', $this->gateway_name ),
-						'type'        => 'text',
-						'description' => __( 'This controls the title which the user sees during checkout.', $this->gateway_name ),
-						'default'     => __( 'Omise Payment Gateway', $this->gateway_name )
-					),
-					'payment_action' => array(
-						'title'       => __( 'Payment Action', $this->gateway_name ),
-						'type'        => 'select',
-						'description' => __( 'Manual Capture or Capture Automatically', $this->gateway_name ),
-						'default'     => 'auto_capture',
-						'class'       => 'wc-enhanced-select',
-						'options'     => $this->form_field_payment_actions(),
-						'desc_tip'    => true
-					),
-					'omise_3ds' => array(
-						'title'       => __( '3DSecure Support', $this->gateway_name ),
-						'type'        => 'checkbox',
-						'label'       => __( 'Enables 3DSecure on this account (does not support for Japan account)', $this->gateway_name ),
-						'default'     => 'no'
-					),
-					'description' => array(
-						'title'       => __( 'Description:', $this->gateway_name ),
-						'type'        => 'textarea',
-						'description' => __( 'This controls the description which the user sees during checkout.', $this->gateway_name ),
-						'default'     => __( 'Omise payment gateway.', $this->gateway_name )
-					)
-				);
+				$this->form_fields = include( 'includes/omise-wc-setting.php' );
 			}
 
 			/**
@@ -322,11 +262,29 @@ function register_omise_wc_gateway_plugin() {
 			 * @see WC_Payment_Gateway::get_icon()
 			 */
 			public function get_icon() {
-				$icon = '<img src="' . WC_HTTPS::force_https_url ( WC ()->plugin_url () . '/assets/images/icons/credit-cards/visa.png' ) . '" alt="Visa" />';
-				$icon .= '<img src="' . WC_HTTPS::force_https_url ( WC ()->plugin_url () . '/assets/images/icons/credit-cards/mastercard.png' ) . '" alt="Mastercard" />';
-				$icon .= '<img src="' . WC_HTTPS::force_https_url ( WC ()->plugin_url () . '/assets/images/icons/credit-cards/jcb.png' ) . '" alt="JCB" />';
+				$icon = '';
 
-				return apply_filters ( 'woocommerce_gateway_icon', $icon, $this->id );
+				if ( Omise_Card_Image::is_visa_enabled( $this->settings ) ) {
+					$icon .= Omise_Card_Image::get_visa_image();
+				}
+
+				if ( Omise_Card_Image::is_mastercard_enabled( $this->settings ) ) {
+					$icon .= Omise_Card_Image::get_mastercard_image();
+				}
+
+				if ( Omise_Card_Image::is_jcb_enabled( $this->settings ) ) {
+					$icon .= Omise_Card_Image::get_jcb_image();
+				}
+
+				if ( Omise_Card_Image::is_diners_enabled( $this->settings ) ) {
+					$icon .= Omise_Card_Image::get_diners_image();
+				}
+
+				if ( Omise_Card_Image::is_amex_enabled( $this->settings ) ) {
+					$icon .= Omise_Card_Image::get_amex_image();
+				}
+
+				return empty( $icon ) ? '' : apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
 			}
 
 			/**

--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -15,7 +15,7 @@ function register_omise_wc_gateway_plugin() {
 				$this->id               = 'omise';
 				$this->method_title     = "Omise";
 				$this->has_fields       = true;
-				
+
 				// call base functions required for WooCommerce gateway
 				$this->init_form_fields();
 				$this->init_settings();
@@ -158,7 +158,7 @@ function register_omise_wc_gateway_plugin() {
 						"description" => "WooCommerce Order id " . $order_id,
 						"return_uri"  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=wc_gateway_omise" )
 					);
-					
+
 					if ( ! empty( $card_id ) && ! empty( $omise_customer_id ) ) {
 						// create charge with a specific card of customer
 						$data["customer"] = $omise_customer_id;
@@ -305,16 +305,6 @@ function register_omise_wc_gateway_plugin() {
 					'key'       => $this->public_key,
 					'vault_url' => OMISE_VAULT_HOST
 				) );
-			}
-
-			/**
-			 * @return array
-			 */
-			public function form_field_payment_actions() {
-				return array(
-					'auto_capture'   => __( "Auto Capture", $this->gateway_name ),
-					'manual_capture' => __( "Manual Capture", $this->gateway_name )
-				);
 			}
 		}
 	}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -23,6 +23,7 @@ require_once dirname( __FILE__ ) . '/includes/libraries/omise-plugin/Omise.php';
 require_once dirname( __FILE__ ) . '/includes/classes/class-omise-charge.php';
 require_once dirname( __FILE__ ) . '/includes/classes/class-omise-hooks.php';
 require_once dirname( __FILE__ ) . '/includes/classes/class-omise-transfer.php';
+require_once dirname( __FILE__ ) . '/includes/classes/class-omise-card-image.php';
 
 require_once 'omise-util.php';
 require_once 'omise-api-wrapper.php';


### PR DESCRIPTION
**1. Objective reason**

Accepting card payment for each merchants are not the same. For example, some merchant can accept payments via JCB. Some merchant can not accept payment via JCB but can accept payment via Diners Club.

So it is easier and more comfortable, if the merchant can configure the display card brand logo by themselves.

Related ticket: T373

**2. Description of change**

Add a configuration, Supported card icons, at the back-end, setting page.

![screenshot-192 168 99 100 8080 2016-07-15 15-27-19](https://cloud.githubusercontent.com/assets/4145121/16868896/4dec1cb4-4aa4-11e6-9b1f-cf37ce98178f.png)

Add the condition to determine card brand logo display at the front-end, checkout page.

![screenshot-192 168 99 100 8080 2016-07-15 15-55-12](https://cloud.githubusercontent.com/assets/4145121/16868960/b06a04e6-4aa4-11e6-8c9d-0cfe5dbdcff9.png)

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`