### PR TITLE
Now merchant doesn't need to re-set Omise keys in every new payment methods.

### DIFF
--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -43,99 +43,80 @@ function register_omise_creditcard() {
 		 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
 		 */
 		function init_form_fields() {
-			$this->form_fields = array(
-				'enabled' => array(
-					'title'       => __( 'Enable/Disable', 'omise' ),
-					'type'        => 'checkbox',
-					'label'       => __( 'Enable Omise Payment Module.', 'omise' ),
-					'default'     => 'no'
-				),
-				'sandbox' => array(
-					'title'       => __( 'Sandbox', 'omise' ),
-					'type'        => 'checkbox',
-					'label'       => __( 'Enabling sandbox means that all your transactions will be in TEST mode.', 'omise' ),
-					'default'     => 'yes'
-				),
-				'test_public_key' => array(
-					'title'       => __( 'Public key for test', 'omise' ),
-					'type'        => 'text',
-					'description' => __( 'The "Test" mode public key can be found in Omise Dashboard.', 'omise' )
-				),
-				'test_private_key' => array(
-					'title'       => __( 'Secret key for test', 'omise' ),
-					'type'        => 'password',
-					'description' => __( 'The "Test" mode secret key can be found in Omise Dashboard.', 'omise' )
-				),
-				'live_public_key' => array(
-					'title'       => __( 'Public key for live', 'omise' ),
-					'type'        => 'text',
-					'description' => __( 'The "Live" mode public key can be found in Omise Dashboard.', 'omise' )
-				),
-				'live_private_key' => array(
-					'title'       => __( 'Secret key for live', 'omise' ),
-					'type'        => 'password',
-					'description' => __( 'The "Live" mode secret key can be found in Omise Dashboard.', 'omise' )
-				),
-				'advanced' => array(
-					'title'       => __( 'Advance Settings', 'omise' ),
-					'type'        => 'title',
-					'description' => '',
-				),
-				'accept_visa' => array(
-					'title'       => __( 'Supported card icons', 'omise' ),
-					'type'        => 'checkbox',
-					'label'       => Omise_Card_Image::get_visa_image(),
-					'css'         => Omise_Card_Image::get_css(),
-					'default'     => Omise_Card_Image::get_visa_default_display()
-				),
-				'accept_mastercard' => array(
-					'type'        => 'checkbox',
-					'label'       => Omise_Card_Image::get_mastercard_image(),
-					'css'         => Omise_Card_Image::get_css(),
-					'default'     => Omise_Card_Image::get_mastercard_default_display()
-				),
-				'accept_jcb' => array(
-					'type'        => 'checkbox',
-					'label'       => Omise_Card_Image::get_jcb_image(),
-					'css'         => Omise_Card_Image::get_css(),
-					'default'     => Omise_Card_Image::get_jcb_default_display()
-				),
-				'accept_diners' => array(
-					'type'        => 'checkbox',
-					'label'       => Omise_Card_Image::get_diners_image(),
-					'css'         => Omise_Card_Image::get_css(),
-					'default'     => Omise_Card_Image::get_diners_default_display()
-				),
-				'accept_amex' => array(
-					'type'        => 'checkbox',
-					'label'       => Omise_Card_Image::get_amex_image(),
-					'css'         => Omise_Card_Image::get_css(),
-					'default'     => Omise_Card_Image::get_amex_default_display(),
-					'description' => __( 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.', 'omise' )
-				),
-				'title' => array(
-					'title'       => _x( 'Title', 'Label for setting of checkout form title', 'omise' ),
-					'type'        => 'text',
-					'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
-					'default'     => _x( 'Omise Payment Gateway', 'Default title at checkout form', 'omise' )
-				),
-				'payment_action' => array(
-					'title'       => __( 'Payment action', 'omise' ),
-					'type'        => 'select',
-					'description' => __( 'Manual Capture or Capture Automatically', 'omise' ),
-					'default'     => 'auto_capture',
-					'class'       => 'wc-enhanced-select',
-					'options'     => array(
-						'auto_capture'   => _x( 'Auto Capture', 'Setting auto capture', 'omise' ),
-						'manual_capture' => _x( 'Manual Capture', 'Setting manual capture', 'omise' )
+			$this->form_fields = array_merge(
+				array(
+					'enabled' => array(
+						'title'   => __( 'Enable/Disable', 'omise' ),
+						'type'    => 'checkbox',
+						'label'   => __( 'Enable Omise Internet Banking Payment', 'omise' ),
+						'default' => 'no'
 					),
-					'desc_tip'    => true
+
+					'title' => array(
+						'title'       => __( 'Title', 'omise' ),
+						'type'        => 'text',
+						'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
+						'default'     => __( 'Internet Banking', 'omise' ),
+						'desc_tip'    => true,
+					),
 				),
-				'omise_3ds' => array(
-					'title'       => __( '3-D Secure support', 'omise' ),
-					'type'        => 'checkbox',
-					'label'       => __( 'Enable or disable 3-D Secure for the account. (Japan-based accounts are not eligible for the service.)', 'omise' ),
-					'default'     => 'no'
+				$this->get_default_payment_setting_fields(),
+				array(
+					'advanced' => array(
+						'title'       => __( 'Advance Settings', 'omise' ),
+						'type'        => 'title',
+						'description' => '',
+					),
+					'payment_action' => array(
+						'title'       => __( 'Payment action', 'omise' ),
+						'type'        => 'select',
+						'description' => __( 'Manual Capture or Capture Automatically', 'omise' ),
+						'default'     => 'auto_capture',
+						'class'       => 'wc-enhanced-select',
+						'options'     => array(
+							'auto_capture'   => _x( 'Auto Capture', 'Setting auto capture', 'omise' ),
+							'manual_capture' => _x( 'Manual Capture', 'Setting manual capture', 'omise' )
+						),
+						'desc_tip'    => true
+					),
+					'omise_3ds' => array(
+						'title'       => __( '3-D Secure support', 'omise' ),
+						'type'        => 'checkbox',
+						'label'       => __( 'Enable or disable 3-D Secure for the account. (Japan-based accounts are not eligible for the service.)', 'omise' ),
+						'default'     => 'no'
+					),
+					'accept_visa' => array(
+						'title'       => __( 'Supported card icons', 'omise' ),
+						'type'        => 'checkbox',
+						'label'       => Omise_Card_Image::get_visa_image(),
+						'css'         => Omise_Card_Image::get_css(),
+						'default'     => Omise_Card_Image::get_visa_default_display()
+					),
+					'accept_mastercard' => array(
+						'type'        => 'checkbox',
+						'label'       => Omise_Card_Image::get_mastercard_image(),
+						'css'         => Omise_Card_Image::get_css(),
+						'default'     => Omise_Card_Image::get_mastercard_default_display()
+					),
+					'accept_jcb' => array(
+						'type'        => 'checkbox',
+						'label'       => Omise_Card_Image::get_jcb_image(),
+						'css'         => Omise_Card_Image::get_css(),
+						'default'     => Omise_Card_Image::get_jcb_default_display()
+					),
+					'accept_diners' => array(
+						'type'        => 'checkbox',
+						'label'       => Omise_Card_Image::get_diners_image(),
+						'css'         => Omise_Card_Image::get_css(),
+						'default'     => Omise_Card_Image::get_diners_default_display()
+					),
+					'accept_amex' => array(
+						'type'        => 'checkbox',
+						'label'       => Omise_Card_Image::get_amex_image(),
+						'css'         => Omise_Card_Image::get_css(),
+						'default'     => Omise_Card_Image::get_amex_default_display(),
+						'description' => __( 'This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway.', 'omise' )
+					)
 				)
 			);
 		}

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -36,58 +36,24 @@ function register_omise_internetbanking() {
 		 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
 		 */
 		public function init_form_fields() {
-			$this->form_fields = array(
-				'enabled' => array(
-					'title'   => __( 'Enable/Disable', 'omise' ),
-					'type'    => 'checkbox',
-					'label'   => __( 'Enable Omise Internet Banking Payment', 'omise' ),
-					'default' => 'no'
-				),
+			$this->form_fields = array_merge(
+				array(
+					'enabled' => array(
+						'title'   => __( 'Enable/Disable', 'omise' ),
+						'type'    => 'checkbox',
+						'label'   => __( 'Enable Omise Internet Banking Payment', 'omise' ),
+						'default' => 'no'
+					),
 
-				'title' => array(
-					'title'       => __( 'Title', 'omise' ),
-					'type'        => 'text',
-					'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
-					'default'     => __( 'Internet Banking', 'omise' ),
-					'desc_tip'    => true,
+					'title' => array(
+						'title'       => __( 'Title', 'omise' ),
+						'type'        => 'text',
+						'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
+						'default'     => __( 'Internet Banking', 'omise' ),
+						'desc_tip'    => true,
+					),
 				),
-
-				'payment_setting' => array(
-					'title'       => __( 'Payment Settings', 'omise' ),
-					'type'        => 'title',
-					'description' => '',
-				),
-
-				'sandbox' => array(
-					'title'       => __( 'Sandbox', 'omise' ),
-					'type'        => 'checkbox',
-					'label'       => __( 'Enabling sandbox means that all your transactions will be in TEST mode.', 'omise' ),
-					'default'     => 'yes'
-				),
-
-				'test_public_key' => array(
-					'title'       => __( 'Public key for test', 'omise' ),
-					'type'        => 'text',
-					'description' => __( 'The "Test" mode public key can be found in Omise Dashboard.', 'omise' )
-				),
-
-				'test_private_key' => array(
-					'title'       => __( 'Secret key for test', 'omise' ),
-					'type'        => 'password',
-					'description' => __( 'The "Test" mode secret key can be found in Omise Dashboard.', 'omise' )
-				),
-
-				'live_public_key' => array(
-					'title'       => __( 'Public key for live', 'omise' ),
-					'type'        => 'text',
-					'description' => __( 'The "Live" mode public key can be found in Omise Dashboard.', 'omise' )
-				),
-
-				'live_private_key' => array(
-					'title'       => __( 'Secret key for live', 'omise' ),
-					'type'        => 'password',
-					'description' => __( 'The "Live" mode secret key can be found in Omise Dashboard.', 'omise' )
-				)
+				$this->get_default_payment_setting_fields()
 			);
 		}
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -36,24 +36,21 @@ function register_omise_internetbanking() {
 		 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
 		 */
 		public function init_form_fields() {
-			$this->form_fields = array_merge(
-				array(
-					'enabled' => array(
-						'title'   => __( 'Enable/Disable', 'omise' ),
-						'type'    => 'checkbox',
-						'label'   => __( 'Enable Omise Internet Banking Payment', 'omise' ),
-						'default' => 'no'
-					),
-
-					'title' => array(
-						'title'       => __( 'Title', 'omise' ),
-						'type'        => 'text',
-						'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
-						'default'     => __( 'Internet Banking', 'omise' ),
-						'desc_tip'    => true,
-					),
+			$this->form_fields = array(
+				'enabled' => array(
+					'title'   => __( 'Enable/Disable', 'omise' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable Omise Internet Banking Payment', 'omise' ),
+					'default' => 'no'
 				),
-				$this->get_default_payment_setting_fields()
+
+				'title' => array(
+					'title'       => __( 'Title', 'omise' ),
+					'type'        => 'text',
+					'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
+					'default'     => __( 'Internet Banking', 'omise' ),
+					'desc_tip'    => true,
+				)
 			);
 		}
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -39,6 +39,52 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Returns the array of default payment settings
+	 *
+	 * @return array of default payment settings
+	 */
+	protected function get_default_payment_setting_fields() {
+		return array(
+			'payment_setting' => array(
+				'title'       => __( 'Payment Settings', 'omise' ),
+				'type'        => 'title',
+				'description' => '',
+			),
+
+			'sandbox' => array(
+				'title'       => __( 'Sandbox', 'omise' ),
+				'type'        => 'checkbox',
+				'label'       => __( 'Enabling sandbox means that all your transactions will be in TEST mode.', 'omise' ),
+				'default'     => 'yes'
+			),
+
+			'test_public_key' => array(
+				'title'       => __( 'Public key for test', 'omise' ),
+				'type'        => 'text',
+				'description' => __( 'The "Test" mode public key can be found in Omise Dashboard.', 'omise' )
+			),
+
+			'test_private_key' => array(
+				'title'       => __( 'Secret key for test', 'omise' ),
+				'type'        => 'password',
+				'description' => __( 'The "Test" mode secret key can be found in Omise Dashboard.', 'omise' )
+			),
+
+			'live_public_key' => array(
+				'title'       => __( 'Public key for live', 'omise' ),
+				'type'        => 'text',
+				'description' => __( 'The "Live" mode public key can be found in Omise Dashboard.', 'omise' )
+			),
+
+			'live_private_key' => array(
+				'title'       => __( 'Secret key for live', 'omise' ),
+				'type'        => 'password',
+				'description' => __( 'The "Live" mode secret key can be found in Omise Dashboard.', 'omise' )
+			)
+		);
+	}
+
+	/**
 	 * @param  string|WC_Order $order
 	 *
 	 * @return Omise_Order|null

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -21,6 +21,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	public $id = 'omise';
 
 	/**
+	 * Payment setting values.
+	 *
+	 * @var array
+	 */
+	public $payment_settings = array();
+
+	/**
 	 * @var array
 	 */
 	private $currency_subunits = array(
@@ -36,6 +43,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	protected $order;
 
 	public function __construct() {
+		$this->payment_settings = $this->get_payment_settings( 'omise' );
 	}
 
 	/**
@@ -85,6 +93,30 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Returns the payment gateway settings option name
+	 *
+	 * @param  string $payment_method_id
+	 *
+	 * @return string The payment gateway settings option name.
+	 *
+	 * @since  2.0
+	 */
+	protected function get_payment_method_settings_name( $payment_method_id = 'omise' ) {
+		return 'woocommerce_' . $payment_method_id . '_settings';
+	}
+
+	/**
+	 * @param  string $id
+	 *
+	 * @return array
+	 *
+	 * @since  2.0
+	 */
+	public function get_payment_settings( $id ) {
+		return get_option( $this->get_payment_method_settings_name( $id ) );
+	}
+
+	/**
 	 * @param  string|WC_Order $order
 	 *
 	 * @return Omise_Order|null
@@ -116,7 +148,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return bool
 	 */
 	public function is_test() {
-		$sandbox = $this->get_option( 'sandbox' );
+		$sandbox = $this->payment_settings['sandbox'];
 
 		return isset( $sandbox ) && $sandbox == 'yes';
 	}
@@ -128,10 +160,10 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 */
 	protected function public_key() {
 		if ( $this->is_test() ) {
-			return $this->get_option( 'test_public_key' );
+			return $this->payment_settings['test_public_key'];
 		}
 
-		return $this->get_option( 'live_public_key' );
+		return $this->payment_settings['live_public_key'];
 	}
 
 	/**
@@ -141,10 +173,10 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 */
 	protected function secret_key() {
 		if ( $this->is_test() ) {
-			return $this->get_option( 'test_private_key' );
+			return $this->payment_settings['test_private_key'];
 		}
 
-		return $this->get_option( 'live_private_key' );
+		return $this->payment_settings['live_private_key'];
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

Previously merchant needs to set Omise public and secret keys twice on both Credit Card and Internet Banking configuration pages, which creates a bad user experience (as described in PR #41, section number 6).

**Related information**:
Related issue(s): No

#### 2. Description of change

- Now merchant doesn't need to set any keys on a new payment method. It would automatically use the same keys as from Credit Card configuration page.

#### 3. Quality assurance

**🔧 Environments:**

- WordPress v4.8
- WooCommerce v3.1.0
- PHP v5.6.30

**✏️ Details:**

✅ **3.1. Test create charge with the Internet Banking payment method.**
_**Expectation**_ Buyer must be able to create a new charge right away.

✅ **3.2. Now, try to set a wrong key at Credit Card configuration page and make a new charge with Internet Banking again.**
_**Expectation**_ Charge must be failed because the key in Credit Card configuration page has changed (to prove that right now, Internet Banking payment method use the same key as set in Credit Card payment method).

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No.