### PR TITLE
Removing the deprecated function (from jQuery's reported)

### DIFF
--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -32,7 +32,7 @@
 			$card_list = $("input[name='card_id']");
 			$selected_card_id = $("input[name='card_id']:checked");
 			// there is some existing cards but nothing selected then warning
-			if($card_list.size() > 0 && $selected_card_id.size() === 0){
+			if($card_list.length > 0 && $selected_card_id.length === 0){
 				return false;
 			}
 			
@@ -41,7 +41,7 @@
 		
 		function getSelectedCardId(){
 			$selected_card_id = $("input[name='card_id']:checked");
-			if($selected_card_id.size() > 0){
+			if($selected_card_id.length > 0){
 				return $selected_card_id.val();
 			}
 			
@@ -60,7 +60,7 @@
 				return true;
 			}
 			
-			if ( 0 === $( 'input.omise_token' ).size() ) {
+			if ( 0 === $( 'input.omise_token' ).length ) {
 				$form.block({
 					message: null,
 					overlayCSS: {


### PR DESCRIPTION
#### 1. Objective

Buyer can't make a purchase using credit card payment method due to the javascript error in `omise-payment-form-handler.js` file (deprecated function size()).

This pull request is aiming to solve the above issue by replaceing all `.size()` to `.length`.
Ref. https://api.jquery.com/size

_Also note that `.size()` has been deprecated since jQuery v1.8 and been removed after jQuery v3.0._

#### 2. Description of change

- Replacing `.size()` function with `.length` (according to the jQuery deprecated functions).

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**:  v4.9.8.
- **WooCommerce**: v3.4.4.
- **PHP version**: v5.6.30.

**✏️ Details:**

Create a new charge should work properly without a warning message in a console.log.

#### 4. Impact of the change

Nothing

#### 5. Priority of change

Normal

#### 6. Additional Notes

No