### PR TITLE
✨ Meet, Omise-WooCommerce v3.2 ✨

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Specify the details of your test environments, including, for each, the platform
 
 i.e.
 - **Platform version**: WooCommerce 3.1.1.
-- **Omise plugin version**: Omise-WooCommerce 3.1.
+- **Omise plugin version**: Omise-WooCommerce 3.2.
 - **PHP version**: 7.0.16.
 
 **✏️ Details:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+### [v3.2 _(Apr 20, 2018)_](https://github.com/omise/omise-woocommerce/releases/tag/v3.2)
+
+#### ✨ Highlights
+
+- Support multi currency (PR [#84](https://github.com/omise/omise-woocommerce/pull/84))
+
+#### 🚀 Enhancements
+
+- Remove legacy files and codes (that we no longer use) (PR [#85](https://github.com/omise/omise-woocommerce/pull/85))
+
+#### 👾 Bug Fixes
+
+- Issue #78 fatal error, if install omise plugin before woo commerce (PR [#83](https://github.com/omise/omise-woocommerce/pull/83), [#88](https://github.com/omise/omise-woocommerce/pull/88))
+
+---
+
 ### [v3.1 _(Sep 19, 2017)_](https://github.com/omise/omise-woocommerce/releases/tag/v3.1)
 
 #### ✨ Highlights

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
                     potHeaders: {
                         poedit: false,                  // Includes common Poedit headers.
                         'x-poedit-keywordslist': true,  // Include a list of all possible gettext functions.
-                        'Project-Id-Version': 'Omise Payment Gateway v3.1',
+                        'Project-Id-Version': 'Omise Payment Gateway v3.2',
                         'Report-Msgid-Bugs-To': 'https://github.com/omise/omise-woocommerce/issues'
                     },                                  // Headers to add to the generated POT file.
                     processPot: null,                   // A callback function for manipulating the POT file.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ In order to install Omise-WooCommerce plugin, you can either manually download t
 
 #### Manually
 
-1. Download and extract the zip file from [Omise-WooCommerce](https://github.com/omise/omise-woocommerce/archive/v3.1.zip) to your local machine.
+1. Download and extract the zip file from [Omise-WooCommerce](https://github.com/omise/omise-woocommerce/archive/v3.2.zip) to your local machine.
   ![screen shot 2560-07-26 at 12 36 43 pm](https://user-images.githubusercontent.com/2154669/38302382-ac3b1cf8-382c-11e8-80d4-61e935b7a567.png)
 
-2. Copy all files from the step 1 to WordPress plugin folder, `your-wordpress-dir/wp-content/plugins/omise-woocommerce-3.1`.
+2. Copy all files from the step 1 to WordPress plugin folder, `your-wordpress-dir/wp-content/plugins/omise-woocommerce-3.2`.
 
-3. Rename `omise-woocommerce-3.1` folder to `omise`
+3. Rename `omise-woocommerce-3.2` folder to `omise`
   ![screen shot 2560-07-26 at 12 36 43 pm](https://user-images.githubusercontent.com/2154669/28606035-2b9387dc-71ff-11e7-887d-dc90ce774a39.png)
 
 4. Once done, `Omise Payment Gateway` plugin will be shown at the **Installed Plugins** page. Click `activate` to activate the plugin.

--- a/languages/omise-ja.po
+++ b/languages/omise-ja.po
@@ -1,7 +1,7 @@
 # This file is distributed under the same license as the Omise package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Omise Payment Gateway v3.1\n"
+"Project-Id-Version: Omise Payment Gateway v3.2\n"
 "Report-Msgid-Bugs-To: https://github.com/omise/omise-woocommerce/issues\n"
 "POT-Creation-Date: 2017-07-14 20:17+0700\n"
 "MIME-Version: 1.0\n"

--- a/languages/omise.pot
+++ b/languages/omise.pot
@@ -1,7 +1,7 @@
 # This file is distributed under the same license as the Omise package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Omise Payment Gateway v3.1\n"
+"Project-Id-Version: Omise Payment Gateway v3.2\n"
 "Report-Msgid-Bugs-To: https://github.com/omise/omise-woocommerce/issues\n"
 "POT-Creation-Date: 2017-07-14 13:16:47+00:00\n"
 "MIME-Version: 1.0\n"

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     3.2-dev
+ * Version:     3.2
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -18,7 +18,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '3.2-dev';
+	public $version = '3.2';
 
 	/**
 	 * The Omise Instance.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omise",
   "title": "Omise Payment Gateway",
-  "version": "3.1",
+  "version": "3.2",
   "homepage": "https://www.omise.co/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin
 Requires at least: 4.3.1
 Tested up to: 4.8
-Stable tag: 3.1
+Stable tag: 3.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,20 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 3.2 =
+
+#### ✨ Highlights
+
+- Support multi currency (PR [#84](https://github.com/omise/omise-woocommerce/pull/84))
+
+#### 🚀 Enhancements
+
+- Remove legacy files and codes (that we no longer use) (PR [#85](https://github.com/omise/omise-woocommerce/pull/85))
+
+#### 👾 Bug Fixes
+
+- Issue #78 fatal error, if install omise plugin before woo commerce (PR [#83](https://github.com/omise/omise-woocommerce/pull/83), [#88](https://github.com/omise/omise-woocommerce/pull/88))
 
 = 3.1 =
 


### PR DESCRIPTION
Now Omise-WooCommerce supported `USD`, `GBP`, and `EUR` currencies!
Also, we've cleaned up our code base and fixed issue #78 to make code less complex and keep code maintainable :)) 

**This release contains 3 PRs as below.**

- PR #85 : Remove legacy files and codes (that we no longer use)
- PR #84 : Support multi currency
- PR #83, #88 : Issue #78 fatal error, if install omise plugin before woo commerce

Ready for this!?
And don't forget to check our full-detail [v3.2 release note](https://github.com/omise/omise-woocommerce/releases/tag/v3.2).
Also, feel free to create a [ticket](https://github.com/omise/omise-woocommerce/issues) or leave your comment below if you have any questions.
