### PR TITLE
Correct the English grammar of error message

### DIFF
--- a/omise-wc-gateway.php
+++ b/omise-wc-gateway.php
@@ -221,7 +221,7 @@ function register_omise_wc_gateway_plugin() {
 						}
 
 						if ( ! $success )
-							throw new Exception( __( 'This charge cannot authorize or capture, please contact our support.', 'omise' ) );
+							throw new Exception( __( 'This charge cannot be authorized or captured, please contact our support team.', 'omise' ) );
 
 						// Remove cart
 						WC()->cart->empty_cart();


### PR DESCRIPTION
#### 1. Objective

Correct the English grammar of error message.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

Modify a file, omise-wc-gateway.php, to correct the English grammar of error message.

**Note**
The error message will be appeared after created Omise charge and then retrieved the Omise charge status but the Omise charge status is NOT authorized (in case of manual capture) or NOT paid (in case of auto capture).

#### 3. Quality assurance

**Environments:**

- **Platform version**: WordPress 4.7.5, WooCommerce 3.0.7
- **Omise plugin version**: Omise WooCommerce 1.2.3
- **PHP version**: 7.0.15

**Details:**

**There are 3 test cases below.**

1. Create failed Omise charge, expected that the English grammar of error message is corrected
2. (Regression test) Create success non 3-D Secure Omise charge
3. (Regression test) Create success 3-D Secure Omise charge

**Test case 1: Create failed Omise charge**

To enter the condition that the error message will be appeared, it can be entered by configure the setting of Omise public key and secret key by using the keys of Omise 3-D Secure account but UNCHECKED the setting of 3-D Secure support.

The screenshot below shows part of Omise configuration at the back-end. The setting of 3-D Secure support is unchecked.

![screenshot-52 221 219 34-2017-05-22-19-30-52](https://cloud.githubusercontent.com/assets/4145121/26308916/589ef58e-3f25-11e7-916d-bf15636b0c18.png)

After configured, proceed the checkout by normal, using a success test card number such as 4242424242424242.

The screenshot below shows the error message that has been corrected.

![screenshot-52 221 219 34-2017-05-22-17-22-04](https://cloud.githubusercontent.com/assets/4145121/26308696/7288f428-3f24-11e7-8817-52ccc4b3885b.png)

**Test case 2: Create success non 3-D Secure Omise charge**

The screenshot below shows the success order at front-end. The order ID is 23.

![screenshot-52 221 219 34-2017-05-22-23-11-21](https://cloud.githubusercontent.com/assets/4145121/26318104/1e2422f2-3f44-11e7-931d-1035d4ac481d.png)

The screenshot below shows the detail of Omise success charge. The order ID is 23.

![screenshot-dashboard omise co-2017-05-22-23-07-22](https://cloud.githubusercontent.com/assets/4145121/26317970/9125feb6-3f43-11e7-8987-f64cf6580ea8.png)

**Test case 3: Create success 3-D Secure Omise charge**

The screenshot below shows the success order at front-end. The order ID is 21.

![screenshot-52 221 219 34-2017-05-22-19-44-24](https://cloud.githubusercontent.com/assets/4145121/26309505/82b7aaf8-3f27-11e7-81d2-c69075fa03e3.png)

The screenshot below shows the log of Omise success charge. The order ID is 21.

![screenshot-dashboard omise co-2017-05-22-19-45-41](https://cloud.githubusercontent.com/assets/4145121/26309565/b0c58852-3f27-11e7-8ed3-fdaf39d1bde7.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

- The meaning of the error message remains the same. Only English grammar has been corrected.
- The [Japanese translation of the error message](https://github.com/omise/omise-woocommerce/blob/master/languages/omise-woocommerce-ja.po#L466) is not included in this pull request.