### PR TITLE
Be able to manual sync a charge status from Omise to WooCommerce order.

### DIFF
--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -507,7 +507,12 @@ function register_omise_creditcard() {
 		 * @return array
 		 */
 		function add_omise_creditcard_manual_capture_action( $order_actions ) {
-			$order_actions['omise_charge_capture'] = __( "Capture charge (via Omise)" );
+			global $theorder;
+
+			if ( 'omise' === $theorder->get_payment_method() ) {
+				$order_actions['omise_charge_capture'] = __( 'Omise: Capture this order' );
+			}
+
 			return $order_actions;
 		}
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -32,7 +32,8 @@ function register_omise_creditcard() {
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'omise_assets' ) );
-			add_action( 'woocommerce_order_action_omise_charge_capture', array( $this, 'capture' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_charge_capture', array( $this, 'capture' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 
 			/** @deprecated 2.0 */
 			add_action( 'woocommerce_api_wc_gateway_' . $this->id, array( $this, 'callback' ) );
@@ -498,25 +499,6 @@ function register_omise_creditcard() {
 		}
 
 		add_filter( 'woocommerce_payment_gateways', 'add_omise_creditcard' );
-	}
-
-	if ( ! function_exists( 'add_omise_creditcard_manual_capture_action' ) ) {
-		/**
-		 * @param  array $order_actions
-		 *
-		 * @return array
-		 */
-		function add_omise_creditcard_manual_capture_action( $order_actions ) {
-			global $theorder;
-
-			if ( 'omise' === $theorder->get_payment_method() ) {
-				$order_actions['omise_charge_capture'] = __( 'Omise: Capture this order' );
-			}
-
-			return $order_actions;
-		}
-
-		add_filter( 'woocommerce_order_actions', 'add_omise_creditcard_manual_capture_action' );
 	}
 }
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -29,6 +29,7 @@ function register_omise_internetbanking() {
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'omise_assets' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 		}
 
 		/**
@@ -142,7 +143,7 @@ function register_omise_internetbanking() {
 
 				if ( 'pending' === $charge['status'] && ! $charge['captured'] ) {
 					$order->add_order_note( __( 'Omise: the charge has been pending due to the Bank process. Please check the payment status at Omise dashboard again later', 'omise' ) );
-					$order->update_status( 'processing' );
+					$order->update_status( 'on-hold' );
 
 					WC()->cart->empty_cart();
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -74,7 +74,8 @@ class Omise {
 		if ( is_admin() ) {
 			require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-admin.php';
 
-		    add_action( 'plugins_loaded', array( Omise_Admin::get_instance(), 'register_admin_page_and_actions' ) );
+			add_action( 'plugins_loaded', array( Omise_Admin::get_instance(), 'register_admin_page_and_actions' ) );
+			add_filter( 'woocommerce_order_actions', array( $this, 'register_order_actions' ) );
 		}
 	}
 
@@ -86,6 +87,23 @@ class Omise {
 
 		$user_agent = sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, WC()->version );
 		defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', $user_agent );
+	}
+
+	/**
+	 * @param  array $order_actions
+	 *
+	 * @return array
+	 */
+	public function register_order_actions( $order_actions ) {
+		global $theorder;
+
+		if ( 'omise' === $theorder->get_payment_method() ) {
+			$order_actions[ $theorder->get_payment_method() . '_charge_capture'] = __( 'Omise: Capture this order' );
+		}
+
+		$order_actions[ $theorder->get_payment_method() . '_sync_payment']   = __( 'Omise: Sync payment status' );
+
+		return $order_actions;
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

Because we can't just only rely on Bank(s)'s response at the time that charge has been made (especially on Internet Banking payment method).
They won't always always return a charge result ('successful', 'failed') status right away after you make a request. Sometimes they take few mins ~ few hours to process a payment before returning a charge result.

Means, if this thing occurs, WooCommerce store has no way to know this result unless we integrate with **[Omise Webhook](https://www.omise.co/api-webhooks)** feature or 'Manual Sync'.

**Related information**:
Related issue(s): No

#### 2. Description of change

- Now WooCommerce order status will be set to 'on-hold' status for all Internet Banking charges that've been returned as `pending` status.

- Merchant now be able to perform `manual sync` their order status after it has been created at Order Detail page.
    <img width="1368" alt="screen shot 2560-07-11 at 5 03 27 pm" src="https://user-images.githubusercontent.com/2154669/28063302-e886d0ac-665a-11e7-952e-3d82aca488c4.png">

- Hide 'manual capture' action if payment method is the internet banking.

#### 3. Quality assurance

**🔧 Environments:**

- WordPress v4.8
- WooCommerce v3.1.0
- PHP v5.6.30

**✏️ Details:**

✅ **3.1. Test make charge with internet banking payment method. At the Omise Internet Banking test page, just leave it like that. Don't mark as success nor fail. Then perform 'manual sync' at the order detail page.**
__**Expectation:**__ You will get a note tells that currently payment is in progress.

![screen shot 2560-07-11 at 5 06 16 pm](https://user-images.githubusercontent.com/2154669/28063608-d620c0f2-665b-11e7-9969-794f0ed7e7da.png)

✅ **3.2. Now make it as failed, then perform 'manual sync' again**
__**Expectation:**__ Your order status will be changed to `failed` with some note on an order note panel.

![screen shot 2560-07-11 at 5 08 11 pm](https://user-images.githubusercontent.com/2154669/28063670-1df5fb90-665c-11e7-858d-75a9185b4d78.png)

✅ **3.3. Make another charge, now make it as success and perform 'manual sync'**
__**Expectation:**__ Your order status will be changed to `processing` with some note on an order note panel tell you that your charge has been captured (paid).

![screen shot 2560-07-11 at 5 16 28 pm](https://user-images.githubusercontent.com/2154669/28063837-b3ef5362-665c-11e7-9335-f355b187385b.png)

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No.