### PR TITLE
Add Omise Setting page (separate between general settings and payment method settings)

### DIFF
--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -7,11 +7,39 @@ if ( class_exists( 'Omise_Page_Settings' ) ) {
 }
 
 class Omise_Page_Settings {
+	/**
+	 * @var Omise_Setting
+	 */
 	protected $settings;
 
+	/**
+	 * @since 3.1
+	 */
 	public function __construct() {
 		$this->settings = new Omise_Setting;
 	}
+
+	/**
+	 * @return array
+	 *
+	 * @since  3.1
+	 */
+	protected function get_settings() {
+		return $this->settings->get_settings();
+	}
+
+	/**
+	 * @param array $data
+	 *
+	 * @since  3.1
+	 */
+	protected function save( $data ) {
+		$this->settings->update_settings( $data );
+	}
+
+	/**
+	 * @since  3.1
+	 */
 	public static function render() {
 		global $title;
 
@@ -22,17 +50,8 @@ class Omise_Page_Settings {
 			$page->save( $_POST );
 		}
 
-		$settings = array();
-		$settings['payment'] = $page->get_settings();
+		$settings = $page->get_settings();
 
 		include_once __DIR__ . '/views/omise-page-settings.php';
-	}
-
-	protected function get_settings() {
-		return $this->settings->get_settings();
-	}
-
-	protected function save( $data ) {
-		$this->settings->update_settings( $data );		
 	}
 }

--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -1,0 +1,38 @@
+<?php
+
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Page_Settings' ) ) {
+	return;
+}
+
+class Omise_Page_Settings {
+	protected $settings;
+
+	public function __construct() {
+		$this->settings = new Omise_Setting;
+	}
+	public static function render() {
+		global $title;
+
+		$page = new self;
+
+		// Save settings if data has been posted
+		if ( ! empty( $_POST ) ) {
+			$page->save( $_POST );
+		}
+
+		$settings = array();
+		$settings['payment'] = $page->get_settings();
+
+		include_once __DIR__ . '/views/omise-page-settings.php';
+	}
+
+	protected function get_settings() {
+		return $this->settings->get_settings();
+	}
+
+	protected function save( $data ) {
+		$this->settings->update_settings( $data );		
+	}
+}

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -20,45 +20,45 @@
 		<table class="form-table">
 			<tbody>
 				<tr>
-					<th scope="row"><label for="sandbox"><?php echo __( 'Test mode', 'omise' ); ?></label></th>
+					<th scope="row"><label for="sandbox"><?php _e( 'Test mode', 'omise' ); ?></label></th>
 					<td>
 						<fieldset>
 							<label for="sandbox">
-								<input name="sandbox" type="checkbox" id="sandbox" value="1" <?php echo 'yes' === $settings['payment']['sandbox'] ? 'checked="checked"' : ''; ?>>
-								<?php echo __( 'Enabling test mode means that all your transactions will be performed under the Omise test account.', 'omise' ); ?>
+								<input name="sandbox" type="checkbox" id="sandbox" value="1" <?php echo 'yes' === $settings['sandbox'] ? 'checked="checked"' : ''; ?>>
+								<?php _e( 'Enabling test mode means that all your transactions will be performed under the Omise test account.', 'omise' ); ?>
 							</label>
 						</fieldset>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="test_public_key"><?php echo __( 'Public key for test', 'omise' ); ?></label></th>
+					<th scope="row"><label for="test_public_key"><?php _e( 'Public key for test', 'omise' ); ?></label></th>
 					<td>
 						<fieldset>
-							<input name="test_public_key" type="text" id="test_public_key" value="<?php echo $settings['payment']['test_public_key']; ?>" class="regular-text" />
+							<input name="test_public_key" type="text" id="test_public_key" value="<?php echo $settings['test_public_key']; ?>" class="regular-text" />
 						</fieldset>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="test_private_key"><?php echo __( 'Secret key for test', 'omise' ); ?></label></th>
