### PR TITLE
Fix WooCommerce version number hasn't been shown properly at user-agent

### DIFF
--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -136,7 +136,7 @@ class Omise {
 	public function register_user_agent() {
 		global $wp_version;
 
-		$user_agent = sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, class_exists('WC') ? WC()->version : '' );
+		$user_agent = sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, function_exists('WC') ? WC()->version : '' );
 		defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', $user_agent );
 	}
 


### PR DESCRIPTION
#### 1. Objective

Currently the WooCommerce version number can't be shown at the user-agent.
This PR is bringing the version number back.

![screen shot 2561-04-19 at 00 03 53](https://user-images.githubusercontent.com/2154669/38946943-30575702-4365-11e8-9add-f1944e08b51c.png)

#### 2. Description of change

• At the moment the code does user-agent assignment, check if function WC exists instead of check class existing.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: WooCommerce 3.3.4, WooCommerce 3.3.5.
- **PHP version**: 7.1.16.

**✏️ Details:**

**• Make sure that WooCommerce version number is assigned to USER-AGENT properly when create charges.**

Just make an order as normal, then check at the Omise Dashboard, now we should see 'WooCommerce version number' at the user-agent section of charge's log.

![screen shot 2561-04-19 at 00 06 45](https://user-images.githubusercontent.com/2154669/38947085-ab5c5b64-4365-11e8-8b27-1d3a763c824f.png)
  
#### 4. Impact of the change

No

#### 5. Priority of change

High

#### 6. Additional Notes

No