### PR TITLE
Chatbot : Display product list under a given category.

### DIFF
--- a/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
+++ b/includes/chatbot/events/class-omise-chatbot-facebook-webhook-event-messaging-postbacks.php
@@ -147,11 +147,21 @@ class Omise_Chatbot_Facebook_Webhook_Event_Messaging_Postbacks {
 	 * @since  3.2
 	 */
 	protected function payload_action_product_list( $messaging ) {
-		$this->components['text']->set_text( 'Hey! You just tapped "View product" button.' );
+		$payload = json_decode( $messaging['postback']['payload'] );
+		$filters = array(
+			'category' => $payload->data->category_slug,
+			'status'   => array( 'publish' )
+		);
+
+		foreach( wc_get_products( $filters ) as $product ) {
+			$this->components['template_generic']->add_element(
+				new Omise_Chatbot_Component_Element_Product( $product )
+			);
+		}
 
 		$this->chatbot->message_to(
 			$messaging['sender']['id'],
-			$this->components['text']->to_array()
+			$this->components['template_generic']->to_array()
 		);
 	}
 


### PR DESCRIPTION
> ⚠️ This PR is a sub-task of Chatbot feature (PR #70)

#### 1. Objective

Continue from PR #74, When you click `View products` button from 'Category List' screen, it should show 'list of product that belongs to that given category'.
This PR aims to finish the remain task from the previous PR (#74)

#### 2. Description of change

1. Proper read payload `action_product_list` and retrieve product list, display on screen.

    <img width="566" alt="screen shot 2560-09-27 at 10 31 47 pm" src="https://user-images.githubusercontent.com/2154669/30922576-be168aae-a3d3-11e7-8302-e0a9e9dac520.png">

#### 3. Quality assurance

**🔧 Environments:**

- **PHP**: v5.4.45
- **WordPress**: v4.8.2
- **WooCommerce**: v3.1.2

**✏️ Details:**

1. Make sure that Chatbot can display product list that belongs to a given category properly when 'View product' button has been clicked from Facebook Messenger.
    1.1 Also, it must show only product that status has set to 'published'.

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No