### PR TITLE
Chatbot : Setup greeting screen and be able to retrieve Facebook payload and response back

### DIFF
--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -46,13 +46,19 @@ class Omise_Page_Settings {
 		global $title;
 
 		$page = new self;
-
-		// Save settings if data has been posted
-		if ( ! empty( $_POST ) ) {
-			$page->save( $_POST );
-		}
+		$page->update_settings_if_needed();
 
 		include_once __DIR__ . '/views/omise-page-settings.php';
+	}
+
+	protected function update_settings_if_needed() {
+		if ( ! empty( $_POST ) ) {
+			$this->save( $_POST );
+
+			$hook = 'omise_saved_setting' . ( isset( $_POST['omise_setting_tab'] ) ? '_' . $_POST['omise_setting_tab'] : '' );
+
+			do_action( $hook );
+		}
 	}
 
 	/**

--- a/includes/admin/views/omise-page-chatbot-settings.php
+++ b/includes/admin/views/omise-page-chatbot-settings.php
@@ -19,6 +19,8 @@
 </p>
 
 <form method="POST">
+	<input name="omise_setting_tab" type="hidden" value="chatbot" />
+
 	<table class="form-table">
 		<tbody>
 			<tr>

--- a/includes/admin/views/omise-page-payment-settings.php
+++ b/includes/admin/views/omise-page-payment-settings.php
@@ -13,7 +13,10 @@
 	);
 	?>
 </p>
+
 <form method="POST">
+	<input name="omise_setting_tab" type="hidden" value="payment" />
+
 	<table class="form-table">
 		<tbody>
 			<tr>

--- a/includes/chatbot/class-omise-chatbot-facebook-webhook-events.php
+++ b/includes/chatbot/class-omise-chatbot-facebook-webhook-events.php
@@ -1,0 +1,52 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Facebook_Webhook_Events' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Facebook_Webhook_Events {
+	/**
+	 * @var array  of event classes that Chatbot can handle.
+	 */
+	protected $events = array();
+
+	public function __construct() {
+		$events = array(
+			'Omise_Chatbot_Facebook_Webhook_Event_Messages',
+			'Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks',
+		);
+
+		foreach ( $events as $event ) {
+			$clazz = new $event;
+			$this->events[ $clazz->event ] = $clazz;
+		}
+	}
+
+	/**
+	 * Note. It doesn't return anything back because nobody using the result
+	 * unless we have a 'log' system.
+	 *
+	 * @param  mixed $messaging
+	 *
+	 * @return void
+	 */
+	public function handle( $messaging ) {
+		/**
+		 * Subscribes to Message Received events
+		 *
+		 * @see https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/message
+		 */
+		if ( isset( $messaging['message'] ) ) {
+			$this->events['messages']->handle( $messaging );
+
+		/**
+		 * Postback Received events
+		 *
+		 * @see https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_postbacks
+		 */
+		} else if ( isset( $messaging['postback'] ) ) {
+			$this->events['messaging_postbacks']->handle( $messaging );
+		}
+	}
+}

--- a/includes/chatbot/class-omise-chatbot-payloads.php
+++ b/includes/chatbot/class-omise-chatbot-payloads.php
@@ -1,0 +1,10 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Payloads' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Payloads {
+	const GET_START_TAPPED = 'GET_START_TAPPED';
+}

--- a/includes/chatbot/class-omise-chatbot.php
+++ b/includes/chatbot/class-omise-chatbot.php
@@ -1,0 +1,63 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot' ) ) {
+	return;
+}
+
+class Omise_Chatbot extends Omise_Setting {
+	/**
+	 * @var string
+	 */
+	const FACEBOOK_BASE_ENDPOINT    = 'https://graph.facebook.com/v2.6/me';
+	const FACEBOOK_PROFILE_ENDPOINT = 'messenger_profile';
+
+	/**
+	 * @return string
+	 *
+	 * @since  3.2
+	 */
+	protected function get_facebook_endpoint( $endpoint ) {
+		return esc_url(
+			add_query_arg(
+				array( 'access_token' => $this->get_setting( 'chatbot_facebook_page_access_token' ) ),
+				self::FACEBOOK_BASE_ENDPOINT . '/' . $endpoint
+			)
+		);
+	}
+
+	/**
+	 * @return string
+	 *
+	 * @since  3.2
+	 */
+	public function get_facebook_profile_endpoint() {
+		return $this->get_facebook_endpoint( self::FACEBOOK_PROFILE_ENDPOINT );
+	}
+
+	/**
+	 * Setup Facebook Messenger bot.
+	 *
+	 * @see   https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api
+	 *
+	 * @since 3.2
+	 */
+	public function setup() {
+		if ( 'yes' === $this->get_setting( 'chatbot_enabled' ) ) {
+			wp_safe_remote_post(
+				$this->get_facebook_profile_endpoint(),
+				array(
+					'timeout' => 60,
+					'body'    => array(
+						'greeting' => array(
+							array(
+								'locale' => 'default',
+								'text'   => "Hi {{user_first_name}}, welcome to " . get_bloginfo( 'name' )
+							)
+						)
+					)
+				)
+			);
+		}
+	}
+}

