### PR TITLE
Introduce WebHooks feature

### DIFF
--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -65,6 +65,38 @@
 			</tbody>
 		</table>
 
+		<hr />
+
+		<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row"><label><?php _e( 'Webhook endpoint', 'omise' ); ?></label></th>
+					<td>
+						<fieldset>
+							<code><?php echo get_rest_url( null, 'omise/webhooks' ); ?></code>
+							<p class="description">
+								<?php
+								echo sprintf(
+									wp_kses(
+										__( 'To enable <a href="%s">WebHooks</a> feature, you must setup an endpoint at <a href="%s"><strong>Omise dashboard</strong></a> by using the above url <em>(HTTPS only)</em>.', 'omise' ),
+										array(
+											'a'       => array( 'href' => array() ),
+											'em'      => array(),
+											'strong'  => array()
+										)
+									),
+									esc_url( 'https://www.omise.co/api-webhooks' ),
+									esc_url( 'https://dashboard.omise.co/test/webhooks/edit' )
+								);
+								?>
+						</fieldset>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<hr />
+
 		<h3><?php _e( 'Payment Methods', 'omise' ); ?></h3>
 		<p><?php _e( 'The table below is a list of available payment methods that you can enable in your WooCommerce store.', 'omise' ); ?></p>
 		<table class="form-table">

--- a/includes/class-omise-events.php
+++ b/includes/class-omise-events.php
@@ -1,0 +1,60 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Events' ) ) {
+	return;
+}
+
+class Omise_Events {
+	/**
+	 * @var array  of event classes that we can handle.
+	 */
+	protected $events = array();
+
+	public function __construct() {
+		$events = array(
+			'Omise_Event_Charge_Capture',
+			'Omise_Event_Charge_Complete',
+			'Omise_Event_Charge_Create'
+		);
+
+		foreach ( $events as $event ) {
+			$clazz = new $event;
+			$this->events[ $clazz->event ] = $clazz;
+		}
+	}
+
+	/**
+	 * Note. It doesn't return anything back because nobody using the result
+	 * unless we have a 'log' system.
+	 *
+	 * @param  string $event
+	 * @param  mixed  $data
+	 *
+	 * @return void
+	 */
+	public function handle( $event, $data ) {
+		if ( ! isset( $this->events[ $event ] ) ) {
+			return;
+		}
+
+		/**
+		 * Hook before Omise handle an event from webhook.
+		 *
+		 * @param mixed $data  a data of an event object
+		 */
+		do_action( 'omise_before_handle_event_' . $event, $data );
+
+		$result = $this->events[ $event ]->handle( $data );
+
+		/**
+		 * Hook after Omise handle an event from webhook.
+		 *
+		 * @param mixed $data    a data of an event object
+		 * @param mixed $result  a result of an event handler
+		 */
+		do_action( 'omise_after_handle_event_' . $event, $data, $result );
+
+		return $result;
+	}
+}

