### PR TITLE
Chatbot: Preparing Facebook Messenger template file structure

### DIFF
--- a/includes/chatbot/class-omise-chatbot-client.php
+++ b/includes/chatbot/class-omise-chatbot-client.php
@@ -1,0 +1,62 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Client' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Client {
+	/**
+	 * @param  string $url
+	 * @param  mixed  $body
+	 *
+	 * @return WP_Error|array  The response or WP_Error on failure.
+	 *
+	 * @since  3.2
+	 */
+	public function get( $url, $body = null ) {
+		return wp_safe_remote_get(
+			$url,
+			array(
+				'timeout' => 60,
+				'body'    => $body
+			) 
+		);
+	}
+
+	/**
+	 * @param  string $url
+	 * @param  mixed  $body
+	 *
+	 * @return WP_Error|array  The response or WP_Error on failure.
+	 *
+	 * @since  3.2
+	 */
+	public function post( $url, $body = null ) {
+		return wp_safe_remote_post(
+			$url,
+			array(
+				'timeout' => 60,
+				'body'    => $body
+			) 
+		);
+	}
+
+	/**
+	 * @param  string $url
+	 * @param  mixed  $body
+	 *
+	 * @return WP_Error|array  The response or WP_Error on failure.
+	 *
+	 * @since  3.2
+	 */
+	public function delete( $url, $body = null ) {
+		return wp_remote_request(
+			$url,
+			wp_parse_args(
+				$body,
+				array( 'method' => 'DELETE' )
+			)
+		);
+	}
+}

--- a/includes/chatbot/class-omise-chatbot-payloads.php
+++ b/includes/chatbot/class-omise-chatbot-payloads.php
@@ -6,5 +6,11 @@ if ( class_exists( 'Omise_Chatbot_Payloads' ) ) {
 }
 
 class Omise_Chatbot_Payloads {
-	const GET_START_TAPPED = 'GET_START_TAPPED';
+	/**
+	 * @var string
+	 */
+	const GET_START_TAPPED         = 'GET_START_TAPPED';
+	const ACTION_FEATURED_PRODUCTS = 'ACTION_FEATURED_PRODUCTS';
+	const ACTION_PRODUCT_CATEGORY  = 'ACTION_PRODUCT_CATEGORY';
+	const ACTION_ORDER_STATUS      = 'ACTION_ORDER_STATUS';
 }

