### PR TITLE
Fix that user cannot use saved-card at the checkout page. Also, better credit card form UI

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -1,12 +1,24 @@
-fieldset.omise-hidden {
-	display:none;
+.omise-remember-card input,
+.omise-remember-card label {
+	display: inline-block;
 }
 
-input[name='card_id']:checked ~ #new_card_form {
-    display: none;
+.omise-customer-card-list {
+	padding-bottom: .75em;
+	border-bottom: 1px solid #ddd;
+	box-shadow: 0 1px 1px #fff;
 }
 
-#new_card_info:checked ~ #new_card_form {
+#label-new_card_info h3 {
+	margin-top: .75em;
+	display: inline-block;
+}
+
+fieldset.card-exists {
+	display: none;
+}
+
+#new_card_info:checked ~ fieldset.card-exists {
     display: block;
 }
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -224,14 +224,13 @@ function register_omise_creditcard() {
 							throw new Exception( $e->getMessage() );
 						}
 					} else {
-						$description   = "WooCommerce customer " . $user->id;
+						$description   = "WooCommerce customer " . $user->ID;
 						$customer_data = array(
 							"description" => $description,
 							"card"        => $token
 						);
 
 						$omise_customer = OmiseCustomer::create( $customer_data, '', $this->secret_key() );
-						$omise_customer = Omise::create_customer( $this->secret_key(), $customer_data );
 
 						if ( $omise_customer['object'] == "error" ) {
 							throw new Exception( $omise_customer['message'] );

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -164,7 +164,7 @@ function register_omise_creditcard() {
 				$omise_customer_id = $this->is_test() ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
 				if ( ! empty( $omise_customer_id ) ) {
 
-					$customer                  = OmiseCustomer::retrieve( $omise_customer_id , '', $this->secret_key() );
+					$customer                  = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
 					$viewData['existingCards'] = $customer->cards( array( 'order' => 'reverse_chronological' ) );
 				}
 			} else {

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -164,8 +164,8 @@ function register_omise_creditcard() {
 				$omise_customer_id = $this->is_test() ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
 				if ( ! empty( $omise_customer_id ) ) {
 
-					$customer                  = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
-					$viewData['existingCards'] = $customer->cards();
+					$customer                  = OmiseCustomer::retrieve( $omise_customer_id , '', $this->secret_key() );
+					$viewData['existingCards'] = $customer->cards( array( 'order' => 'reverse_chronological' ) );
 				}
 			} else {
 				$viewData['user_logged_in'] = false;
@@ -209,7 +209,7 @@ function register_omise_creditcard() {
 					if ( ! empty( $omise_customer_id ) ) {
 						try {
 							// attach a new card to customer
-							$customer = OmiseCustomer::retrieve( $this->omise_customer_id, '', $this->secret_key() );
+							$customer = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
 							$customer->update( array(
 								'card' => $token
 							) );

--- a/templates/payment/form-creditcard.php
+++ b/templates/payment/form-creditcard.php
@@ -1,29 +1,30 @@
 <p class="form-row form-row-wide omise-required-field">
-	<label for="omise_card_name"><?php echo _x( 'Name', 'Card holder name at payment form', 'omise' ); ?> <span class="required">*</span></label>
-	<input id="omise_card_name" class="input-text" type="text"
-		maxlength="255" autocomplete="off" placeholder="<?php echo _x( 'Name', 'Placeholder for card holder name', 'omise' ); ?>"
-		name="omise_card_name">
-</p>
-<p class="form-row form-row-wide omise-required-field">
-	<label for="omise_card_number"><?php echo _x( 'Card Number', 'Card number at payment form', 'omise' ); ?> <span class="required">*</span></label>
+	<label for="omise_card_number"><?php echo _x( 'Card number', 'Card number at payment form', 'omise' ); ?></label>
 	<input id="omise_card_number" class="input-text" type="text"
-		maxlength="20" autocomplete="off" placeholder="<?php echo _x( 'Card Number', 'Placeholder for card number', 'omise' ); ?>"
+		maxlength="20" autocomplete="off" placeholder="<?php echo _x( '•••• •••• •••• ••••', 'Placeholder for card number', 'omise' ); ?>"
 		name="omise_card_number">
 </p>
+
+<p class="form-row form-row-wide omise-required-field">
+	<label for="omise_card_name"><?php echo _x( 'Name on card', 'Card holder name at payment form', 'omise' ); ?></label>
+	<input id="omise_card_name" class="input-text" type="text"
+		maxlength="255" autocomplete="off" placeholder="<?php echo _x( 'FULL NAME', 'Placeholder for card holder name', 'omise' ); ?>"
+		name="omise_card_name">
+</p>
 <p class="form-row form-row-first omise-required-field">
-	<label for="omise_card_expiration_month"><?php echo _x( 'Expiration Month', 'Expiration month at payment form', 'omise' ); ?> <span class="required">*</span></label>
+	<label for="omise_card_expiration_month"><?php echo _x( 'Expiration month', 'Expiration month at payment form', 'omise' ); ?></label>
 	<input id="omise_card_expiration_month" class="input-text" type="text"
 		autocomplete="off" placeholder="<?php echo _x( 'MM', 'Placeholder for expiration month', 'omise' ); ?>" name="omise_card_expiration_month">
 </p>
 <p class="form-row form-row-last omise-required-field">
-	<label for="omise_card_expiration_year"><?php echo _x( 'Expiration Year', 'Expiration year at payment form', 'omise' ); ?> <span class="required">*</span></label>
+	<label for="omise_card_expiration_year"><?php echo _x( 'Expiration year', 'Expiration year at payment form', 'omise' ); ?></label>
 	<input id="omise_card_expiration_year" class="input-text" type="text"
 		autocomplete="off" placeholder="<?php echo _x( 'YYYY', 'Placeholder for expiration year', 'omise' ); ?>"
 		name="omise_card_expiration_year">
 </p>
 <p class="form-row form-row-first omise-required-field">
-	<label for="omise_card_security_code"><?php echo _x( 'Security Code', 'Security Code at payment form', 'omise' ); ?> <span class="required">*</span></label>
+	<label for="omise_card_security_code"><?php echo _x( 'Security code', 'Security Code at payment form', 'omise' ); ?></label>
 	<input id="omise_card_security_code"
 		class="input-text" type="password" autocomplete="off"
-		placeholder="<?php echo _x( 'Security Code', 'Placeholder for security Code', 'omise' ); ?>" name="omise_card_security_code">
+		placeholder="<?php echo _x( '•••', 'Placeholder for security Code', 'omise' ); ?>" name="omise_card_security_code">
 </p>

--- a/templates/payment/form.php
+++ b/templates/payment/form.php
@@ -25,7 +25,7 @@
 
 		<fieldset id="new_card_form" class="<?php echo $showExistingCards ? 'card-exists' : ''; ?>">
 
-			<?php require_once('form-creditcard.php'); ?>
+			<?php require_once( 'form-creditcard.php' ); ?>
 
 			<div class="clear"></div>
 

--- a/templates/payment/form.php
+++ b/templates/payment/form.php
@@ -1,28 +1,44 @@
+<?php $showExistingCards = $viewData['user_logged_in'] && isset( $viewData['existingCards']['data'] ) && sizeof( $viewData['existingCards']['data'] ) > 0; ?>
+
 <div id="omise_cc_form">
-	<?php $showExistingCards = $viewData['user_logged_in'] && isset( $viewData['existingCards']['data'] ) && sizeof( $viewData['existingCards']['data'] ) > 0; ?>
-
 	<?php if ( $showExistingCards ) : ?>
-		<p class="form-row form-row-wide">
-			<?php echo __( 'Select card', 'omise' ); ?> : <br/>
-
-				<?php foreach ( $viewData['existingCards']['data'] as $card ) : ?>
-						<?php echo "<input type='radio' name='card_id' value='{$card['id']}' />" . __( 'Card ends with', 'omise' ) . " {$card['last_digits']}<br/>"; ?>
-				<?php endforeach; ?>
-		</p>
-		&nbsp;<input type="radio" id="new_card_info" name="card_id" value="" /><?php echo __( 'New payment information', 'omise' ); ?>
+		<h3><?php echo __( 'Use an existing card', 'omise' ); ?></h3>
+		<ul class="omise-customer-card-list">
+			<?php foreach ( $viewData['existingCards']['data'] as $row => $card ) : ?>
+				<li class="item">
+					<input <?php echo $row === 0 ? 'checked=checked' : ''; ?> id="card-<?php echo $card['id']; ?>" type="radio" name="card_id" value="<?php echo $card['id']; ?>" />
+					<label for="card-<?php echo $card['id']; ?>">
+						<?php echo '<strong>' . $card['brand'] . '</strong> xxxx' . $card['last_digits']; ?>
+					</label>
+				</li>
+			<?php endforeach; ?>
+		</ul>
 	<?php endif; ?>
 
-	<fieldset id="new_card_form" class="<?php echo $showExistingCards ? 'omise-hidden' : ''; ?>">
-
-		<?php require_once('form-creditcard.php'); ?>
-
-		<?php if ( $viewData['user_logged_in'] ) : ?>
-			<p class="form-row form-row-wide">
-				<input type="checkbox" name="omise_save_customer_card" id="omise_save_customer_card" />
-				<label for="omise_save_customer_card" class="inline"><?php echo __( 'Save card for next time', 'omise' ); ?></label>
-			</p>
+	<div>
+		<?php if ( $showExistingCards ) : ?>
+			<input id="new_card_info" type="radio" name="card_id" value="" />
+			<label id="label-new_card_info" for="new_card_info">
+				<h3><?php echo __( 'Create a charge using new card', 'omise' ); ?></h3>
+			</label>
 		<?php endif; ?>
 
-		<div class="clear"></div>
-	</fieldset>
+		<fieldset id="new_card_form" class="<?php echo $showExistingCards ? 'card-exists' : ''; ?>">
+
+			<?php require_once('form-creditcard.php'); ?>
+
+			<div class="clear"></div>
+
+			<?php if ( $viewData['user_logged_in'] ) : ?>
+				<p class="omise-remember-card">
+					<input type="checkbox" name="omise_save_customer_card" id="omise_save_customer_card" />
+					<label for="omise_save_customer_card" class="inline">
+						<?php echo __( 'Remember this card', 'omise' ); ?>
+					</label>
+				</p>
+			<?php endif; ?>
+
+			<div class="clear"></div>
+		</fieldset>
+	</div>
 </div>


### PR DESCRIPTION
#### 1. Objective

WooCommerce html-renderer has been changed in v3.x cause that user cannot use a 'saved-card' to perform a checkout at the checkout page.

**Related information**:
Related issue(s): No

#### 2. Description of change

- Correct HTML structure at the credit card form to proper display saved-card list.

- Also enhance the credit card form UI (basically, makes credit card form UI corresponding to the new  Omise.js UI).

    <img width="1239" alt="screen shot 2560-07-04 at 6 22 22 pm" src="https://user-images.githubusercontent.com/2154669/27828937-0e24806a-60e9-11e7-885b-d58cb6509159.png">

    <img width="1239" alt="screen shot 2560-07-04 at 6 21 15 pm" src="https://user-images.githubusercontent.com/2154669/27828660-7d6c8456-60e7-11e7-86c0-f2f799d16929.png">

    <img width="1239" alt="screen shot 2560-07-04 at 6 21 35 pm" src="https://user-images.githubusercontent.com/2154669/27828662-7e0926c6-60e7-11e7-90d2-724fa6136307.png">
#### 3. Quality assurance

**🔧 Environments:**

- WordPress v4.8
- WooCommerce v3.0.9
- PHP v5.6.30

**✏️ Details:**


✅ **3.1. Test create a charge first time with a new-registered user account without saving card**
_Expectation_ Charge must be created properly.

✅ **3.2. Second time, try create another charge, now, save your card**
_Expectation_ Charge must be created properly and a `customer` object must be created and attach a new card.

✅ **3.3. Now, try use the card that you just saved to charge**
_Expectation_ Charge must be created properly with your new saved-card.

✅ **3.4. Try create another charge. But this time you will choose to 'Create a card using new card' option**
_Expectation_ Charge must be created properly.


#### 4. Impact of the change

- Credit card form UI changed.

- Need to re-translate labels & texts in the credit card form.

#### 5. Priority of change

High

#### 6. Additional Notes

No.