### PR TITLE
Separate fbbot entity to new class and update confidence rate to 0.85

### DIFF
--- a/includes/fbbot/class-omise-fbbot-conversation-generator.php
+++ b/includes/fbbot/class-omise-fbbot-conversation-generator.php
@@ -88,8 +88,7 @@ class Omise_FBBot_Conversation_Generator {
 
 	private function entities_handle( $entities ) {
 		$filtered_entities = array_filter( $entities, function ($value) {
-			$confidence_rate = 0.9;
-			return ($value[0]['confidence'] > $confidence_rate);
+			return ($value[0]['confidence'] > Omise_FBBot_Entity::CONFIDENCE_RATE);
 		} );
 
 		if ( count( $filtered_entities ) != 0 ) {
@@ -104,14 +103,14 @@ class Omise_FBBot_Conversation_Generator {
 			}
 			
 			switch ( $user_intent ) {
-				case 'greetings':
-				case 'user_greetings':
+				case Omise_FBBot_Entity::GREETINGS:
+				case Omise_FBBot_Entity::USER_GREETINGS:
 					return self::greeting_message( $this->sender_id );
 				
-				case 'check_order_status':
+				case Omise_FBBot_Entity::CHECK_ORDER_STATUS:
 					return self::rechecking_order_number_message();
 
-				case 'need_help':
+				case Omise_FBBot_Entity::NEED_HELP:
 					return self::helping_message(); 
 				default:
 					return self::unrecognized_message();

--- a/includes/fbbot/class-omise-fbbot-entity.php
+++ b/includes/fbbot/class-omise-fbbot-entity.php
@@ -1,0 +1,15 @@
+<?php
+defined( 'ABSPATH' ) or die( "No direct script access allowed." );
+
+if ( class_exists( 'Omise_FBBot_Entity' ) ) {
+	return;
+}
+
+abstract class Omise_FBBot_Entity {
+	const CONFIDENCE_RATE = 0.85;
+
+	const GREETINGS = "greetings";
+	const USER_GREETINGS = "user_greetings";
+	const CHECK_ORDER_STATUS = "check_order_status";
+	const NEED_HELP = "need_help";
+}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -79,6 +79,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-woocommerce.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-wccategory.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-wcproduct.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-entity.php';
 
 		// Messenger Bot Template
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/templates/fbbot/url-button-item.php';


### PR DESCRIPTION
#### 1. Objective

Separate bot entity to new class and update confidence rate to 0.85

#### 2. Description of change

2.1. Facebook messenger bot with NLP feature for woocommerce shop

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: WooCommerce 3.1.1.
- **Omise plugin version**: Omise-WooCommerce v3.1.1
- **PHP version**: 5.6.30

#### 4. Impact of the change

No.

#### 5. Priority of change

Normal

#### 6. Additional Notes

- Messenger app should enable NLP service
- Merchant must import ShopHelperBot app to wit.ai
- ShopHelperBot app is wit.ai app, merchant can download from Omise plugin document site