### PR TITLE
Use an inline style for card brand image

### DIFF
--- a/includes/classes/class-omise-card-image.php
+++ b/includes/classes/class-omise-card-image.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 		 */
 		private static function get_image( $file, $alternate_text ) {
 			$url = WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/' );
-			return "<img src='$url/$file' style='width: 38px;' alt='$alternate_text' />";
+			return "<img src='$url/$file' class='Omise-CardBrandImage' style='width: 38px;' alt='$alternate_text' />";
 		}
 
 		/**

--- a/includes/classes/class-omise-card-image.php
+++ b/includes/classes/class-omise-card-image.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'Omise_Card_Image' ) ) {
 		 */
 		private static function get_image( $file, $alternate_text ) {
 			$url = WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/' );
-			return "<img src='$url/$file' width='38px' alt='$alternate_text' />";
+			return "<img src='$url/$file' style='width: 38px;' alt='$alternate_text' />";
 		}
 
 		/**


### PR DESCRIPTION
**1. Objective reason**

Define the inline style for the card brand image.

When the customer has define the rule (cascading style sheet) for the image size by themselves or by theme that they use and that rule impacts to the display of the card brand image, the display of image will not proportional.

The image below shows an example of the display of card brand image is not proportional.

![screenshot-192 168 99 100 8080 2016-08-24 22-10-38](https://cloud.githubusercontent.com/assets/4145121/17938385/ec0ee1ae-6a4f-11e6-960a-0e0707d750df.png)

Related ticket: T914

**2. Description of change**

Remove an attribute, width, from the image and add an inline style to override the user's style.

A reference for the cascading order: [W3C The cascade](https://www.w3.org/TR/CSS22/cascade.html#cascade)

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

Bundle the card brand images instead of using the images of WooCommerce and define the cascading style sheet (CSS) to control the display and override the other CSS.