--- a/includes/chatbot/class-omise-chatbot.php
+++ b/includes/chatbot/class-omise-chatbot.php
@@ -14,6 +14,17 @@ class Omise_Chatbot extends Omise_Setting {
 	const FACEBOOK_MESSAGE_ENDPOINT = 'messages';
 
 	/**
+	 * @var Omise_Chatbot_Client
+	 */
+	protected $client;
+
+	public function __construct() {
+		parent::__construct();
+
+		$this->client = new Omise_Chatbot_Client;
+	}
+
+	/**
 	 * @return string
 	 *
 	 * @since  3.2
@@ -72,5 +83,30 @@ class Omise_Chatbot extends Omise_Setting {
 				)
 			);
 		}
+	}
+
+	/**
+	 * @return Omise_Chatbot_Client
+	 */
+	public function client() {
+		return $this->client;
+	}
+
+	/**
+	 * @param  string $recipient_id
+	 * @param  string $message
+	 *
+	 * @return WP_Error|array  The response or WP_Error on failure.
+	 *
+	 * @since  3.2
+	 */
+	public function message_to( $recipient_id, $message ) {
+		return $this->client()->post(
+			$this->get_facebook_message_endpoint(),
+			array(
+				'recipient' => array( 'id' => $recipient_id ),
+				'message'   => $message
+			)
+		);
 	}
 }

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-featuredproducts.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-featuredproducts.php
@@ -6,10 +6,6 @@ if ( class_exists( 'Omise_Chatbot_Component_Button_Featuredproducts' ) ) {
 }
 
 class Omise_Chatbot_Component_Button_Featuredproducts extends Omise_Chatbot_Component_Button_Postback {
-	/**
-	 * @param string $title
-	 * @param string $payload
-	 */
 	public function __construct() {
 		$this->attributes['title']   = __( 'Featured products', 'omise' );
 		$this->attributes['payload'] = Omise_Chatbot_Payloads::ACTION_FEATURED_PRODUCTS;

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-featuredproducts.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-featuredproducts.php
@@ -1,0 +1,17 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Button_Featuredproducts' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Component_Button_Featuredproducts extends Omise_Chatbot_Component_Button_Postback {
+	/**
+	 * @param string $title
+	 * @param string $payload
+	 */
+	public function __construct() {
+		$this->attributes['title']   = __( 'Featured products', 'omise' );
+		$this->attributes['payload'] = Omise_Chatbot_Payloads::ACTION_FEATURED_PRODUCTS;
+	}
+}

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-orderstatus.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-orderstatus.php
@@ -6,10 +6,6 @@ if ( class_exists( 'Omise_Chatbot_Component_Button_Orderstatus' ) ) {
 }
 
 class Omise_Chatbot_Component_Button_Orderstatus extends Omise_Chatbot_Component_Button_Postback {
-	/**
-	 * @param string $title
-	 * @param string $payload
-	 */
 	public function __construct() {
 		$this->attributes['title']   = __( 'Check order status', 'omise' );
 		$this->attributes['payload'] = Omise_Chatbot_Payloads::ACTION_ORDER_STATUS;

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-orderstatus.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-orderstatus.php
@@ -1,0 +1,17 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Button_Orderstatus' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Component_Button_Orderstatus extends Omise_Chatbot_Component_Button_Postback {
+	/**
+	 * @param string $title
+	 * @param string $payload
+	 */
+	public function __construct() {
+		$this->attributes['title']   = __( 'Check order status', 'omise' );
+		$this->attributes['payload'] = Omise_Chatbot_Payloads::ACTION_ORDER_STATUS;
+	}
+}

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-postback.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-postback.php
@@ -9,6 +9,9 @@ if ( class_exists( 'Omise_Chatbot_Component_Button_Postback' ) ) {
  * @see https://developers.facebook.com/docs/messenger-platform/send-messages/buttons/postback
  */
 class Omise_Chatbot_Component_Button_Postback extends Omise_Chatbot_Component_Button {
+	/**
+	 * @var array
+	 */
 	protected $attributes = array(
 		'type'    => 'postback',
 		'title'   => '',

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-postback.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-postback.php
@@ -1,0 +1,17 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Button_Postback' ) ) {
+	return;
+}
+
+/**
+ * @see https://developers.facebook.com/docs/messenger-platform/send-messages/buttons/postback
+ */
+class Omise_Chatbot_Component_Button_Postback extends Omise_Chatbot_Component_Button {
+	protected $attributes = array(
+		'type'    => 'postback',
+		'title'   => '',
+		'payload' => ''
+	);
+}

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-productcategory.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-productcategory.php
@@ -6,10 +6,6 @@ if ( class_exists( 'Omise_Chatbot_Component_Button_Productcategory' ) ) {
 }
 
 class Omise_Chatbot_Component_Button_Productcategory extends Omise_Chatbot_Component_Button_Postback {
-	/**
-	 * @param string $title
-	 * @param string $payload
-	 */
 	public function __construct() {
 		$this->attributes['title']   = __( 'Product category', 'omise' );
 		$this->attributes['payload'] = Omise_Chatbot_Payloads::ACTION_PRODUCT_CATEGORY;

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button-productcategory.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button-productcategory.php
@@ -1,0 +1,17 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Button_Productcategory' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Component_Button_Productcategory extends Omise_Chatbot_Component_Button_Postback {
+	/**
+	 * @param string $title
+	 * @param string $payload
+	 */
+	public function __construct() {
+		$this->attributes['title']   = __( 'Product category', 'omise' );
+		$this->attributes['payload'] = Omise_Chatbot_Payloads::ACTION_PRODUCT_CATEGORY;
+	}
+}

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button.php
@@ -1,0 +1,23 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Button' ) ) {
+	return;
+}
+
+/**
+ * @see https://developers.facebook.com/docs/messenger-platform/send-messages/buttons
+ */
+class Omise_Chatbot_Component_Button {
+	protected $attributes = array(
+		'type'    => '',
+		'title'   => ''
+	);
+
+	/**
+	 * @return array  of required attributes for create a button element on Facebook Messenger.
+	 */
+	public function to_array() {
+		return $this->attributes;
+	}
+}

--- a/includes/chatbot/components/buttons/class-omise-chatbot-component-button.php
+++ b/includes/chatbot/components/buttons/class-omise-chatbot-component-button.php
@@ -9,9 +9,12 @@ if ( class_exists( 'Omise_Chatbot_Component_Button' ) ) {
  * @see https://developers.facebook.com/docs/messenger-platform/send-messages/buttons
  */
 class Omise_Chatbot_Component_Button {
+	/**
+	 * @var array
+	 */
 	protected $attributes = array(
-		'type'    => '',
-		'title'   => ''
+		'type'  => '',
+		'title' => ''
 	);
 
 	/**

--- a/includes/chatbot/components/class-omise-chatbot-component-attachment.php
+++ b/includes/chatbot/components/class-omise-chatbot-component-attachment.php
@@ -1,0 +1,39 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Attachment' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Component_Attachment {
+	/**
+	 * @see https://developers.facebook.com/docs/messenger-platform/send-api-reference/contenttypes
+	 *
+	 * @var string  of the following: 'template', 'audio', 'image', 'video', 'file'
+	 */
+	protected $type;
+
+	/**
+	 * @var array
+	 */
+	protected $payload = array();
+
+	/**
+	 * @param array $attributes
+	 */
+	public function payload( $attributes ) {
+		$this->payload = array_merge( $this->payload, $attributes );
+	}
+
+	/**
+	 * @return array  of required attributes for create a button element on Facebook Messenger.
+	 */
+	public function to_array() {
+		return array(
+			'attachment' => array(
+				'type'    => $this->type,
+				'payload' => $this->payload
+			)
+		);
+	}
+}

--- a/includes/chatbot/components/class-omise-chatbot-component-attachment.php
+++ b/includes/chatbot/components/class-omise-chatbot-component-attachment.php
@@ -26,7 +26,7 @@ class Omise_Chatbot_Component_Attachment {
 	}
 
 	/**
-	 * @return array  of required attributes for create a button element on Facebook Messenger.
+	 * @return array  of required attributes for create an element on Facebook Messenger.
 	 */
 	public function to_array() {
 		return array(

--- a/includes/chatbot/components/class-omise-chatbot-component-template.php
+++ b/includes/chatbot/components/class-omise-chatbot-component-template.php
@@ -23,6 +23,9 @@ class Omise_Chatbot_Component_Template extends Omise_Chatbot_Component_Attachmen
 	 */
 	protected $template_payload = array();
 
+	/**
+	 * @return array  of required attributes for create an element on Facebook Messenger.
+	 */
 	public function to_array() {
 		$this->payload(
 			array_merge(

--- a/includes/chatbot/components/class-omise-chatbot-component-template.php
+++ b/includes/chatbot/components/class-omise-chatbot-component-template.php
@@ -1,0 +1,36 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Template' ) ) {
+	return;
+}
+
+class Omise_Chatbot_Component_Template extends Omise_Chatbot_Component_Attachment {
+	/**
+	 * @var string
+	 */
+	protected $type = 'template';
+
+	/**
+	 * @see https://developers.facebook.com/docs/messenger-platform/send-messages/templates
+	 *
+	 * @var string  of the following: 'generic', 'button'
+	 */
+	protected $template_type;
+
+	/**
+	 * @var array
+	 */
+	protected $template_payload = array();
+
+	public function to_array() {
+		$this->payload(
+			array_merge(
+				array( 'template_type' => $this->template_type ),
+				$this->template_payload
+			)
+		);
+
+		return parent::to_array();
+	}
+}

--- a/includes/chatbot/components/class-omise-chatbot-component-text.php
+++ b/includes/chatbot/components/class-omise-chatbot-component-text.php
@@ -1,0 +1,32 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Text' ) ) {
+	return;
+}
+
+/**
+ * @see https://developers.facebook.com/docs/messenger-platform/send-api-reference/text-message
+ */
+class Omise_Chatbot_Component_Text {
+	/**
+	 * @var array
+	 */
+	protected $attributes = array(
+		'text' => ''
+	);
+
+	/**
+	 * @param string $text
+	 */
+	public function set_text( $text ) {
+		$this->attributes['text'] = $text;
+	}
+
+	/**
+	 * @return array  of required attributes for create an element on Facebook Messenger.
+	 */
+	public function to_array() {
+		return $this->attributes;
+	}
+}

--- a/includes/chatbot/components/templates/class-omise-chatbot-component-template-button.php
+++ b/includes/chatbot/components/templates/class-omise-chatbot-component-template-button.php
@@ -1,0 +1,53 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Template_Button' ) ) {
+	return;
+}
+
+/**
+ * @see https://developers.facebook.com/docs/messenger-platform/send-messages/template/button
+ */
+class Omise_Chatbot_Component_Template_Button extends Omise_Chatbot_Component_Template {
+	/**
+	 * @var string
+	 */
+	protected $template_type = 'button';
+
+	/**
+	 * @var array
+	 */
+	protected $template_payload = array(
+		'text'    => '',
+		'buttons' => array()
+	);
+
+	/**
+	 * @param string $text
+	 */
+	public function set_text( $text ) {
+		$this->template_payload['text'] = $text;
+
+		return $this;
+	}
+
+	/**
+	 * @param Omise_Chatbot_Component_Button $button
+	 */
+	public function add_button( Omise_Chatbot_Component_Button $button ) {
+		$this->template_payload['buttons'][] = $button->to_array();
+
+		return $this;
+	}
+
+	/**
+	 * @param array $buttons  of Omise_Chatbot_Component_Button object
+	 */
+	public function add_buttons( array $buttons ) {
+		foreach ( $buttons as $button ) {
+			$this->add_button( $button );
+		}
+
+		return $this;
+	}
+}

--- a/includes/chatbot/components/templates/class-omise-chatbot-component-template-button.php
+++ b/includes/chatbot/components/templates/class-omise-chatbot-component-template-button.php
@@ -32,7 +32,9 @@ class Omise_Chatbot_Component_Template_Button extends Omise_Chatbot_Component_Te
 	}
 
 	/**
-	 * @param Omise_Chatbot_Component_Button $button
+	 * @param  Omise_Chatbot_Component_Button $button
+	 *
+	 * @return self
 	 */
 	public function add_button( Omise_Chatbot_Component_Button $button ) {
 		$this->template_payload['buttons'][] = $button->to_array();
@@ -41,7 +43,9 @@ class Omise_Chatbot_Component_Template_Button extends Omise_Chatbot_Component_Te
 	}
 
 	/**
-	 * @param array $buttons  of Omise_Chatbot_Component_Button object
+	 * @param  array $buttons  of Omise_Chatbot_Component_Button object
+	 *
+	 * @return self
 	 */
 	public function add_buttons( array $buttons ) {
 		foreach ( $buttons as $button ) {

--- a/includes/chatbot/components/templates/class-omise-chatbot-component-template-generic.php
+++ b/includes/chatbot/components/templates/class-omise-chatbot-component-template-generic.php
@@ -1,0 +1,23 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+if ( class_exists( 'Omise_Chatbot_Component_Template_Generic' ) ) {
+	return;
+}
+
+/**
+ * @see https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic
+ */
+class Omise_Chatbot_Component_Template_Generic extends Omise_Chatbot_Component_Template {
+	/**
+	 * @var string
+	 */
+	protected $template_type = 'generic';
+
+	/**
+	 * @var array
+	 */
+	protected $template_payload = array(
+		'elements' => array()
+	);
+}

--- a/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
+++ b/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
@@ -17,10 +17,19 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 	protected $chatbot;
 
 	/**
+	 * @var array
+	 */
+	protected $components;
+
+	/**
 	 * @since 3.2
 	 */
 	public function __construct() {
-		$this->chatbot  = new Omise_Chatbot;
+		$this->chatbot    = new Omise_Chatbot;
+		$this->components = array(
+			'text'            => new Omise_Chatbot_Component_Text,
+			'template_button' => new Omise_Chatbot_Component_Template_Button
+		);
 	}
 
 	/**
@@ -49,24 +58,55 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 	 * @since 3.2
 	 */
 	protected function payload_get_start_tapped( $messaging ) {
+		$this->components['template_button']
+			->set_text( 'I\'m glad you visited How may I assist ?' )
+			->add_buttons(
+				array(
+					new Omise_Chatbot_Component_Button_Featuredproducts,
+					new Omise_Chatbot_Component_Button_Productcategory,
+					new Omise_Chatbot_Component_Button_Orderstatus
+				)
+			);
+
 		$this->chatbot->message_to(
 			$messaging['sender']['id'],
-			array(
-				'attachment' => array(
-					'type'    => 'template',
-					'payload' => array(
-						'template_type' => 'button',
-						'text'          => 'Hello, now you can talk to me :)',
-						'buttons'       => array(
-							array(
-								'type'    => 'postback',
-								'title'   => 'Check Items',
-								'payload' => 'CHECKITEM'
-							)
-						)
-					)
-				)
-			)
+			$this->components['template_button']->to_array()
 		);
+	}
+
+	protected function payload_action_featured_products( $messaging ) {
+		// TODO: This whole code inside this method is just for mock.
+		$this->components['text']->set_text( 'Hey! You just tapped "Featured Products" button.' );
+
+		$this->chatbot->message_to(
+			$messaging['sender']['id'],
+			$this->components['text']->to_array()
+		);
+
+		$this->payload_get_start_tapped( $messaging );
+	}
+
+	protected function payload_action_product_category( $messaging ) {
+		// TODO: This whole code inside this method is just for mock.
+		$this->components['text']->set_text( 'Hey! You just tapped "Product Category" button.' );
+
+		$this->chatbot->message_to(
+			$messaging['sender']['id'],
+			$this->components['text']->to_array()
+		);
+
+		$this->payload_get_start_tapped( $messaging );
+	}
+
+	protected function payload_action_order_status( $messaging ) {
+		// TODO: This whole code inside this method is just for mock.
+		$this->components['text']->set_text( 'Hey! You just tapped "Order Status" button.' );
+
+		$this->chatbot->message_to(
+			$messaging['sender']['id'],
+			$this->components['text']->to_array()
+		);
+
+		$this->payload_get_start_tapped( $messaging );
 	}
 }

--- a/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
+++ b/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
@@ -49,26 +49,19 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 	 * @since 3.2
 	 */
 	protected function payload_get_start_tapped( $messaging ) {
-		// TODO: This is just to prove concept, need to find other solution.
-		wp_safe_remote_post(
-			$this->chatbot->get_facebook_message_endpoint(),
+		$this->chatbot->message_to(
+			$messaging['sender']['id'],
 			array(
-				'timeout' => 60,
-				'body'    => array(
-					'recipient' => array('id' => $messaging['sender']['id']),
-					'message'   => array(
-						'attachment' => array(
-							'type'    => 'template',
-							'payload' => array(
-								'template_type' => 'button',
-								'text'          => 'Hello, now you can talk to me :)',
-								'buttons'       => array(
-									array(
-										'type'    => 'postback',
-										'title'   => 'Check Items',
-										'payload' => 'CHECKITEM'
-									)
-								)
+				'attachment' => array(
+					'type'    => 'template',
+					'payload' => array(
+						'template_type' => 'button',
+						'text'          => 'Hello, now you can talk to me :)',
+						'buttons'       => array(
+							array(
+								'type'    => 'postback',
+								'title'   => 'Check Items',
+								'payload' => 'CHECKITEM'
 							)
 						)
 					)

--- a/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
+++ b/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
@@ -34,17 +34,28 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 	 * @since 3.2
 	 */
 	public function handle( $messaging ) {
-		// Event payload.
-		$sender_id = $messaging['sender']['id'];
-		$payload   = $messaging['postback']['payload'];
+		$payload = strtolower( 'payload_' . $messaging['postback']['payload'] );
 
+		if ( method_exists( $this, $payload ) ) {
+			$this->$payload( $messaging );
+		}
+	}
+
+	/**
+	 * @param  mixed $messaging
+	 *
+	 * @return void
+	 *
+	 * @since 3.2
+	 */
+	protected function payload_get_start_tapped( $messaging ) {
 		// TODO: This is just to prove concept, need to find other solution.
 		wp_safe_remote_post(
 			$this->chatbot->get_facebook_message_endpoint(),
 			array(
 				'timeout' => 60,
 				'body'    => array(
-					'recipient' => array('id' => $sender_id),
+					'recipient' => array('id' => $messaging['sender']['id']),
 					'message'   => array(
 						'attachment' => array(
 							'type'    => 'template',

--- a/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
+++ b/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
@@ -40,7 +40,7 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 	 *
 	 * @return void
 	 *
-	 * @since 3.2
+	 * @since  3.2
 	 */
 	public function handle( $messaging ) {
 		$payload = strtolower( 'payload_' . $messaging['postback']['payload'] );
@@ -55,7 +55,7 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 	 *
 	 * @return void
 	 *
-	 * @since 3.2
+	 * @since  3.2
 	 */
 	protected function payload_get_start_tapped( $messaging ) {
 		$this->components['template_button']
@@ -74,6 +74,13 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 		);
 	}
 
+	/**
+	 * @param  mixed $messaging
+	 *
+	 * @return void
+	 *
+	 * @since  3.2
+	 */
 	protected function payload_action_featured_products( $messaging ) {
 		// TODO: This whole code inside this method is just for mock.
 		$this->components['text']->set_text( 'Hey! You just tapped "Featured Products" button.' );
@@ -86,6 +93,13 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 		$this->payload_get_start_tapped( $messaging );
 	}
 
+	/**
+	 * @param  mixed $messaging
+	 *
+	 * @return void
+	 *
+	 * @since  3.2
+	 */
 	protected function payload_action_product_category( $messaging ) {
 		// TODO: This whole code inside this method is just for mock.
 		$this->components['text']->set_text( 'Hey! You just tapped "Product Category" button.' );
@@ -98,6 +112,13 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 		$this->payload_get_start_tapped( $messaging );
 	}
 
+	/**
+	 * @param  mixed $messaging
+	 *
+	 * @return void
+	 *
+	 * @since  3.2
+	 */
 	protected function payload_action_order_status( $messaging ) {
 		// TODO: This whole code inside this method is just for mock.
 		$this->components['text']->set_text( 'Hey! You just tapped "Order Status" button.' );

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -63,6 +63,16 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
 
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/class-omise-chatbot-component-attachment.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/class-omise-chatbot-component-template.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/class-omise-chatbot-component-text.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/buttons/class-omise-chatbot-component-button.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/buttons/class-omise-chatbot-component-button-postback.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/buttons/class-omise-chatbot-component-button-featuredproducts.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/buttons/class-omise-chatbot-component-button-productcategory.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/buttons/class-omise-chatbot-component-button-orderstatus.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/templates/class-omise-chatbot-component-template-button.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/components/templates/class-omise-chatbot-component-template-generic.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messages.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot.php';

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -66,6 +66,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messages.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-client.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-endpoint-controller.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-facebook-webhook-events.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/chatbot/class-omise-chatbot-payloads.php';


### PR DESCRIPTION
> ⚠️ This PR is a sub-task of Chatbot feature (PR #70)

#### 1. Objective

If we take a look at this document https://developers.facebook.com/docs/messenger-platform/reference/send-api. Facebook has quite complicated (and rich) template structure that allows 3rd-party developer to integrate and customize a message output that Bot will use to reply to a user.

Because of that, we need to carefully implement this part, otherwise it would easily turns to [Spaghetti Code](https://en.wikipedia.org/wiki/Spaghetti_code).
So this PR aims to make clear on a structure that we would go with for the Facebook Messenger Templates _(a bit irony that to solve a complex structure, this PR quite also complex.. any thoughts are welcome!)_.

#### 2. Description of change

- Implement with 2 templates and 1 plain-text content. (generic template and button template)
- Mock an output that we can see how it is going to be used.
    <img width="559" alt="screen shot 2560-09-25 at 7 34 26 pm" src="https://user-images.githubusercontent.com/2154669/30808521-9c518934-a228-11e7-9d1f-460889927dd6.png">

#### 3. Quality assurance

**🔧 Environments:**

- **PHP**: v5.4.45
- **WordPress**: v4.8.2
- **WooCommerce**: v3.1.2

**✏️ Details:**

1. Make sure that these templates can be used by Chatbot properly. (see screenshot at section 2)

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

- An output messages are mock-data. It would be changed in another PR.

- To help demonstrate how these classes related to each others.
Here are outputs of each class when you try initiate its classes.
```php
print_r((new Omise_Chatbot_Component_Attachment)->to_array());
// output
Array(
    [attachment] => Array(
        [type] => 
        [payload] => Array()
    )
)

// Omise_Chatbot_Component_Template extends from Omise_Chatbot_Component_Attachment
print_r((new Omise_Chatbot_Component_Template)->to_array());
// output
Array(
    [attachment] => Array(
        [type] => template
        [payload] => Array(
            [template_type] =>
        )
    )
)

// Omise_Chatbot_Component_Template_Button extends from Omise_Chatbot_Component_Template
print_r((new Omise_Chatbot_Component_Template_Button)->to_array());
// output
Array(
    [attachment] => Array(
        [type] => template
        [payload] => Array(
            [template_type] => button
            [text] => 
            [buttons] => Array()
        )
    )
)
```