--- a/includes/class-omise-rest-webhooks-controller.php
+++ b/includes/class-omise-rest-webhooks-controller.php
@@ -1,0 +1,56 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Rest_Webhooks_Controller' ) ) {
+	return;
+}
+
+class Omise_Rest_Webhooks_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	const ENDPOINT_NAMESPACE = 'omise';
+
+	/**
+	 * @var string
+	 */
+	const ENDPOINT = 'webhooks';
+
+	/**
+	 * Register the routes for webhooks.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::ENDPOINT_NAMESPACE,
+			'/' . self::ENDPOINT,
+			array(
+				'methods' => WP_REST_Server::EDITABLE,
+				'callback' => array( $this, 'callback' ),
+			)
+		);
+	}
+
+	/**
+	 * @param  WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function callback( $request ) {
+		if ( 'application/json' !== $request->get_header( 'Content-Type' ) ) {
+			return new WP_Error( 'omise_rest_wrong_header', __( 'Wrong header type.', 'omise' ), array( 'status' => 400 ) );
+		}
+
+		$body = json_decode( $request->get_body() );
+
+		if ( 'event' !== $body->object ) {
+			return new WP_Error( 'omise_rest_wrong_object', __( 'Wrong object type.', 'omise' ), array( 'status' => 400 ) );
+		}
+
+		$event = new Omise_Events;
+		$event = $event->handle( $body->key, $body->data );
+
+		return rest_ensure_response( $event );
+	}
+}

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -41,7 +41,10 @@ class Omise_Event_Charge_Capture {
 
 		switch ($data->status) {
 			case 'successful':
-				if ( $data->authorized && $data->captured ) {
+				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
+				$paid = isset( $data->captured ) ? $data->captured : $data->paid;
+
+				if ( $data->authorized && $paid ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -1,0 +1,82 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Event_Charge_Capture' ) ) {
+	return;
+}
+
+class Omise_Event_Charge_Capture {
+	/**
+	 * @var string  of an event name.
+	 */
+	public $event = 'charge.capture';
+
+	/**
+	 * There are several cases that can trigger the 'charge.capture' event.
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Credit Card
+	 * charge data in payload will be:
+	 *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+	 *
+	 * @param  mixed $data
+	 *
+	 * @return void
+	 */
+	public function handle( $data ) {
+		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+			return;
+		}
+
+		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+			return;
+		}
+
+		$order->add_order_note(
+			__(
+				'Omise: an event charge.capture has been caught (webhook).',
+				'omise'
+			)
+		);
+
+		switch ($data->status) {
+			case 'successful':
+				if ( $data->authorized && $data->captured ) {
+					$order->add_order_note(
+						sprintf(
+							wp_kses(
+								__( 'Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid', 'omise' ),
+								array( 'br' => array() )
+							),
+							$order->get_total(),
+							$order->get_order_currency()
+						)
+					);
+
+					$order->payment_complete( $data->id );
+				}
+
+				break;
+			
+			default:
+				$order->add_order_note(
+					wp_kses(
+						__( 'Omise: Payment invalid.<br/>There was something wrong in the Webhook payload. Please contact Omise support team to investigate further.', 'omise' ),
+						array( 'br' => array() )
+					)
+				);
+
+				break;
+		}
+
+		/**
+		 * Hook after Omise handle an event from webhook.
+		 *
+		 * @param WC_Order $order  an order object.
+		 * @param mixed $data      a data of an event object
+		 */
+		do_action( 'omise_handled_event_charge_capture', $order, $data );
+
+		return;
+	}
+}

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -75,7 +75,10 @@ class Omise_Event_Charge_Complete {
 				break;
 
 			case 'successful':
-				if ( $data->authorized && $data->captured ) {
+				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
+				$paid = isset( $data->captured ) ? $data->captured : $data->paid;
+
+				if ( $data->authorized && $paid ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -1,0 +1,114 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Event_Charge_Complete' ) ) {
+	return;
+}
+
+class Omise_Event_Charge_Complete {
+	/**
+	 * @var string  of an event name.
+	 */
+	public $event = 'charge.complete';
+
+	/**
+	 * There are several cases with the following payment methods
+	 * that would trigger the 'charge.complete' event.
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Alipay
+	 * charge data in payload:
+	 *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Internet Banking
+	 * charge data in payload:
+	 *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Credit Card (3-D Secure)
+	 * CAPTURE = FALSE
+	 * charge data in payload could be one of these sets:
+	 *     [status: 'pending'], [authorized: 'true'], [paid: 'false']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * CAPTURE = TRUE
+	 * charge data in payload could be one of these sets:
+	 *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * @param  mixed $data
+	 *
+	 * @return void
+	 */
+	public function handle( $data ) {
+		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+			return;
+		}
+
+		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+			return;
+		}
+
+		$order->add_order_note(
+			__(
+				'Omise: an event charge.complete has been caught (webhook).',
+				'omise'
+			)
+		);
+
+		switch ($data->status) {
+			case 'failed':
+				$order->add_order_note(
+					sprintf(
+						wp_kses(
+							__( 'Omise: Payment failed.<br/>%s', 'omise' ),
+							array( 'br' => array() )
+						),
+						$data->failure_message . ' (code: ' . $data->failure_code . ')'
+					)
+				);
+
+				$order->update_status( 'failed' );
+				break;
+
+			case 'successful':
+				if ( $data->authorized && $data->captured ) {
+					$order->add_order_note(
+						sprintf(
+							wp_kses(
+								__( 'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' ),
+								array( 'br' => array() )
+							),
+							$order->get_total(),
+							$order->get_order_currency()
+						)
+					);
+
+					$order->payment_complete( $data->id );
+				}
+				break;
+			
+			case 'pending':
+				if ( $data->authorized ) {
+					$order->payment_complete( $data->id );
+				}
+				break;
+
+			default:
+				break;
+		}
+
+		/**
+		 * Hook after Omise handle an event from webhook.
+		 *
+		 * @param WC_Order $order  an order object.
+		 * @param mixed $data      a data of an event object
+		 */
+		do_action( 'omise_handled_event_charge_complete', $order, $data );
+
+		return;
+	}
+}

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -95,8 +95,9 @@ class Omise_Event_Charge_Complete {
 				break;
 			
 			case 'pending':
+				// Credit Card 3-D Secure with 'authorize only' payment action case.
 				if ( $data->authorized ) {
-					$order->payment_complete( $data->id );
+					$order->update_status( 'processing' );
 				}
 				break;
 

--- a/includes/events/class-omise-event-charge-create.php
+++ b/includes/events/class-omise-event-charge-create.php
@@ -1,0 +1,88 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Event_Charge_Create' ) ) {
+	return;
+}
+
+class Omise_Event_Charge_Create {
+	/**
+	 * @var string  of an event name.
+	 */
+	public $event = 'charge.create';
+
+	/**
+	 * There are several cases when make a new charge with the following
+	 * payment methods that would trigger the 'charge.create' event.
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Alipay
+	 * charge data in payload:
+	 *     [status: 'pending' (always)], [authorized: 'false' (always)]
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Internet Banking
+	 * charge data in payload:
+	 *     [status: 'pending' (always)], [authorized: 'false' (always)]
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Credit Card (none 3-D Secure)
+	 * CAPTURE = FALSE
+	 * charge data in payload could be one of these sets:
+	 *     [status: 'pending'], [authorized: 'true'], [paid: 'false']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * CAPTURE = TRUE
+	 * charge data in payload could be one of these sets:
+	 *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	 * Credit Card (3-D Secure)
+	 * CAPTURE = FALSE
+	 * charge data in payload could be one of these sets:
+	 *     [status: 'pending'], [authorized: 'false'], [paid: 'false']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * CAPTURE = TRUE
+	 * charge data in payload could be one of these sets:
+	 *     [status: 'pending'], [authorized: 'false'], [paid: 'false']
+	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+	 *
+	 * @param  mixed $data
+	 *
+	 * @return void
+	 */
+	public function handle( $data ) {
+		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+			return;
+		}
+
+		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+			return;
+		}
+
+		$order->add_order_note(
+			__(
+				'Omise: an event charge.create has been caught (webhook).',
+				'omise'
+			)
+		);
+
+		/** 
+		 * Note. There is no special case for 'charge.create' event to handle with.
+		 *       Basically, just to pass this event in case some 3rd-party developer
+		 *       need to add extra process, then they can hook 'omise_handled_event_charge_create' action.
+		 */
+
+		/**
+		 * Hook after Omise handle an event from webhook.
+		 *
+		 * @param WC_Order $order  an order object.
+		 * @param mixed $data      a data of an event object
+		 */
+		do_action( 'omise_handled_event_charge_create', $order, $data );
+
+		return;
+	}
+}

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -184,7 +184,10 @@ function register_omise_alipay() {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 				}
 