+					<th scope="row"><label for="test_private_key"><?php _e( 'Secret key for test', 'omise' ); ?></label></th>
 					<td>
 						<fieldset>
-							<input name="test_private_key" type="text" id="test_private_key" value="<?php echo $settings['payment']['test_private_key']; ?>" class="regular-text" />
+							<input name="test_private_key" type="text" id="test_private_key" value="<?php echo $settings['test_private_key']; ?>" class="regular-text" />
 						</fieldset>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="live_public_key"><?php echo __( 'Public key for live', 'omise' ); ?></label></th>
+					<th scope="row"><label for="live_public_key"><?php _e( 'Public key for live', 'omise' ); ?></label></th>
 					<td>
 						<fieldset>
-							<input name="live_public_key" type="text" id="live_public_key" value="<?php echo $settings['payment']['live_public_key']; ?>" class="regular-text" />
+							<input name="live_public_key" type="text" id="live_public_key" value="<?php echo $settings['live_public_key']; ?>" class="regular-text" />
 						</fieldset>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="live_private_key"><?php echo __( 'Secret key for live', 'omise' ); ?></label></th>
+					<th scope="row"><label for="live_private_key"><?php _e( 'Secret key for live', 'omise' ); ?></label></th>
 					<td>
 						<fieldset>
-							<input name="live_private_key" type="password" id="live_private_key" value="<?php echo $settings['payment']['live_private_key']; ?>" class="regular-text" />
+							<input name="live_private_key" type="password" id="live_private_key" value="<?php echo $settings['live_private_key']; ?>" class="regular-text" />
 						</fieldset>
 					</td>
 				</tr>
@@ -70,7 +70,7 @@
 		<table class="form-table">
 			<tbody>
 				<tr>
-					<th scope="row"><label for="sandbox"><?php echo __( 'Available Payment Methods', 'omise' ); ?></label></th>
+					<th scope="row"><label for="sandbox"><?php _e( 'Available Payment Methods', 'omise' ); ?></label></th>
 					<td>
 						<table class="widefat fixed striped" cellspacing="0">
 							<thead>
@@ -112,7 +112,7 @@
 									foreach ( $columns as $key => $column ) :
 										switch ( $key ) {
 											case 'name' :
-												$method_title = $gateway->get_title() ? $gateway->get_title() : __( '(no title)', 'woocommerce' );
+												$method_title = $gateway->get_title() ? $gateway->get_title() : __( '(no title)', 'omise' );
 												echo '<td class="name">
 													<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . esc_html( $method_title ) . '</a>
 												</td>';
@@ -120,7 +120,7 @@
 
 											case 'status' :
 												echo '<td class="status" style="text-align: center;">';
-												echo ( 'yes' === $gateway->enabled ) ? '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Yes', 'woocommerce' ) . '">' . esc_html__( 'Yes', 'woocommerce' ) . '</span>' : '-';
+												echo ( 'yes' === $gateway->enabled ) ? '<span>' . __( 'Yes', 'omise' ) . '</span>' : '-';
 												echo '</td>';
 												break;
 

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -65,6 +65,85 @@
 			</tbody>
 		</table>
 