--- a/includes/chatbot/class-omise-chatbot.php
+++ b/includes/chatbot/class-omise-chatbot.php
@@ -11,6 +11,7 @@ class Omise_Chatbot extends Omise_Setting {
 	 */
 	const FACEBOOK_BASE_ENDPOINT    = 'https://graph.facebook.com/v2.6/me';
 	const FACEBOOK_PROFILE_ENDPOINT = 'messenger_profile';
+	const FACEBOOK_MESSAGE_ENDPOINT = 'messages';
 
 	/**
 	 * @return string
@@ -36,6 +37,15 @@ class Omise_Chatbot extends Omise_Setting {
 	}
 
 	/**
+	 * @return string
+	 *
+	 * @since  3.2
+	 */
+	public function get_facebook_message_endpoint() {
+		return $this->get_facebook_endpoint( self::FACEBOOK_MESSAGE_ENDPOINT );
+	}
+
+	/**
 	 * Setup Facebook Messenger bot.
 	 *
 	 * @see   https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api
@@ -49,6 +59,9 @@ class Omise_Chatbot extends Omise_Setting {
 				array(
 					'timeout' => 60,
 					'body'    => array(
+						'get_started' => array(
+							'payload' => Omise_Chatbot_Payloads::GET_START_TAPPED
+						),
 						'greeting' => array(
 							array(
 								'locale' => 'default',

--- a/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messages.php
+++ b/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messages.php
@@ -1,0 +1,39 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Facebook_Webhook_Event_Messages' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Facebook_Webhook_Event_Messages {
+	/**
+	 * @var string  of an event name.
+	 */
+	public $event = 'messages';
+
+	/**
+	 * @var Omise_Chatbot
+	 */
+	protected $chatbot;
+
+	/**
+	 * @since 3.2
+	 */
+	public function __construct() {
+		$this->chatbot  = new Omise_Chatbot;
+	}
+
+	/**
+	 * Note. It doesn't return anything back because nobody using the result
+	 * unless we have a 'log' system.
+	 *
+	 * @param  mixed $messaging
+	 *
+	 * @return void
+	 *
+	 * @since 3.2
+	 */
+	public function handle( $messaging ) {
+		return;
+	}
+}

