### PR TITLE
Change text domain as same as plugin directory name.

### DIFF
--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -6,6 +6,7 @@
  * Version: 1.2.3
  * Author: Omise
  * Author URI: https://www.omise.co
+ * Text Domain: omise
  *
  * Copyright: Copyright 2014-2015. Omise Co., Ltd.
  * License: MIT
@@ -17,7 +18,7 @@ defined( 'OMISE_VAULT_HOST' ) || define( 'OMISE_VAULT_HOST', 'vault.omise.co' );
 defined( 'OMISE_API_HOST' ) || define( 'OMISE_API_HOST', 'api.omise.co' );
 defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION', '1.2.3' );
 defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2014-07-27' );
-defined( 'OMISE_WOOCOMMERCE_TEXT_DOMAIN' ) || define( 'OMISE_WOOCOMMERCE_TEXT_DOMAIN', 'omise-woocommerce' );
+defined( 'OMISE_WOOCOMMERCE_TEXT_DOMAIN' ) || define( 'OMISE_WOOCOMMERCE_TEXT_DOMAIN', 'omise' );
 
 require_once dirname( __FILE__ ) . '/includes/libraries/omise-php/lib/Omise.php';
 require_once dirname( __FILE__ ) . '/includes/libraries/omise-plugin/Omise.php';


### PR DESCRIPTION
**1. Objective reason**

This plugin is not translatable on GlotPress, the tool which allows every locale team to manage WordPress plugin translation and generate/provide language pack.

Related ticket: Not translatable with GrotPress. #31

**2. Description of change**

Change text domain as same as plugin directory name.

**3. Users affected by the change**

Translation editors.

**4. Impact of the change**

I believe nothing.

**5. Priority of change**

not high

**6. Alternate solution (if any)**

Ask translation editors to do with old way.
