### PR TITLE
✨ Here we are, Omise-WooCommerce v3.0 ✨

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
                     potHeaders: {
                         poedit: false,                  // Includes common Poedit headers.
                         'x-poedit-keywordslist': true,  // Include a list of all possible gettext functions.
-                        'Project-Id-Version': 'Omise Payment Gateway v2.0.0',
+                        'Project-Id-Version': 'Omise Payment Gateway v3.0',
                         'Report-Msgid-Bugs-To': 'https://github.com/omise/omise-woocommerce/issues'
                     },                                  // Headers to add to the generated POT file.
                     processPot: null,                   // A callback function for manipulating the POT file.

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -41,7 +41,7 @@ function register_omise_creditcard() {
 			add_action( 'woocommerce_order_action_' . $this->id . '_charge_capture', array( $this, 'capture' ) );
 			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 
-			/** @deprecated 2.0 */
+			/** @deprecated 3.0 */
 			add_action( 'woocommerce_api_wc_gateway_' . $this->id, array( $this, 'callback' ) );
 		}
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -105,7 +105,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 *
 	 * @return string The payment gateway settings option name.
 	 *
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	protected function get_payment_method_settings_name( $payment_method_id = 'omise' ) {
 		return 'woocommerce_' . $payment_method_id . '_settings';
@@ -116,7 +116,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 *
 	 * @return array
 	 *
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public function get_payment_settings( $id ) {
 		return get_option( $this->get_payment_method_settings_name( $id ) );
@@ -380,7 +380,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	/**
 	 * Retrieve a charge id from a post.
 	 *
-	 * @deprecated 2.0  No longer assign a new charge id with new post.
+	 * @deprecated 3.0  No longer assign a new charge id with new post.
 	 *
 	 * @return     string
 	 */

--- a/languages/omise-ja.po
+++ b/languages/omise-ja.po
@@ -1,7 +1,7 @@
 # This file is distributed under the same license as the Omise package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Omise Payment Gateway v2.0.0\n"
+"Project-Id-Version: Omise Payment Gateway v3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/omise/omise-woocommerce/issues\n"
 "POT-Creation-Date: 2017-07-14 20:17+0700\n"
 "MIME-Version: 1.0\n"

--- a/languages/omise.pot
+++ b/languages/omise.pot
@@ -1,7 +1,7 @@
 # This file is distributed under the same license as the Omise package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Omise Payment Gateway v2.0.0\n"
+"Project-Id-Version: Omise Payment Gateway v3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/omise/omise-woocommerce/issues\n"
 "POT-Creation-Date: 2017-07-14 13:16:47+00:00\n"
 "MIME-Version: 1.0\n"

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI: https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version: 1.2.3
+ * Version: 3.0
  * Author: Omise
  * Author URI: https://www.omise.co
  * Text Domain: omise
@@ -20,19 +20,19 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '2.0.0-dev';
+	public $version = '3.0';
 
 	/**
 	 * The Omise Instance.
 	 *
-	 * @since 2.0
+	 * @since 3.0
 	 *
 	 * @var   \Omise
 	 */
 	protected static $the_instance = null;
 
 	/**
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public function __construct() {
 		$this->initiate();
@@ -41,7 +41,7 @@ class Omise {
 	}
 
 	/**
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	protected function initiate() {
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION', $this->version );
@@ -71,7 +71,7 @@ class Omise {
 	}
 
 	/**
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	protected function init_admin() {
 		if ( is_admin() ) {
@@ -83,14 +83,14 @@ class Omise {
 	}
 
 	/**
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain( 'omise', false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
 	}
 
 	/**
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public function register_user_agent() {
 		global $wp_version;
@@ -121,7 +121,7 @@ class Omise {
 	 *
 	 * @see    Omise()
 	 *
-	 * @since  2.0
+	 * @since  3.0
 	 *
 	 * @static
 	 *

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omise",
   "title": "Omise Payment Gateway",
-  "version": "2.0.0-dev",
+  "version": "3.0",
   "homepage": "https://www.omise.co/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin
 Requires at least: 4.3.1
 Tested up to: 4.8
-Stable tag: 3.0.0
+Stable tag: 3.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -33,7 +33,7 @@ From there:
 
 == Changelog ==
 
-= 3.0.0 =
+= 3.0 =
 
 #### ✨ Highlights
 
@@ -93,6 +93,10 @@ Added Omise-Version into the cURL request header.
 Adds support for 3-D Secure feature
 
 == Upgrade Notice ==
+
+= 3.0 =
+For anyone who did customize on the core plugin code, please carefully check on our README log at https://github.com/omise/omise-woocommerce/releases/tag/v3.0 and backup your website before update to this version (note, this release doesn't touch any database, just code structure changed).
+
 = 1.2.3 =
 (Added) Add a new feature, localization
 (Added) Add a translation file for Japanese


### PR DESCRIPTION
**O**MG _(not Omise Go)_, was the first thing came to my mind after finished up everything and making a release note.. 
 
Don't get it? Then look at the following PRs that would be released in this **v3.0** 😳

**This release contains 17 PRs as below.**

- PR #50 : Backward compatible with Omsie-WooCommerce v1.2.3.
- PR #49 : Humanize messages that will be displayed on a user's screen.
- PR #48 : Support Alipay payment.
- PR #47 : Be able to manual sync a charge status from Omise to WooCommerce order.
- PR #46 : Now merchant doesn't need to re-set Omise keys in every new payment methods.
- PR #45 : Fix that user cannot use saved-card at the checkout page. Also, better credit card form UI.
- PR #44 : Remove dashboard support.
- PR #43 : Upgrade Omise-PHP lib to v2.8.0 (latest one at the time).
- PR #42 : Support refund feature. (credit card only).
- PR #41 : Support Internet Banking payment method.
- PR #40 : Huge refactoring plugin file structures and templates.
- PR #39 : Refactoring core plugin file, having Omise class to handle initiate the plugin.
- PR #38 : Fully use Omise-PHP in the plugin, remove legacy API connector.
- PR #37 : Introduce a new plugin template structure.
- PR #36 : Give a proper deigned-structure for payment methods.
- PR #34 : Support WordPress Plugin Translation system.
- PR #32 : Change text domain as same as plugin directory name.

Sounds interesting!?
And don't forget to check our full-detail [v3.0 release note](https://github.com/omise/omise-woocommerce/releases/tag/v3.0).
Also, feel free to create a [ticket](https://github.com/omise/omise-woocommerce/issues) or leave your comment below if you have any questions.


Until then, see you next release.
Cheers! 🍻 🖖