--- a/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
+++ b/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
@@ -1,0 +1,68 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
+	/**
+	 * @var string  of an event name.
+	 */
+	public $event = 'messaging_postbacks';
+
+	/**
+	 * @var Omise_Chatbot
+	 */
+	protected $chatbot;
+
+	/**
+	 * @since 3.2
+	 */
+	public function __construct() {
+		$this->chatbot  = new Omise_Chatbot;
+	}
+
+	/**
+	 * Note. It doesn't return anything back because nobody using the result
+	 * unless we have a 'log' system.
+	 *
+	 * @param  mixed $messaging
+	 *
+	 * @return void
+	 *
+	 * @since 3.2
+	 */
+	public function handle( $messaging ) {
+		// Event payload.
+		$sender_id = $messaging['sender']['id'];
+		$payload   = $messaging['postback']['payload'];
+
+		// TODO: This is just to prove concept, need to find other solution.
+		wp_safe_remote_post(
+			$this->chatbot->get_facebook_message_endpoint(),
+			array(
+				'timeout' => 60,
+				'body'    => array(
+					'recipient' => array('id' => $sender_id),
+					'message'   => array(
+						'attachment' => array(
+							'type'    => 'template',
+							'payload' => array(
+								'template_type' => 'button',
+								'text'          => 'Hello, now you can talk to me :)',
+								'buttons'       => array(
+									array(
+										'type'    => 'postback',
+										'title'   => 'Check Items',
+										'payload' => 'CHECKITEM'
+									)
+								)
+							)
+						)
+					)
+				)
+			)
+		);
+	}
+}

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -49,6 +49,18 @@ class Omise_Setting {
 	}
 
 	/**
+	 * @param  string $field
+	 * @param  mixed  $default
+	 *
+	 * @return array
+	 *
+	 * @since  3.2
+	 */
+	public function get_setting( $field, $default = null ) {
+		return isset( $this->settings[ $field ] ) ? $this->settings[ $field ] : $default;
+	}
+
+	/**
 	 * Returns the payment gateway settings option name
 	 *
 	 * @param  string $payment_id  Payment ID can be found at each of gateway classes (includes/gateway).

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -63,8 +63,11 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
 
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messages.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-endpoint-controller.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-facebook-webhook-events.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-payloads.php';
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -65,6 +65,7 @@ class Omise {
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-endpoint-controller.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-payloads.php';
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -76,8 +76,10 @@ class Omise {
 		add_action( 'plugins_loaded', array( $this, 'load_plugin_textdomain' ), 0 );
 		add_action( 'plugins_loaded', array( $this, 'register_user_agent' ), 10 );
 
-		$chatbot = new Omise_Chatbot;
-		$chatbot->setup();
+		add_action( 'omise_saved_setting_chatbot', function () {
+			$chatbot = new Omise_Chatbot;
+			$chatbot->setup();
+		} );
 
 		$this->init_admin();
 		$this->init_route();

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -63,6 +63,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
 
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-endpoint-controller.php';
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';
@@ -74,6 +75,9 @@ class Omise {
 		add_action( 'plugins_loaded', 'prepare_omise_myaccount_panel', 0 );
 		add_action( 'plugins_loaded', array( $this, 'load_plugin_textdomain' ), 0 );
 		add_action( 'plugins_loaded', array( $this, 'register_user_agent' ), 10 );
+
+		$chatbot = new Omise_Chatbot;
+		$chatbot->setup();
 
 		$this->init_admin();
 		$this->init_route();


### PR DESCRIPTION
> ⚠️ Note that the original PR was PR #58 on `bot` branch.
> This PR aims to do refactoring code based on that original PR because of the plugin structure and some UI have changed.

> ⚠️ This PR is a sub-task of Chatbot feature (main branch is [fbbot](https://github.com/omise/omise-woocommerce/tree/fbbot)) focusing on proving the concept that Omise-WooCommerce plugin can communicate with Facebook Messenger Bot properly via Facebook Webhook feature.

#### 1. Objective

Well, after we have Chatbot setting page and we can setup Chatbot into Facebook Messenger application. Next, we are going to prove that Omise-WooCommerce Chatbot can communicate with Facebook Messenger Bot properly via Facebook Webhook feature.

#### 2. Description of change

1. New endpoint: **`POST`** `wp-json/omise/chatbot/facebook`.
    This endpoint will be an endpoint that Facebook broadcast their Webhook events with.
    By that, means every message events that we subscribed with (see, PR #68, section 3.2) will be broadcasted to this endpoint. That we can determine a response that we want to submit back to Facebook user.

2. Setup greeting screen.
    ![image_uploaded_from_ios](https://user-images.githubusercontent.com/2154669/30737141-c2fe3260-9faf-11e7-97c4-70d8467aeba3.jpg)

3. Now Chatbot can response to `Get Started` button.
    ![image_uploaded_from_ios__1_](https://user-images.githubusercontent.com/2154669/30737261-32aed308-9fb0-11e7-8063-cc2a29c14caf.jpg)

#### 3. Quality assurance

**🔧 Environments:**

- **PHP**: v5.4.45
- **WordPress**: v4.8.2
- **WooCommerce**: v3.1.2

**✏️ Details:**

1. Make sure that Chatbot will be set properly only when setting from Chatbot page is saved and Chatbot itself is enabled at the setting page.

2. Make sure that Chatbot can response with the 'Get Started Tapped' action.

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No