+		<h3><?php _e( 'Payment Methods', 'omise' ); ?></h3>
+		<p><?php _e( 'The table below is a list of available payment methods that you can enable in your WooCommerce store.', 'omise' ); ?></p>
+		<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row"><label for="sandbox"><?php echo __( 'Available Payment Methods', 'omise' ); ?></label></th>
+					<td>
+						<table class="widefat fixed striped" cellspacing="0">
+							<thead>
+								<tr>
+									<?php
+										$columns = array(
+											'name'    => __( 'Payment Method', 'omise' ),
+											'status'  => __( 'Enabled', 'omise' ),
+											'setting' => ''
+										);
+
+										foreach ( $columns as $key => $column ) {
+											switch ( $key ) {
+												case 'status' :
+												case 'setting' :
+													echo '<th style="text-align: center; padding: 10px;" class="' . esc_attr( $key ) . '">' . esc_html( $column ) . '</th>';
+													break;
+
+												default:
+													echo '<th style="padding: 10px;" class="' . esc_attr( $key ) . '">' . esc_html( $column ) . '</th>';
+													break;
+											}
+
+										}
+									?>
+								</tr>
+							</thead>
+							<tbody>
+								<?php
+								$available_gateways = array(
+									new Omise_Payment_Alipay,
+									new Omise_Payment_Creditcard,
+									new Omise_Payment_Internetbanking
+								);
+								foreach ( $available_gateways as $gateway ) :
+
+									echo '<tr>';
+
+									foreach ( $columns as $key => $column ) :
+										switch ( $key ) {
+											case 'name' :
+												$method_title = $gateway->get_title() ? $gateway->get_title() : __( '(no title)', 'woocommerce' );
+												echo '<td class="name">
+													<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . esc_html( $method_title ) . '</a>
+												</td>';
+												break;
+
+											case 'status' :
+												echo '<td class="status" style="text-align: center;">';
+												echo ( 'yes' === $gateway->enabled ) ? '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Yes', 'woocommerce' ) . '">' . esc_html__( 'Yes', 'woocommerce' ) . '</span>' : '-';
+												echo '</td>';
+												break;
+
+											case 'setting' :
+												echo '<td class="setting" style="text-align: center;">
+													<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . __( 'config', 'omise' ) . '</a>
+												</td>';
+												break;
+										}
+									endforeach;
+
+									echo '</tr>';
+
+								endforeach;
+								?>
+							</tbody>
+						</table>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
 		<?php submit_button( __( 'Save Settings', 'omise' ) ); ?>
+
 	</form>
 </div>

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -1,0 +1,70 @@
+<div class="wrap omise">
+	<h1><?php echo $title; ?></h1>
+	<h2><?php echo _e( 'Payment Settings', 'omise' ); ?></h2>
+	<p>
+		<?php
+		echo sprintf(
+			wp_kses(
+				__( 'All of your keys can be found at your Omise dashboard, check the following links.<br/><a href="%s">Test keys</a> or <a href="%s">Live keys</a> (login required)', 'omise' ),
+				array(
+					'br' => array(),
+					'a'  => array( 'href' => array() )
+				)
+			),
+			esc_url( 'https://dashboard.omise.co/test/keys' ),
+			esc_url( 'https://dashboard.omise.co/live/keys' )
+		);
+		?>
+	</p>
+	<form method="POST">
+		<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row"><label for="sandbox"><?php echo __( 'Test mode', 'omise' ); ?></label></th>
+					<td>
+						<fieldset>
+							<label for="sandbox">
+								<input name="sandbox" type="checkbox" id="sandbox" value="1" <?php echo 'yes' === $settings['payment']['sandbox'] ? 'checked="checked"' : ''; ?>>
+								<?php echo __( 'Enabling test mode means that all your transactions will be performed under the Omise test account.', 'omise' ); ?>
+							</label>
+						</fieldset>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="test_public_key"><?php echo __( 'Public key for test', 'omise' ); ?></label></th>
+					<td>
+						<fieldset>
+							<input name="test_public_key" type="text" id="test_public_key" value="<?php echo $settings['payment']['test_public_key']; ?>" class="regular-text" />
+						</fieldset>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="test_private_key"><?php echo __( 'Secret key for test', 'omise' ); ?></label></th>
+					<td>
+						<fieldset>
+							<input name="test_private_key" type="text" id="test_private_key" value="<?php echo $settings['payment']['test_private_key']; ?>" class="regular-text" />
+						</fieldset>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="live_public_key"><?php echo __( 'Public key for live', 'omise' ); ?></label></th>
+					<td>
+						<fieldset>
+							<input name="live_public_key" type="text" id="live_public_key" value="<?php echo $settings['payment']['live_public_key']; ?>" class="regular-text" />
+						</fieldset>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="live_private_key"><?php echo __( 'Secret key for live', 'omise' ); ?></label></th>
+					<td>
+						<fieldset>
+							<input name="live_private_key" type="password" id="live_private_key" value="<?php echo $settings['payment']['live_private_key']; ?>" class="regular-text" />
+						</fieldset>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<?php submit_button( __( 'Save Settings', 'omise' ) ); ?>
+	</form>
+</div>

