### PR TITLE
#78 fatal error, if install omise plugin before woo commerce

### DIFF
--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -38,6 +38,18 @@ class Omise {
 		do_action( 'omise_initiated' );
 	}
 
+	/** 
+	 * Plugin Activation Hook to check if WooCommerce is installed
+	 *   
+	 */
+	function activate() {
+		if (!is_plugin_active('woocommerce/woocommerce.php')){
+			deactivate_plugins( basename( __FILE__ ) );
+			wp_die( '<p>The Omise WooCommerce plugin requires <strong>WooCommerce</strong> to be installed and active.</p>',
+						'Plugin Activation Error', array( 'response'=>200, 'back_link'=>true ) );
+		}
+	}
+
 	/**
 	 * @since  3.0
 	 */
@@ -62,6 +74,8 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
 
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';
+
+		register_activation_hook( __FILE__, array( $this, 'activate' ) );
 
 		add_action( 'init', 'register_omise_wc_gateway_post_type' );
 		add_action( 'plugins_loaded', 'register_omise_alipay', 0 );

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -85,7 +85,6 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
-
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';		
 
 		add_action( 'admin_init', array( $this, 'check_woocommerce_active' ) );

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -39,14 +39,15 @@ class Omise {
 	}
 
 	/** 
-	 * Plugin Activation Hook to check if WooCommerce is installed
+	 * Plugin Activation Hook
 	 *   
 	 */
 	function activate() {
+		// check if WooCommerce Plugin is installed and active
 		if (!is_plugin_active('woocommerce/woocommerce.php')){
 			deactivate_plugins( basename( __FILE__ ) );
-			wp_die( '<p>The Omise WooCommerce plugin requires <strong>WooCommerce</strong> to be installed and active.</p>',
-						'Plugin Activation Error', array( 'response'=>200, 'back_link'=>true ) );
+			wp_die( __( '<p>The Omise WooCommerce plugin requires <strong>WooCommerce</strong> to be installed and active.</p>', 'omise' ),
+					__( 'Plugin Activation Error', 'omise'), array( 'response'=>403, 'back_link'=>true ) );
 		}
 	}
 


### PR DESCRIPTION
#### 1. Objective

Fix for #78 Fatal error, if install omise plugin before woo commerce

This section will be used in the release notes. 

#### 2. Description of change

Added hook on admin_init where in callback added detection if WooCommerce plugin is active.
If not than added self-deactivation (Omise WooCommerce Plugin).

Deactivation is done in both cases: 

- when user will activate Omise Plugin in situation when WooCommerce plugin is not active

- when user will deactivate WooCommerce Plugin when both plugins (Omise and WooCommerce) were active.

Added also checking if object WC (WooCommerce) exists when defining OMISE_USER_AGENT_SUFFIX,t o prevent plugin crash in case of deactivating WooCommerce plugin.

#### 3. Quality assurance

Follow instructions from bug report.

**🔧 Environments:**

- **Platform version**: WooCommerce 3.3.4.
- **Omise plugin version**: Omise-WooCommerce 3.1.
- **PHP version**:  5.6.25.

**✏️ Details:**

Follow instructions from bug report.

#### 4. Impact of the change

None

#### 5. Priority of change

Normal.

#### 6. Additional Notes

None