### PR TITLE
Backward compatible with Omsie-WooCommerce v1.2.3.

### DIFF
--- a/includes/class-omise-wc-myaccount.php
+++ b/includes/class-omise-wc-myaccount.php
@@ -59,11 +59,15 @@ if ( ! class_exists( 'Omise_MyAccount' ) ) {
 		 */
 		public function init_panel() {
 			if ( ! empty( $this->omise_customer_id ) ) {
-				$customer                  = OmiseCustomer::retrieve( $this->omise_customer_id, '', $this->private_key );
-				$viewData['existingCards'] = $customer->cards();
+				try {
+					$customer                  = OmiseCustomer::retrieve( $this->omise_customer_id, '', $this->private_key );
+					$viewData['existingCards'] = $customer->cards();
 
-				Omise_Util::render_view( 'templates/myaccount/my-card.php', $viewData );
-				$this->register_omise_my_account_scripts();
+					Omise_Util::render_view( 'templates/myaccount/my-card.php', $viewData );
+					$this->register_omise_my_account_scripts();
+				} catch (Exception $e) {
+					// nothing.
+				}
 			}
 		}
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -152,9 +152,12 @@ function register_omise_creditcard() {
 				$current_user      = wp_get_current_user();
 				$omise_customer_id = $this->is_test() ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
 				if ( ! empty( $omise_customer_id ) ) {
-
-					$customer                  = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
-					$viewData['existingCards'] = $customer->cards( array( 'order' => 'reverse_chronological' ) );
+					try {
+						$customer                  = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
+						$viewData['existingCards'] = $customer->cards( array( 'order' => 'reverse_chronological' ) );
+					} catch (Exception $e) {
+						// nothing
+					}
 				}
 			} else {
 				$viewData['user_logged_in'] = false;

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -312,6 +312,11 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		try {
 			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
 
+			if ( empty( $this->order()->get_transaction_id() ) ) {
+				$this->order()->set_transaction_id( $charge['id'] );
+				$this->order()->save();
+			}
+
 			if ( 'failed' === $charge['status'] ) {
 				$this->order()->add_order_note(
 					sprintf(


### PR DESCRIPTION
### 1. Objective

There are some parts that we need to make a backward compatible to the version `1.2.3`

### 2. Description of change

**1.  Retrieve a charge id from a custom post if can't find any attached charge id in an order object.**
Previously, we store a charge id in a Omise custom post type but now, we attach a charge id into a custom field of an order object instead.

However, there is a chance that merchant still need to retrieve a charge id from an old order structure. So, if plugin cannot retrieve a charge id from an order object, it will also try to retrieve from the Omise custom post before consider a result as empty.

**2. Add an order transaction id if cannot find one.**
In WooCommerce we can set a 'transaction id' of each of order objects but we didn't set it.

So basically, this one will just set a 'charge id' as a WooCommerce transaction id if it hasn't been set when perform a manual sync action.

**3. Prevent a 'customer not found' error when using different Omise account in the same store.**
Because we attached a `customer id` into WordPress's user table. So an error 'customer not found' will be raised at the checkout page if we use different Omise account.

#### 3. Quality assurance

- **Platform version**: WooCommerce v3.1.1
- **PHP version**: 5.6.30

**✏️ Details:**

**1. Try manual capture on an order that has been processed with Omise-WooCommerce v1.2.3.**  
This action must be successful as usual.

**2. Test manual sync a charge transaction with WooCommerce order transaction that has been processed with Omise-WooCommerce v1.2.3**
Omise will attach a charge id back to order object as a transaction id. 

#### 4. Impact of the change

No.

#### 5. Priority of change

Normal

#### 6. Additional Notes

No