--- a/includes/class-omise-admin.php
+++ b/includes/class-omise-admin.php
@@ -22,20 +22,26 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		 * Register Omise to WordPress, WooCommerce
 		 * @return void
 		 */
-		public function register_admin_page_and_actions() {
+		public function register_admin_menu() {
 			if ( ! current_user_can( 'manage_options' ) ) {
 				return;
 			}
 
-			add_action( 'admin_menu', array( $this, 'add_dashboard_omise_menu' ) );
+			add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
 		}
 
 		/**
 		 * Add Omise menu to sidebar admin menu
 		 * @return void
 		 */
-		public function add_dashboard_omise_menu() {
-			add_menu_page( 'Omise', 'Omise', 'manage_options', 'wc-settings&tab=checkout&section=omise', function(){} );
+		public function add_admin_menu() {
+			add_menu_page( 'Omise', 'Omise', 'manage_options', 'omise', array( $this, 'page_settings') );
+
+			add_submenu_page( 'omise', __( 'Omise Settings', 'omise' ), __( 'Settings', 'omise' ), 'manage_options', 'omise-settings', array( $this, 'page_settings') );
+		}
+
+		public function page_settings() {
+			Omise_Page_Settings::render();
 		}
 	}
 }

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -91,4 +91,41 @@ class Omise_Setting {
 
 		return $this->get_default_settings();
 	}
+
+	/**
+	 * Whether Sandbox (test) mode is enabled or not.
+	 *
+	 * @return bool
+	 */
+	public function is_test() {
+		$sandbox = $this->settings['sandbox'];
+
+		return isset( $sandbox ) && $sandbox == 'yes';
+	}
+
+	/**
+	 * Return Omise public key.
+	 *
+	 * @return string
+	 */
+	public function public_key() {
+		if ( $this->is_test() ) {
+			return $this->settings['test_public_key'];
+		}
+
+		return $this->settings['live_public_key'];
+	}
+
+	/**
+	 * Return Omise secret key.
+	 *
+	 * @return string
+	 */
+	public function secret_key() {
+		if ( $this->is_test() ) {
+			return $this->settings['test_private_key'];
+		}
+
+		return $this->settings['live_private_key'];
+	}
 }

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -16,10 +16,7 @@ class Omise_Setting {
 	 * @since 3.1
 	 */
 	public function __construct() {
-		$this->settings = array_merge(
-			$this->get_default_settings(),
-			$this->get_payment_settings( 'omise' )
-		);
+		$this->settings = $this->get_payment_settings( 'omise' );
 	}
 
 	/**
@@ -85,6 +82,13 @@ class Omise_Setting {
 	 * @since  3.0
 	 */
 	public function get_payment_settings( $id ) {
-		return get_option( $this->get_payment_method_settings_name( $id ) );
+		if ( $options = get_option( $this->get_payment_method_settings_name( $id ) ) ) {
+			return array_merge(
+				$this->get_default_settings(),
+				$options
+			);
+		}
+
+		return $this->get_default_settings();
 	}
 }

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -1,0 +1,90 @@
+<?php
+
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Setting' ) ) {
+	return;
+}
+
+class Omise_Setting {
+	/**
+	 * @var null | array
+	 */
+	public $settings;
+
+	/**
+	 * @since 3.1
+	 */
+	public function __construct() {
+		$this->settings = array_merge(
+			$this->get_default_settings(),
+			$this->get_payment_settings( 'omise' )
+		);
+	}
+
+	/**
+	 * @return array
+	 *
+	 * @since  3.1
+	 */
+	protected function get_default_settings() {
+		return array(
+			'sandbox'          => 'yes',
+			'test_public_key'  => '',
+			'test_private_key' => '',
+			'live_public_key'  => '',
+			'live_private_key' => ''
+		);
+	}
+
+	/**
+	 * @return array
+	 *
+	 * @since  3.1
+	 */
+	public function get_settings() {
+		return $this->settings;
+	}
+
+	/**
+	 * @param  array $data
+	 *
+	 * @return array
+	 *
+	 * @since  3.1
+	 */
+	public function update_settings( $data ) {
+		$data['sandbox'] = ! is_null( $data['sandbox'] ) ? 'yes' : 'no';
+		
+		$this->settings = array_merge(
+			$this->settings,
+			$data
+		);
+
+		update_option( $this->get_payment_method_settings_name( 'omise' ), $this->settings );
+	}
+
+	/**
+	 * Returns the payment gateway settings option name
+	 *
+	 * @param  string $payment_method_id
+	 *
+	 * @return string The payment gateway settings option name.
+	 *
+	 * @since  3.0
+	 */
+	protected function get_payment_method_settings_name( $payment_method_id = 'omise' ) {
+		return 'woocommerce_' . $payment_method_id . '_settings';
+	}
+
+	/**
+	 * @param  string $id
+	 *
+	 * @return array
+	 *
+	 * @since  3.0
+	 */
+	public function get_payment_settings( $id ) {
+		return get_option( $this->get_payment_method_settings_name( $id ) );
+	}
+}

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -44,45 +44,29 @@ class Omise_Setting {
 	}
 
 	/**
-	 * @param  array $data
+	 * Returns the payment gateway settings option name
+	 *
+	 * @param  string $payment_id  Payment ID can be found at each of gateway classes (includes/gateway).
+	 *
+	 * @return string              The payment gateway settings option name.
+	 *
+	 * @since  3.1
+	 */
+	protected function get_payment_method_settings_name( $payment_id = 'omise' ) {
+		return 'woocommerce_' . $payment_id . '_settings';
+	}
+
+	/**
+	 * Get Omise settings from 'wp_options' table.
+	 *
+	 * @param  string $payment_id
 	 *
 	 * @return array
 	 *
 	 * @since  3.1
 	 */