-				if ( 'pending' === $charge['status'] && ! $charge['captured'] ) {
+				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
+				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
+
+				if ( 'pending' === $charge['status'] && ! $paid ) {
 					$order->add_order_note(
 						wp_kses(
 							__( 'Omise: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual \'Sync Payment Status\' action from the Order Actions panel or check the payment status directly at Omise dashboard again later', 'omise' ),
@@ -199,7 +202,10 @@ function register_omise_alipay() {
 					die();
 				}
 
-				if ( 'successful' === $charge['status'] && $charge['captured'] ) {
+				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
+				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
+
+				if ( 'successful' === $charge['status'] && $paid ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -93,7 +93,11 @@ function register_omise_alipay() {
 					'currency'    => $order->get_order_currency(),
 					'description' => 'WooCommerce Order id ' . $order_id,
 					'offsite'     => 'alipay',
-					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" )
+					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
+					'metadata'    => array(
+						/** backward compatible with WooCommerce v2.x series **/
+						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+					)
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -286,6 +286,11 @@ function register_omise_creditcard() {
 					$data['capture'] = false;
 				}
 
+				/** backward compatible with WooCommerce v2.x series **/
+				$data['metadata'] = array(
+					'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+				);
+
 				$charge = OmiseCharge::create( $data, '', $this->secret_key() );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -200,7 +200,10 @@ function register_omise_internetbanking() {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 				}
 
-				if ( 'pending' === $charge['status'] && ! $charge['captured'] ) {
+				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
+				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
+
+				if ( 'pending' === $charge['status'] && ! $paid ) {
 					$order->add_order_note(
 						wp_kses(
 							__( 'Omise: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual \'Sync Payment Status\' action from the Order Actions panel or check the payment status directly at Omise dashboard again later', 'omise' ),
@@ -215,7 +218,10 @@ function register_omise_internetbanking() {
 					die();
 				}
 
-				if ( 'successful' === $charge['status'] && $charge['captured'] ) {
+				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
+				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
+
+				if ( 'successful' === $charge['status'] && $paid ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -109,7 +109,11 @@ function register_omise_internetbanking() {
 					'currency'    => $order->get_order_currency(),
 					'description' => 'WooCommerce Order id ' . $order_id,
 					'offsite'     => $_POST['omise-offsite'],
-					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" )
+					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
+					'metadata'    => array(
+						/** backward compatible with WooCommerce v2.x series **/
+						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+					)
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -50,11 +50,16 @@ class Omise {
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-charge.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-card-image.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-capture.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-complete.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-create.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-alipay.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-creditcard.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-internetbanking.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-php/lib/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-plugin/Omise.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-events.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
 
@@ -69,6 +74,7 @@ class Omise {
 		add_action( 'plugins_loaded', array( $this, 'register_user_agent' ), 10 );
 
 		$this->init_admin();
+		$this->init_route();
 	}
 
 	/**
@@ -82,6 +88,16 @@ class Omise {
 			add_action( 'plugins_loaded', array( Omise_Admin::get_instance(), 'register_admin_menu' ) );
 			add_filter( 'woocommerce_order_actions', array( $this, 'register_order_actions' ) );
 		}
+	}
+
+	/**
+	 * @since  3.1
+	 */
+	protected function init_route() {
+		add_action( 'rest_api_init', function () {
+			$controllers = new Omise_Rest_Webhooks_Controller;
+			$controllers->register_routes();
+		} );
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

There are some cases that we need to consider using WebHooks feature.

- An order has been placed at WooCommerce store with only authorize a charge (not auto capture). Then later, merchant performs `capture` action at Omise dashboard.

    Here, we need something like callback to tell WooCommerce store that that order has been captured already at Omise dashboard, that WooCommerce store can update an order status according to that capture result. 

- Some offsite payments don't resolve users' payments at the time they (user) complete their payment process (for example, Internet Banking, sometimes has some delay on process user's transaction).

    User will be redirected back to WooCommerce store with payment status = `pending` causing that an order status won't be changed to `processing` nor `completed` until merchant manual change it.

    Fortunately, Omise will triggers `charge.complete` event only when those offsite payments have been finished (by finish, means those offsite payments complete their processes). So we can rely on this event to automatically update an order status to `processing` or even `failed` without manual check / update by merchant.

**Related information**:
Related issue(s): -

#### 2. Description of change

1. Display Webhook enpoint at the setting page.
    ![screencapture-127-0-0-1-wp-admin-admin-php-1504862207296](https://user-images.githubusercontent.com/2154669/30205545-46f500ce-94b3-11e7-9ac9-7c2aec586237.png)

2. Handle **`charge.create`** event.
    Basically, there is noting to handle in this event but this PR allows 3rd-party developer to hook this event handler ( `omise_handled_event_charge_create`, check at `Omise_Event_Charge_Create` class).

3. Handle **`charge.capture`** event.
    Only 1 situation that would trigger this event, which is when merchant capture an authorized charge (credit card payment method).

4. Handle **`charge.complete`** event.
    There are 3 cases that would trigger this event.
    4.1 Alipay payment, when buyer complete the redirection flow (either success or fail).
    4.2 Internet Banking payment, when buyer complete the redirection flow (either success or fail).
    4.3 Credit Card payment (with-without auto capture), when buyer complete the redirection flow (either success or fail).

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: 3.8.1
- **WooCommerce**: 3.1.2 with **PHP** 5.6.30.
- **WooCommerce**: 2.6.14 with **PHP** 5.4.45.

**✏️ Details:**

> Note. These tests are using [ngrok](https://ngrok.com) to expose a local server to make it be able to be set into Omise's endpoint.

First, at WordPress admin, go to Omise Setting page. Then copy Webhook endpoint set into [Omise dashboard](https://dashboard.omise.co/test/webhooks/edit).

![screen shot 2560-09-11 at 4 55 51 pm copy](https://user-images.githubusercontent.com/2154669/30269261-6e550446-9712-11e7-9e30-c2e9c4d81554.png)

1. **Make sure that Webhook endpoint is accessible.**
    1.1 Create a new charge with any payment methods.
    1.2 You will see message `Omise: an event charge.create has been caught (webhook).` appears in your order detail page.

2. **Make sure that when you perform the 'capture' action form Omise dashboard, your WooCommerce order status will be updated according to a result of that charge transaction.**
    2.1 Create a new charge with Credit Card payment method (set `payment action` to `auth only`)
    2.2 _If you check your order status at this step, it will be `pending payment`._
    2.3 Then, go to Omise dashboard. Find your recently charge transaction and do capture.
    2.4 If you come back to WooCommerce order detail page, you will see that now your order status has been changed to `processing`.

3. **Make sure that plugin can handle `charge.complete` event properly when charge with **Alipay** payment in case of failed charge.**

4. **Make sure that plugin can handle `charge.complete` event properly when charge with **Alipay** payment in case of successful charge.**

5. **Make sure that plugin can handle `charge.complete` event properly when charge with **Internet Banking** payment in case of failed charge.**

6. **Make sure that plugin can handle `charge.complete` event properly when charge with **Internet Banking** payment in case of successful charge.**

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

- There are some events that this PR doesn't implement with (i.e. `charge.reverse`, `refund.create`).
    More information, please check https://www.omise.co/api-webhooks.