### PR TITLE
Support WooCommerce 2.x series & PHP 5.4

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -102,9 +102,15 @@ function register_omise_alipay() {
 					case 'pending':
 						$this->attach_charge_id_to_order( $charge['id'] );
 
-						$order->set_transaction_id( $charge['id'] );
 						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
-						$order->save();
+
+						/** backward compatible with WooCommerce v2.x series **/
+						if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
+							$order->set_transaction_id( $charge['id'] );
+							$order->save();
+						} else {
+							update_post_meta( $order->id, '_transaction_id', $charge['id'] );
+						}
 
 						return array (
 							'result'   => 'success',

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -118,9 +118,15 @@ function register_omise_internetbanking() {
 					case 'pending':
 						$this->attach_charge_id_to_order( $charge['id'] );
 
-						$order->set_transaction_id( $charge['id'] );
 						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
-						$order->save();
+
+						/** backward compatible with WooCommerce v2.x series **/
+						if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
+							$order->set_transaction_id( $charge['id'] );
+							$order->save();
+						} else {
+							update_post_meta( $order->id, '_transaction_id', $charge['id'] );
+						}
 
 						return array (
 							'result'   => 'success',

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -312,7 +312,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		try {
 			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
 
-			if ( empty( $this->order()->get_transaction_id() ) ) {
+			if ( ! $this->order()->get_transaction_id() ) {
 				$this->order()->set_transaction_id( $charge['id'] );
 				$this->order()->save();
 			}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -107,11 +107,14 @@ class Omise {
 	public function register_order_actions( $order_actions ) {
 		global $theorder;
 
-		if ( 'omise' === $theorder->get_payment_method() ) {
-			$order_actions[ $theorder->get_payment_method() . '_charge_capture'] = __( 'Omise: Capture this order', 'omise' );
+		/** backward compatible with WooCommerce v2.x series **/
+		$payment_method = version_compare( WC()->version, '3.0.0', '>=' ) ? $theorder->get_payment_method() : $theorder->payment_method;
+
+		if ( 'omise' === $payment_method ) {
+			$order_actions[ $payment_method . '_charge_capture'] = __( 'Omise: Capture this order', 'omise' );
 		}
 
-		$order_actions[ $theorder->get_payment_method() . '_sync_payment'] = __( 'Omise: Manual sync payment status', 'omise' );
+		$order_actions[ $payment_method . '_sync_payment'] = __( 'Omise: Manual sync payment status', 'omise' );
 
 		return $order_actions;
 	}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI: https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version: 3.0
+ * Version: 3.1-dev
  * Author: Omise
  * Author URI: https://www.omise.co
  * Text Domain: omise
@@ -20,7 +20,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '3.0';
+	public $version = '3.1-dev';
 
 	/**
 	 * The Omise Instance.


### PR DESCRIPTION
#### 1. Objective

There are bunch of internal support tickets asking for make Omise-WooCommerce support for WooCommerce v2.x series (and also asking to solve an issue after upgrade plugin on WooCommerce v2.x) 

#### 2. Description of change

- So I went to check and found that there are some methods that has been introduced only in WooCommerce v3.x series. But not that much to impact code structure, so I decided to add some condition to check if user is still using WooCommerce legacy version.

- Also, update PHP syntax to support PHP v5.4.x

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: `v4.8.1`.
- **WooCommerce**:  `v3.1.1`.
- **PHP**: `v5.4.45` / `v5.6.30`


**✏️ Details:**

1) Make sure that you can create a new charge on both WooCommerce v2.x and v3.x with Credit Card / Alipay / Internet Banking payment methods

2) Make sure that you can perform `manual sync` action at order detail page.

3) Make sure that you can attach a `charge id` into an order object.

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

- PHP 5.4.x was in [End of Life](http://php.net/eol.php) state since almost 2 years. We strongly suggest that merchants should upgrade their server to at least PHP v5.6 or above.