### PR TITLE
Support Alipay payment

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -1,0 +1,185 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+function register_omise_alipay() {
+	require_once dirname( __FILE__ ) . '/class-omise-payment.php';
+
+	if ( ! class_exists( 'WC_Payment_Gateway' ) ) {
+		return;
+	}
+
+	if ( class_exists( 'Omise_Payment_Alipay' ) ) {
+		return;
+	}
+
+	class Omise_Payment_Alipay extends Omise_Payment {
+		public function __construct() {
+			parent::__construct();
+
+			$this->id                 = 'omise_alipay';
+			$this->has_fields         = false;
+			$this->method_title       = 'Omise Alipay';
+			$this->method_description = 'Accept payment through Alipay';
+
+			$this->init_form_fields();
+			$this->init_settings();
+
+			$this->title = $this->get_option( 'title' );
+
+			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
+			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
+		}
+
+		/**
+		 * @see WC_Settings_API::init_form_fields()
+		 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled' => array(
+					'title'   => __( 'Enable/Disable', 'omise' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable Omise Alipay Payment', 'omise' ),
+					'default' => 'no'
+				),
+
+				'title' => array(
+					'title'       => __( 'Title', 'omise' ),
+					'type'        => 'text',
+					'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
+					'default'     => __( 'Alipay', 'omise' ),
+					'desc_tip'    => true,
+				)
+			);
+		}
+
+		/**
+		 * @param  int $order_id
+		 *
+		 * @see    WC_Payment_Gateway::process_payment( $order_id )
+		 * @see    woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+		 *
+		 * @return array
+		 */
+		public function process_payment( $order_id ) {
+			if ( ! $order = $this->load_order( $order_id ) ) {
+				wc_add_notice( __( 'Order not found: ', 'omise' ) . sprintf( 'cannot find order id %s.', $order_id ), 'error' );
+				return;
+			}
+
+			$order->add_order_note( __( 'Omise: Processing a payment with the Alipay..', 'omise' ) );
+
+			try {
+				$charge = $this->sale( array(
+					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+					'currency'    => $order->get_order_currency(),
+					'description' => 'WooCommerce Order id ' . $order_id,
+					'offsite'     => 'alipay',
+					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" )
+				) );
+
+				$order->add_order_note( sprintf( __( 'Omise: Charge (id: %s) has been created', 'omise' ), $charge['id'] ) );
+
+				switch ( $charge['status'] ) {
+					case 'pending':
+						$this->attach_charge_id_to_order( $charge['id'] );
+
+						$order->set_transaction_id( $charge['id'] );
+						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), $charge['authorize_uri'] ) );
+						$order->save();
+
+						return array (
+							'result'   => 'success',
+							'redirect' => $charge['authorize_uri'],
+						);
+						break;
+
+					case 'failed':
+						throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+						break;
+
+					default:
+						throw new Exception( __( 'Seems that we cannot process your payment properly. Please try place an order again or contact our support team if you have any questions.', 'omise' ) );
+						break;
+				}
+			} catch ( Exception $e ) {
+				wc_add_notice( __( 'Payment failed: ', 'omise' ) . $e->getMessage(), 'error' );
+
+				$order->add_order_note( __( 'Omise: payment failed, ', 'omise' ) . $e->getMessage() );
+
+				return;
+			}
+		}
+
+		/**
+		 * @return void
+		 */
+		public function callback() {
+			if ( ! isset( $_GET['order_id'] ) || ! $order = $this->load_order( $_GET['order_id'] ) ) {
+				wc_add_notice( __( 'Order not found: ', 'omise' ) . __( 'Your payment might already has been completed, please contact our support team if you have any questions.', 'omise' ), 'error' );
+
+				header( 'Location: ' . WC()->cart->get_checkout_url() );
+				die();
+			}
+
+			$order->add_order_note( __( 'Omise: validating a payment result..', 'omise' ) );
+
+			try {
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+
+				if ( 'failed' === $charge['status'] ) {
+					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+				}
+
+				if ( 'pending' === $charge['status'] && ! $charge['captured'] ) {
+					$order->add_order_note( __( 'Omise: the charge has been pending due to the Alipay process. Please check the payment status at Omise dashboard again later', 'omise' ) );
+					$order->update_status( 'on-hold' );
+
+					WC()->cart->empty_cart();
+
+					header( 'Location: ' . $order->get_checkout_order_received_url() );
+					die();
+				}
+
+				if ( 'successful' === $charge['status'] && $charge['captured'] ) {
+					$order->add_order_note( sprintf( __( 'Omise: captured an amount %s', 'omise' ), $order->get_total() ) );
+					$order->payment_complete();
+
+					WC()->cart->empty_cart();
+
+					header( 'Location: ' . $order->get_checkout_order_received_url() );
+					die();
+				}
+
+				throw new Exception( __( 'Seems that we cannot process your payment properly. Anyway, your payment might already has been completed, please contact our support team if you have any questions.', 'omise' ) );
+			} catch ( Exception $e ) {
+				wc_add_notice( __( 'Payment failed: ', 'omise' ) . $e->getMessage(), 'error' );
+
+				$order->add_order_note( __( 'Omise: payment failed, ', 'omise' ) . $e->getMessage() );
+
+				$order->update_status( 'failed' );
+
+				header( 'Location: ' . WC()->cart->get_checkout_url() );
+				die();
+			}
+
+			wp_die( 'Access denied', 'Access Denied', array( 'response' => 401 ) );
+			die();
+		}
+	}
+
+	if ( ! function_exists( 'add_omise_alipay' ) ) {
+		/**
+		 * @param  array $methods
+		 *
+		 * @return array
+		 */
+		function add_omise_alipay( $methods ) {
+			$methods[] = 'Omise_Payment_Alipay';
+			return $methods;
+		}
+
+		add_filter( 'woocommerce_payment_gateways', 'add_omise_alipay' );
+	}
+}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -50,6 +50,7 @@ class Omise {
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-charge.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-card-image.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-alipay.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-creditcard.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-internetbanking.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-php/lib/Omise.php';
@@ -59,6 +60,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';
 
 		add_action( 'init', 'register_omise_wc_gateway_post_type' );
+		add_action( 'plugins_loaded', 'register_omise_alipay', 0 );
 		add_action( 'plugins_loaded', 'register_omise_creditcard', 0 );
 		add_action( 'plugins_loaded', 'register_omise_internetbanking', 0 );
 		add_action( 'plugins_loaded', 'prepare_omise_myaccount_panel', 0 );


### PR DESCRIPTION
### 1. Objective

To add support [Alipay payment](https://www.omise.co/alipay).

### 2. Description of change

2.1. New payment method code `omise_alipay`.
2.2. New callback url `?wc-api=omise_alipay_callback&order_id=xx`
2.3. New setting tab at admin, WooCommerce Checkout page.
2.4. New payment method at the checkout page (Alipay).

#### 3. Quality assurance

- **Platform version**: WooCommerce v3.1.1
- **PHP version**: 5.6.30

**✏️ Details:**

**3.1. Once you install the plugin and enable it. You must see this setting in the WooCommerce > Setting > Checkout page.**

![screen shot 2560-07-12 at 3 07 26 am](https://user-images.githubusercontent.com/2154669/28088250-4da32b8a-66af-11e7-96e9-6bd39be7e075.png)

**3.2. After you enable the payment method. Now the Alipay payment method will be appeared in the checkout page.**

<img width="1329" alt="screen shot 2560-07-12 at 3 08 26 am" src="https://user-images.githubusercontent.com/2154669/28088285-69a62ab2-66af-11e7-9dd8-2306568ca8d8.png">

**3.3. Test checkout with internet banking payment method and mark a payment as `failure`**

<img width="1329" alt="screen shot 2560-07-12 at 3 09 44 am" src="https://user-images.githubusercontent.com/2154669/28088403-be58b9c6-66af-11e7-8bbb-21131b668e13.png">

You will be redirected back to the checkout page with an error message on a screen

<img width="1329" alt="screen shot 2560-07-12 at 3 09 53 am" src="https://user-images.githubusercontent.com/2154669/28088409-c82c4e40-66af-11e7-9cf1-90e972042091.png">

Your order will be marked as `failed` with a proper order's note on a screen.

![screen shot 2560-07-12 at 3 10 46 am](https://user-images.githubusercontent.com/2154669/28088484-02fe1d8c-66b0-11e7-9081-48fddf0e13c7.png)

_Omise Dashboard, charge detail page._

![screen shot 2560-07-12 at 3 12 17 am](https://user-images.githubusercontent.com/2154669/28088463-f36ec484-66af-11e7-9d3f-4ddff5715abf.png)

**3.4. Test checkout with Alipay payment method and mark a payment as `success`.**

<img width="1329" alt="screen shot 2560-07-12 at 3 19 04 am" src="https://user-images.githubusercontent.com/2154669/28088793-0e151b98-66b1-11e7-97b8-01d8312c0a8e.png">

You will be redirected back to the `order-received` page.

<img width="1329" alt="screen shot 2560-07-12 at 3 19 16 am" src="https://user-images.githubusercontent.com/2154669/28088805-17a19222-66b1-11e7-8d9f-559be90e817e.png">

Your order will be marked as `processing` with a proper order's note on a screen.

![screen shot 2560-07-12 at 3 19 32 am](https://user-images.githubusercontent.com/2154669/28088890-5d5fc4be-66b1-11e7-821a-75af9a776211.png)

_Omise Dashboard, charge detail page._

![screen shot 2560-07-12 at 3 19 50 am](https://user-images.githubusercontent.com/2154669/28088873-5130c152-66b1-11e7-9573-801d06071eec.png)

#### 4. Impact of the change

No.

#### 5. Priority of change

Normal

#### 6. Additional Notes

- Alipay is only available for merchants with a Thai-registered Omise account. We’ll be adding support for other countries soon. 

- For users with a live account, please send an email to support@omise.co You’ll need to review Terms & Conditions before testing the API.