### PR TITLE
Handover protocol feature

### DIFF
--- a/includes/fbbot/class-omise-fbbot-configurator.php
+++ b/includes/fbbot/class-omise-fbbot-configurator.php
@@ -10,6 +10,8 @@ class Omise_FBBot_Configurator {
 	private static $namespace = 'omisemsgbot';
 	private static $facebook_profile_endpoint = "https://graph.facebook.com/v2.6/me/messenger_profile?access_token=";
 	private static $facebook_message_endpoint = "https://graph.facebook.com/v2.6/me/messages?access_token=";
+	private static $facebook_secondary_receivers_endpoint = "https://graph.facebook.com/v2.6/me/secondary_receivers?fields=id,name&access_token=";
+	private static $facebook_pass_thread_endpoint = "https://graph.facebook.com/v2.6/me/pass_thread_control?access_token=";
 
 	public static function get_namespace() {
 		return self::$namespace . '/v' . self::$version;
@@ -28,6 +30,16 @@ class Omise_FBBot_Configurator {
 	public static function get_fb_message_endpoint() {
 		$page_access_token = self::get_fb_settings( 'facebook_page_access_token' );
 		return self::$facebook_message_endpoint . $page_access_token;
+	}
+
+	public static function get_fb_secondary_receivers_endpoint() {
+		$page_access_token = self::get_fb_settings( 'facebook_page_access_token' );
+		return self::$facebook_secondary_receivers_endpoint . $page_access_token;
+	}
+
+	public static function get_fb_pass_thread_endpoint() {
+		$page_access_token = self::get_fb_settings( 'facebook_page_access_token' );
+		return self::$facebook_pass_thread_endpoint . $page_access_token;
 	}
 
 	public static function facebook_bot_is_enable() {

--- a/includes/fbbot/class-omise-fbbot-conversation-generator.php
+++ b/includes/fbbot/class-omise-fbbot-conversation-generator.php
@@ -115,7 +115,12 @@ class Omise_FBBot_Conversation_Generator {
 					return self::rechecking_order_number_message();
 
 				case Omise_FBBot_Entity::NEED_HELP:
-					return self::helping_message(); 
+					return self::helping_message();
+
+				case Omise_FBBot_Entity::CALL_SHOP_OWNER:
+					$success = Omise_FBBot_Handover_Protocol_Handler::switch_to_live_agent( $this->sender_id );
+					return self::call_shop_owner_message( $success );
+					 
 				default:
 					return self::unrecognized_message();
 			}

--- a/includes/fbbot/class-omise-fbbot-conversation-generator.php
+++ b/includes/fbbot/class-omise-fbbot-conversation-generator.php
@@ -6,10 +6,11 @@ if ( class_exists( 'Omise_FBBot_Conversation_Generator' ) ) {
 }
 
 class Omise_FBBot_Conversation_Generator {
-	private $sender_id, $message, $payload, $nlp_enabled;
+	private $sender_id, $recipient_id, $message, $payload, $nlp_enabled;
 
-	public function listen( $sender_id, $message ) {
+	public function listen( $sender_id, $recipient_id, $message ) {
 		$this->sender_id = $sender_id;
+		$this->recipient_id = $recipient_id;
 		$this->message = $message;
 
 		if ( $message['nlp'] ) {
@@ -17,10 +18,14 @@ class Omise_FBBot_Conversation_Generator {
 		} else {
 			$this->nlp_enabled = false;
 		}
+
+		error_log($sender_id);
+		error_log($recipient_id);
 	}
 
-	public function listen_payload( $sender_id, $payload ) {
+	public function listen_payload( $sender_id, $recipient_id, $payload ) {
 		$this->sender_id = $sender_id;
+		$this->recipient_id = $recipient_id;
 		$this->payload = $payload;
 	}
 
@@ -69,6 +74,10 @@ class Omise_FBBot_Conversation_Generator {
 
 			case Omise_FBBot_Payload::HELP:
 				return self::helping_message();
+
+			case Omise_FBBot_Payload::CALL_SHOP_OWNER:
+				Omise_FBBot_Handover_Protocol_Handler::pass_thread_to( $this->recipient_id, 263902037430900 );
+				return self::call_shop_owner_message();
 
 			default:
 				# Custom payload :
@@ -299,5 +308,9 @@ class Omise_FBBot_Conversation_Generator {
 		$buttons = Omise_FBBot_Message_Store::get_default_menu_buttons();
 
 		return FB_Button_Template::create( $unrecognized_message, $buttons );
+	}
+
+	public static function call_shop_owner_message() {
+		return FB_Message_Item::create( Omise_FBBot_Message_Store::get_checking_order_helper_message() );
 	}
 }

--- a/includes/fbbot/class-omise-fbbot-endpoints.php
+++ b/includes/fbbot/class-omise-fbbot-endpoints.php
@@ -108,17 +108,19 @@ class Omise_FBBot_Endpoints extends WP_REST_Controller {
 					}
 
 					$sender_id = $messaging_event['sender']['id'];
+					$recipient_id = $messaging_event['recipient']['id'];
 
 					// Handle message object
-					Omise_FBBot_Request_Handler::handle_message_from( $sender_id, $messaging_event['message'] );
+					Omise_FBBot_Request_Handler::handle_message_from( $sender_id, $recipient_id, $messaging_event['message'] );
 					break;
 
 				} else if ( isset( $messaging_event['postback'] ) ) {
 					// Handle payload
 					$sender_id = $messaging_event['sender']['id'];
+					$recipient_id = $messaging_event['recipient']['id'];
 					$payload = $messaging_event['postback']['payload'];
 
-					Omise_FBBot_Request_Handler::handle_payload_from( $sender_id, $payload );
+					Omise_FBBot_Request_Handler::handle_payload_from( $sender_id, $recipient_id, $payload );
 				} else {
 					// Unused case
 					break;

--- a/includes/fbbot/class-omise-fbbot-endpoints.php
+++ b/includes/fbbot/class-omise-fbbot-endpoints.php
@@ -111,7 +111,7 @@ class Omise_FBBot_Endpoints extends WP_REST_Controller {
 					$recipient_id = $messaging_event['recipient']['id'];
 
 					// Handle message object
-					Omise_FBBot_Request_Handler::handle_message_from( $sender_id, $recipient_id, $messaging_event['message'] );
+					Omise_FBBot_Request_Handler::handle_message_from( $sender_id, $messaging_event['message'] );
 					break;
 
 				} else if ( isset( $messaging_event['postback'] ) ) {
@@ -120,7 +120,7 @@ class Omise_FBBot_Endpoints extends WP_REST_Controller {
 					$recipient_id = $messaging_event['recipient']['id'];
 					$payload = $messaging_event['postback']['payload'];
 
-					Omise_FBBot_Request_Handler::handle_payload_from( $sender_id, $recipient_id, $payload );
+					Omise_FBBot_Request_Handler::handle_payload_from( $sender_id, $payload );
 				} else {
 					// Unused case
 					break;

--- a/includes/fbbot/class-omise-fbbot-entity.php
+++ b/includes/fbbot/class-omise-fbbot-entity.php
@@ -12,4 +12,5 @@ abstract class Omise_FBBot_Entity {
 	const USER_GREETINGS = "user_greetings";
 	const CHECK_ORDER_STATUS = "check_order_status";
 	const NEED_HELP = "need_help";
+	const CALL_SHOP_OWNER = "call_shop_owner";
 }

--- a/includes/fbbot/class-omise-fbbot-handover-protocol-handler.php
+++ b/includes/fbbot/class-omise-fbbot-handover-protocol-handler.php
@@ -6,34 +6,23 @@ if ( class_exists( 'Omise_FBBot_Handover_Protocol_Handler' ) ) {
 }
 
 class Omise_FBBot_Handover_Protocol_Handler {
-	public static function get_second_receiver() {
-		$url = Omise_FBBot_Configurator::get_fb_secondary_receivers_endpoint();
-		$response = Omise_FBBot_HTTPService::send_get_request( $url );
-		$body = json_decode($response['body']);
-		error_log(print_r($body->data[0]->id, true));
+	public static function switch_to_live_agent( $sender_id ) {
+		$page_inbox_app_id = "263902037430900";
 
-		return $body->data[0]->id;
-	}
-
-	public static function pass_thread_to( $psid, $target_app_id ) {
 		$body = array(
-			"recipient" => array( "id" => $psid),
-			"target_app_id" => $target_app_id
+			"recipient" => array( "id" => $sender_id ),
+			"target_app_id" => $page_inbox_app_id
 		);
-
-		error_log(print_r($body, true));
 
 		$url = Omise_FBBot_Configurator::get_fb_pass_thread_endpoint();
 		$response = Omise_FBBot_HTTPService::send_request( $url, $body );
 
-		error_log(print_r($response, true));
-	}
+		$body = json_decode($response['body']);
 
-	public static function switch_to_live_agent( $sender_id, $recipient_id ) {
+		if ( $body->success ) {
+			return true;
+		}
 
-	}
-
-	public static function switch_to_bot( $sender_id, $recipient_id ) {
-
+		return false;
 	}
 }

--- a/includes/fbbot/class-omise-fbbot-handover-protocol-handler.php
+++ b/includes/fbbot/class-omise-fbbot-handover-protocol-handler.php
@@ -1,0 +1,39 @@
+<?php
+defined( 'ABSPATH' ) or die( "No direct script access allowed." );
+
+if ( class_exists( 'Omise_FBBot_Handover_Protocol_Handler' ) ) {
+	return;
+}
+
+class Omise_FBBot_Handover_Protocol_Handler {
+	public static function get_second_receiver() {
+		$url = Omise_FBBot_Configurator::get_fb_secondary_receivers_endpoint();
+		$response = Omise_FBBot_HTTPService::send_get_request( $url );
+		$body = json_decode($response['body']);
+		error_log(print_r($body->data[0]->id, true));
+
+		return $body->data[0]->id;
+	}
+
+	public static function pass_thread_to( $psid, $target_app_id ) {
+		$body = array(
+			"recipient" => array( "id" => $psid),
+			"target_app_id" => $target_app_id
+		);
+
+		error_log(print_r($body, true));
+
+		$url = Omise_FBBot_Configurator::get_fb_pass_thread_endpoint();
+		$response = Omise_FBBot_HTTPService::send_request( $url, $body );
+
+		error_log(print_r($response, true));
+	}
+
+	public static function switch_to_live_agent( $sender_id, $recipient_id ) {
+
+	}
+
+	public static function switch_to_bot( $sender_id, $recipient_id ) {
+
+	}
+}

--- a/includes/fbbot/class-omise-fbbot-http-service.php
+++ b/includes/fbbot/class-omise-fbbot-http-service.php
@@ -8,7 +8,7 @@ if ( class_exists( 'Omise_FBBot_HTTPService' ) ) {
 class Omise_FBBot_HTTPService {
 	private function __construct() { }
 
-	public static function send_request( $url, $body ) {
+	public static function send_request( $url, $body = array() ) {
 		return wp_safe_remote_post( $url, array(
 				'timeout' => 60,
 				'body' => $body
@@ -16,7 +16,7 @@ class Omise_FBBot_HTTPService {
 		);
 	}
 
-	public static function send_delete_request( $url, $body ) {
+	public static function send_delete_request( $url, $body = array() ) {
 		$defaults = array('method' => 'DELETE');
 
 		$args = wp_parse_args( $body, $defaults );

--- a/includes/fbbot/class-omise-fbbot-message-store.php
+++ b/includes/fbbot/class-omise-fbbot-message-store.php
@@ -246,8 +246,9 @@ class Omise_FBBot_Message_Store {
 		$feature_products_button = FB_Postback_Button_Item::create( __( 'Featured products', 'omise' ), $payload::FEATURE_PRODUCTS );
 		$category_button = FB_Postback_Button_Item::create( __( 'Product category', 'omise' ), $payload::PRODUCT_CATEGORY );
 		$check_order_button = FB_Postback_Button_Item::create( __( 'Check order status', 'omise' ), $payload::CHECK_ORDER );
+		$call_shop_owner_button = FB_Postback_Button_Item::create( __( 'Call shop owner', 'omise' ), $payload::CALL_SHOP_OWNER );
 
-		return array( $feature_products_button, $category_button , $check_order_button);
+		return array( $feature_products_button, $category_button , $call_shop_owner_button );
 	}
 
 	public static function check_greeting_words( $message ) {

--- a/includes/fbbot/class-omise-fbbot-message-store.php
+++ b/includes/fbbot/class-omise-fbbot-message-store.php
@@ -240,14 +240,27 @@ class Omise_FBBot_Message_Store {
 		return __( 'BOOOOOOOOOOOOOOOOOOOO', 'omise' );
 	}
 
+	public static function get_call_shop_owner_success_message() {
+		return __( "😇 Wait a second. I'll let the store owner know that you'd like to talk. \nLeave your message. I'll pass it on. 🙇", 'omise' );
+	}
+
+	public static function get_call_shop_owner_fail_message() {
+		return __( "😞 Sorry but the store owner is not available at the moment. \nLet me help you out or leave your message, i'll pass it on. 😇", 'omise' );
+	}
+
 	public static function get_default_menu_buttons() {
-		$payload = Omise_FBBot_Payload;
+		$feature_products_button = FB_Postback_Button_Item::create( __( 'Featured products', 'omise' ), Omise_FBBot_Payload::FEATURE_PRODUCTS );
+		$category_button = FB_Postback_Button_Item::create( __( 'Product category', 'omise' ), Omise_FBBot_Payload::PRODUCT_CATEGORY );
+		$check_order_button = FB_Postback_Button_Item::create( __( 'Check order status', 'omise' ), Omise_FBBot_Payload::CHECK_ORDER );
+		
+		return array( $feature_products_button, $category_button , $check_order_button );
+	}
 
-		$feature_products_button = FB_Postback_Button_Item::create( __( 'Featured products', 'omise' ), $payload::FEATURE_PRODUCTS );
-		$category_button = FB_Postback_Button_Item::create( __( 'Product category', 'omise' ), $payload::PRODUCT_CATEGORY );
-		$check_order_button = FB_Postback_Button_Item::create( __( 'Check order status', 'omise' ), $payload::CHECK_ORDER );
-		$call_shop_owner_button = FB_Postback_Button_Item::create( __( 'Call shop owner', 'omise' ), $payload::CALL_SHOP_OWNER );
-
+	public static function get_unrecognized_menu_buttons() {
+		$feature_products_button = FB_Postback_Button_Item::create( __( 'Featured products', 'omise' ), Omise_FBBot_Payload::FEATURE_PRODUCTS );
+		$category_button = FB_Postback_Button_Item::create( __( 'Product category', 'omise' ), Omise_FBBot_Payload::PRODUCT_CATEGORY );
+		$call_shop_owner_button = FB_Postback_Button_Item::create( __( 'Talk to store owner', 'omise' ), Omise_FBBot_Payload::CALL_SHOP_OWNER );
+		
 		return array( $feature_products_button, $category_button , $call_shop_owner_button );
 	}
 

--- a/includes/fbbot/class-omise-fbbot-payload.php
+++ b/includes/fbbot/class-omise-fbbot-payload.php
@@ -11,4 +11,5 @@ abstract class Omise_FBBot_Payload {
 	const PRODUCT_CATEGORY = "PAYLOAD_PRODUCT_CATEGORY";
 	const CHECK_ORDER = "PAYLOAD_CHECK_ORDER";
 	const HELP = "PAYLOAD_HELP";
+	const CALL_SHOP_OWNER = "CALL_SHOP_OWNER";
 }

--- a/includes/fbbot/class-omise-fbbot-request-handler.php
+++ b/includes/fbbot/class-omise-fbbot-request-handler.php
@@ -11,15 +11,15 @@ class Omise_FBBot_Request_Handler {
 		// Hide the constructor
 	}
 
-	public static function handle_message_from( $sender_id, $message ) {
+	public static function handle_message_from( $sender_id, $recipient_id, $message ) {
 		$bot = new Omise_FBBot_Conversation_Generator();
-		$bot->listen( $sender_id, $message );
+		$bot->listen( $sender_id, $recipient_id, $message );
 		$response = Omise_FBBot_HTTPService::send_message_to( $sender_id, $bot->reply_for_message() );
 	}
 
-	public static function handle_payload_from( $sender_id, $payload ) {
+	public static function handle_payload_from( $sender_id, $recipient_id, $payload ) {
 		$bot = new Omise_FBBot_Conversation_Generator();
-		$bot->listen_payload( $sender_id, $payload );
+		$bot->listen_payload( $sender_id, $recipient_id, $payload );
 		$response = Omise_FBBot_HTTPService::send_message_to( $sender_id, $bot->reply_for_payload() );
 	}
 

--- a/includes/fbbot/class-omise-fbbot-request-handler.php
+++ b/includes/fbbot/class-omise-fbbot-request-handler.php
@@ -11,15 +11,15 @@ class Omise_FBBot_Request_Handler {
 		// Hide the constructor
 	}
 
-	public static function handle_message_from( $sender_id, $recipient_id, $message ) {
+	public static function handle_message_from( $sender_id, $message ) {
 		$bot = new Omise_FBBot_Conversation_Generator();
-		$bot->listen( $sender_id, $recipient_id, $message );
+		$bot->listen( $sender_id, $message );
 		$response = Omise_FBBot_HTTPService::send_message_to( $sender_id, $bot->reply_for_message() );
 	}
 
-	public static function handle_payload_from( $sender_id, $recipient_id, $payload ) {
+	public static function handle_payload_from( $sender_id, $payload ) {
 		$bot = new Omise_FBBot_Conversation_Generator();
-		$bot->listen_payload( $sender_id, $recipient_id, $payload );
+		$bot->listen_payload( $sender_id, $payload );
 		$response = Omise_FBBot_HTTPService::send_message_to( $sender_id, $bot->reply_for_payload() );
 	}
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -86,7 +86,8 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-wccategory.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-wcproduct.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-entity.php';
-
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/fbbot/class-omise-fbbot-handover-protocol-handler.php';
+		
 		// Messenger Bot Template
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/templates/fbbot/url-button-item.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/templates/fbbot/postback-button-item.php';


### PR DESCRIPTION
#### 1. Objective

Leverage the handover protocol to supplement your bot experience with live chat through the Facebook page inbox

#### 2. Description of change

2.1. Facebook messenger bot with handover protocol

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: WooCommerce 3.1.1.
- **Omise plugin version**: Omise-WooCommerce v3.1.1
- **PHP version**: 5.6.30

#### 4. Impact of the change

No.

#### 5. Priority of change

Normal

#### 6. Additional Notes

- Page admin must set bot to primary receiver and set page inbox to secondary receiver  under Page Settings > Messenger Platform > Subscribed Apps > Role.