-	public function update_settings( $data ) {
-		$data['sandbox'] = ! is_null( $data['sandbox'] ) ? 'yes' : 'no';
-		
-		$this->settings = array_merge(
-			$this->settings,
-			$data
-		);
-
-		update_option( $this->get_payment_method_settings_name( 'omise' ), $this->settings );
-	}
-
-	/**
-	 * Returns the payment gateway settings option name
-	 *
-	 * @param  string $payment_method_id
-	 *
-	 * @return string The payment gateway settings option name.
-	 *
-	 * @since  3.0
-	 */
-	protected function get_payment_method_settings_name( $payment_method_id = 'omise' ) {
-		return 'woocommerce_' . $payment_method_id . '_settings';
-	}
-
-	/**
-	 * @param  string $id
-	 *
-	 * @return array
-	 *
-	 * @since  3.0
-	 */
-	public function get_payment_settings( $id ) {
-		if ( $options = get_option( $this->get_payment_method_settings_name( $id ) ) ) {
+	public function get_payment_settings( $payment_id ) {
+		if ( $options = get_option( $this->get_payment_method_settings_name( $payment_id ) ) ) {
 			return array_merge(
 				$this->get_default_settings(),
 				$options
@@ -93,9 +77,29 @@ class Omise_Setting {
 	}
 
 	/**
+	 * @param  array $data
+	 *
+	 * @return array
+	 *
+	 * @since  3.1
+	 */
+	public function update_settings( $data ) {
+		$data['sandbox'] = isset( $data['sandbox'] ) && ! is_null( $data['sandbox'] ) ? 'yes' : 'no';
+
+		$this->settings = array_merge(
+			$this->settings,
+			$data
+		);
+
+		update_option( $this->get_payment_method_settings_name( 'omise' ), $this->settings );
+	}
+
+	/**
 	 * Whether Sandbox (test) mode is enabled or not.
 	 *
 	 * @return bool
+	 *
+	 * @since  3.1
 	 */
 	public function is_test() {
 		$sandbox = $this->settings['sandbox'];
@@ -107,6 +111,8 @@ class Omise_Setting {
 	 * Return Omise public key.
 	 *
 	 * @return string
+	 *
+	 * @since  3.1
 	 */
 	public function public_key() {
 		if ( $this->is_test() ) {
@@ -120,6 +126,8 @@ class Omise_Setting {
 	 * Return Omise secret key.
 	 *
 	 * @return string
+	 *
+	 * @since  3.1
 	 */
 	public function secret_key() {
 		if ( $this->is_test() ) {

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -72,7 +72,6 @@ function register_omise_creditcard() {
 						'description' => __( 'This controls the description which the user sees during checkout.', 'omise' )
 					),
 				),
-				$this->get_default_payment_setting_fields(),
 				array(
 					'advanced' => array(
 						'title'       => __( 'Advance Settings', 'omise' ),

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -47,58 +47,6 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * Returns the array of default payment settings
-	 *
-	 * @return array of default payment settings
-	 */
-	protected function get_default_payment_setting_fields() {
-		return array(
-			'payment_setting' => array(
-				'title'       => __( 'Payment Settings', 'omise' ),
-				'type'        => 'title',
-				'description' => sprintf(
-					wp_kses(
-						__( 'All of your keys can be found at your Omise dashboard, check the following links.<br/><a href="%s">Test keys</a> or <a href="%s">Live keys</a> (login required)', 'omise' ),
-						array(
-							'br' => array(),
-							'a'  => array( 'href' => array() )
-						)
-					),
-					esc_url( 'https://dashboard.omise.co/test/keys' ),
-					esc_url( 'https://dashboard.omise.co/live/keys' )
-				),
-			),
-
-			'sandbox' => array(
-				'title'       => __( 'Test mode', 'omise' ),
-				'type'        => 'checkbox',
-				'label'       => __( 'Enabling test mode means that all your transactions will be performed under the Omise test account.', 'omise' ),
-				'default'     => 'yes'
-			),
-
-			'test_public_key' => array(
-				'title'       => __( 'Public key for test', 'omise' ),
-				'type'        => 'text'
-			),
-
-			'test_private_key' => array(
-				'title'       => __( 'Secret key for test', 'omise' ),
-				'type'        => 'text'
-			),
-
-			'live_public_key' => array(
-				'title'       => __( 'Public key for live', 'omise' ),
-				'type'        => 'text'
-			),
-
-			'live_private_key' => array(
-				'title'       => __( 'Secret key for live', 'omise' ),
-				'type'        => 'password'
-			)
-		);
-	}
-
-	/**
 	 * Returns the payment gateway settings option name
 	 *
 	 * @param  string $payment_method_id

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -21,6 +21,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	public $id = 'omise';
 
 	/**
+	 * @see omise/includes/class-omise-setting.php
+	 *
+	 * @var Omise_Setting
+	 */
+	protected $omise_settings;
+
+	/**
 	 * Payment setting values.
 	 *
 	 * @var array
@@ -43,31 +50,8 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	protected $order;
 
 	public function __construct() {
-		$this->payment_settings = $this->get_payment_settings( 'omise' );
-	}
-
-	/**
-	 * Returns the payment gateway settings option name
-	 *
-	 * @param  string $payment_method_id
-	 *
-	 * @return string The payment gateway settings option name.
-	 *
-	 * @since  3.0
-	 */
-	protected function get_payment_method_settings_name( $payment_method_id = 'omise' ) {
-		return 'woocommerce_' . $payment_method_id . '_settings';
-	}
-
-	/**
-	 * @param  string $id
-	 *
-	 * @return array
-	 *
-	 * @since  3.0
-	 */
-	public function get_payment_settings( $id ) {
-		return get_option( $this->get_payment_method_settings_name( $id ) );
+		$this->omise_settings   = new Omise_Setting;
+		$this->payment_settings = $this->omise_settings->get_settings();
 	}
 
 	/**
@@ -102,9 +86,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return bool
 	 */
 	public function is_test() {
-		$sandbox = $this->payment_settings['sandbox'];
-
-		return isset( $sandbox ) && $sandbox == 'yes';
+		return $this->omise_settings->is_test();
 	}
 
 	/**
@@ -113,11 +95,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	protected function public_key() {
-		if ( $this->is_test() ) {
-			return $this->payment_settings['test_public_key'];
-		}
-
-		return $this->payment_settings['live_public_key'];
+		return $this->omise_settings->public_key();
 	}
 
 	/**
@@ -126,11 +104,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	protected function secret_key() {
-		if ( $this->is_test() ) {
-			return $this->payment_settings['test_private_key'];
-		}
-
-		return $this->payment_settings['live_private_key'];
+		return $this->omise_settings->secret_key();
 	}
 
 	/**

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -55,6 +55,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-internetbanking.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-php/lib/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-plugin/Omise.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';
@@ -75,9 +76,10 @@ class Omise {
 	 */
 	protected function init_admin() {
 		if ( is_admin() ) {
+			require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/admin/class-omise-page-settings.php';
 			require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-admin.php';
 
-			add_action( 'plugins_loaded', array( Omise_Admin::get_instance(), 'register_admin_page_and_actions' ) );
+			add_action( 'plugins_loaded', array( Omise_Admin::get_instance(), 'register_admin_menu' ) );
 			add_filter( 'woocommerce_order_actions', array( $this, 'register_order_actions' ) );
 		}
 	}


### PR DESCRIPTION
#### 1. Objective

Previously, Omise configs were located under the `WooCommerce > Checkout > Omise Credit / Debit Card` page, which is in fact, these configs will be used for other payment methods as well.
Without having its own separated page could confusing user on the setting (i.e. user sets pkey/skey at Credit Card payment method but can also use for IB and Alipay).

Also, Webhook feature is coming. Means we need to have some place to have a webhook url setting and it shouldn't be under the `WooCommerce > Checkout > Omise Credit / Debit Card` or other payment method pages.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

1. Setting page under the Omise menu at WordPress admin page.
    ![screencapture-127-0-0-1-wp-admin-admin-php-1504799768907](https://user-images.githubusercontent.com/2154669/30172968-678f6fa6-9420-11e7-82d5-d77a3ca37f5c.png)

2. Removed `Payment Settings` section from `WooCommerce > Checkout > Omise Credit / Debit Card` page.
    ![screencapture-127-0-0-1-wp-admin-admin-php-1504800149487](https://user-images.githubusercontent.com/2154669/30173068-bdd61f54-9420-11e7-916c-478e921ce959.png)

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: 3.8.1
- **WooCommerce**: 3.1.2.
- **PHP**: 5.6.30

**✏️ Details:**

1. **Make sure that this implementation won't cause any trouble with the current settings that has been set at the previous setting page.**

    1.1 Assume that a user already installed Omise and config his public/ secret keys at his store (if not, then install Omise-WooComemrce v3.0 and setup first).

    1.2. Deploy this PR.

    1.3. Then go to Omise new setting page, **your current settings should be displayed there properly**.

2. **Make sure that your store can perform checkout with credit card and other payment methods properly**

    2.1 Continue from [1]. Without any extra steps, your store should still work as normal.

3. **Make sure that user can setup new Omise-WooCommerce plugin and able to config his Omise settings properly.**

    3.1 Assume that user just about to installs Omise for the first time (if not, then re-install WordPree & WooCommerce & Omise from scratch).

    3.2 Test config public / secret keys and enable test mode.

    3.3 Your config should be persisted there.

4. **Make sure that you can use your keys from step [3] to make charge with any payment methods (Credit / Debit Card, Alipay, Internet Banking).**

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No