### PR TITLE
Support multi currency

### DIFF
--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -40,8 +40,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	private $currency_subunits = array(
 		'THB' => 100,
 		'JPY' => 1,
-		'SGD' => 100,
-		'IDR' => 100
+		'SGD' => 100
 	);
 
 	/**

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -38,9 +38,12 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @var array
 	 */
 	private $currency_subunits = array(
-		'THB' => 100,
+		'EUR' => 100,
+		'GBP' => 100,
 		'JPY' => 1,
-		'SGD' => 100
+		'SGD' => 100,
+		'THB' => 100,
+		'USD' => 100
 	);
 
 	/**


### PR DESCRIPTION
### 1. Objective

We've got ton of requests asking for using Omise-WooCommerce with `USD`, `EUR`, `GBP` currencies so merchants can expand their market out of Thailand.

So, this PR enables the plugin to be able to charge an order with `USD`, `EUR`, `GBP` currencies.

### 2. Description of change

• Be able to create a charge with either `USD`, `EUR` or `GBP` currencies.

### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v4.9.4.
- **WooCommerce**: WooCommerce 3.3.3.
- **PHP version**: v5.6.30.

**✏️ Details:**

> Note, to test this feature, your Omise account must belongs to Thailand country.

• **Make sure that we can make charge using `USD`, `EUR` or `GBP` currency.**
1. Go to /wp-admin/admin.php?page=wc-settings
2. At the `Setting > General` tab, scroll down to the bottommost of the page, you will see **Currency options** section. Set **Currency** to `USD`
  ![screen shot 2561-04-03 at 13 40 55](https://user-images.githubusercontent.com/2154669/38233438-c5f1d440-3744-11e8-8a77-7092404496fa.png)
3. Try to make order as normal. WooCommerce store should create a new charge with `USD` currency correctly.
  ![screen shot 2561-04-03 at 13 57 01](https://user-images.githubusercontent.com/2154669/38234085-f0ee73fe-3746-11e8-80ed-63a2d0921938.png)
  ![screen shot 2561-04-03 at 13 56 06](https://user-images.githubusercontent.com/2154669/38234028-c86d7042-3746-11e8-9cd3-7714944c6db9.png)

• **Because Omise-WooCommerce plugin supported for Refund feature, so we should make sure that the refund feature can handle those new currencies correctly.**

1. Go to a specific order at the admin page. There will be a refund button in the order detail page.
  ![omise-woocommerce-refund](https://user-images.githubusercontent.com/2154669/38239944-63c137de-3758-11e8-8ad4-e3913b4d01fb.png)
2. Click `refund` button.
  ![omise-woocommerce-refund-2](https://user-images.githubusercontent.com/2154669/38240359-96a2ff24-3759-11e8-9339-b6fb4926f120.png)
  ![omise-woocommerce-refund-3](https://user-images.githubusercontent.com/2154669/38240478-e5898464-3759-11e8-88c8-a863e9a6251c.png)
3. If you check at the Omise Dashboard:
  ![screen shot 2561-04-03 at 16 11 55](https://user-images.githubusercontent.com/2154669/38240499-f34547aa-3759-11e8-80dd-6dd5e453fd76.png)

• **Make sure that `GBP` and `EUR` are work the same as above tests.**
1. Test charge with `GBP`.
  ![screen shot 2561-04-03 at 16 18 08](https://user-images.githubusercontent.com/2154669/38240765-b5373b34-375a-11e8-8790-4ce58782da6b.png)

2. Test charge with `EUR`.
  ![screen shot 2561-04-03 at 16 16 13](https://user-images.githubusercontent.com/2154669/38240792-cb1d3430-375a-11e8-8ed9-fc6add782ac7.png)

• **Make sure that Internet Banking and Alipay will raise an error when try to make a charge with those currencies (those currencies can be used only with Credit Card payment method)**
  ![screen shot 2561-04-03 at 16 20 22](https://user-images.githubusercontent.com/2154669/38240965-2d7fd1a0-375b-11e8-96e6-898d9daef650.png)

### 4. Impact of the change

None

### 5. Priority of change

Normal

### 6. Additional Notes

> **⚠️ Important!**
> This feature can be used with only an Omise account that registered under Thailand country.
> Do not support for Japan and Singapore accounts.

> **⚠️ Important!**
> This feature is **ONLY** work with `Credit Card Payment Method`.