### PR TITLE
Upgrade Omise-PHP library from v2.8.0 to v2.11.1.

### DIFF
--- a/includes/libraries/omise-php/CHANGELOG.md
+++ b/includes/libraries/omise-php/CHANGELOG.md
@@ -1,5 +1,66 @@
 # CHANGELOG
 
+### [v2.11.1 _(Jan 16, 2019)_](https://github.com/omise/omise-php/releases/tag/v2.11.1)
+
+#### 👾 Bug Fixes
+
+- Fixes issue with use of array constant (mandated PHP 5.6+). (PR [#106](https://github.com/omise/omise-php/pull/106))
+
+---
+
+### [v2.11.0 _(Jan 9, 2019)_](https://github.com/omise/omise-php/releases/tag/v2.11.0)
+
+#### ✨ Highlights
+
+- Introducing Capability API. (PR [#100](https://github.com/omise/omise-php/pull/100))
+- Officially dropping support of PHP v5.3. (PR [#101](https://github.com/omise/omise-php/pull/101))
+
+---
+
+### [v2.10.0 _(December 2, 2018)_](https://github.com/omise/omise-php/releases/tag/v2.10.0)
+
+#### ✨ Highlights
+
+- Refundable within charge class. (PR [#92](https://github.com/omise/omise-php/pull/92))
+
+#### 🚀 Enhancements
+
+- Be able to filter when retrieving a Refund List from a Charge object. (PR [#91](https://github.com/omise/omise-php/pull/91))
+- OmiseCardList, relocate the card-fetching logic back to its parent class (OmiseCustomer). (PR [#90](https://github.com/omise/omise-php/pull/90))
+- Apply PSR Code Styling Standard to the library. (PR [#89](https://github.com/omise/omise-php/pull/89))
+- Add PHP Code Sniffer 3.x to the composer package. (PR [#88](https://github.com/omise/omise-php/pull/88))
+- Update Composer Spec. (PR [#87](https://github.com/omise/omise-php/pull/87))
+- Upgrade CircleCI to v2. (PR [#82](https://github.com/omise/omise-php/pull/82))
+- Centralising all loaders into one file, `lib/Omise.php`. (PR [#81](https://github.com/omise/omise-php/pull/81))
+- README.md: enhancing 'how-to' and other contents, make it clearer and easy to follow. (PR [#77](https://github.com/omise/omise-php/pull/77))
+
+#### 👾 Bug Fixes
+
+- Fix bug "authentication failed" when executing OmiseTransfer::search(). (PR [#94](https://github.com/omise/omise-php/pull/94))
+
+---
+
+### [v2.9.1 _(March 21, 2018)_](https://github.com/omise/omise-php/releases/tag/v2.9.1)
+
+#### 🚀 Enhancements
+
+- Be able to limit items that will be shown at the Search Object. (PR [#75](https://github.com/omise/omise-php/pull/75))
+
+#### 👾 Bug Fixes
+
+- Fix PHP v7.2 raise a warning message when execute OmiseApiResource::execute() with non-array assigned at the first argument. (PR [#71](https://github.com/omise/omise-php/pull/71), thanks @forfunza)
+
+### [v2.9.0 _(November 6, 2017)_](https://github.com/omise/omise-php/releases/tag/v2.9.0)
+
+#### ✨ Highlights
+
+- Support Omise [Source API](https://www.omise.co/source-api). (PR [#68](https://github.com/omise/omise-php/pull/68))
+- Link to Omise Forum instead of Gitter (deprecate Gitter channel). (PR [#67](https://github.com/omise/omise-php/pull/67))
+
+For more information, please visit https://github.com/omise/omise-php/releases/tag/v2.9.0
+
+---
+
 ### [v2.8.0 _(June 24, 2017)_](https://github.com/omise/omise-php/releases/tag/v2.8.0)
 
 #### ✨ Highlights

--- a/includes/libraries/omise-php/README.md
+++ b/includes/libraries/omise-php/README.md
@@ -1,13 +1,17 @@
 # Omise PHP Client
 
-[![Join the chat at https://gitter.im/omise/omise-php](https://badges.gitter.im/omise/omise-php.svg)](https://gitter.im/omise/omise-php?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![](https://img.shields.io/badge/discourse-forum-1a53f0.svg?style=flat-square&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAqlJREFUKBU9UVtLVFEU%2FvY%2B27mPtxl1dG7HbNRx0rwgFhJBPohBL9JTZfRQ0YO9RU%2FVL6iHCIKelaCXqIewl4gEBbEyxSGxzKkR8TbemmbmnDlzVvsYtOHbey1Y317fWh8DwCVMCfSHww3ElCs7CjuzbOcNIaEo9SbtlDRjZiNPY%2BvrqSWrTh7l3yPvrmh0KBZW59HcREjEqcGpElAuESRxopU648dTwfrIyH%2BCFXSH1cFgJLqHlma6443SG0CfqYY2NZjQnkV8eiMgP6ijjnizHglErlocdl5VA0mT3v102dseL2W14cYM99%2B9XGY%2FlQArd8Mo6JhbSJUePHytvf2UdnW0qen93cKQ4nWXX1%2FyOkZufsuZN0L7PPzkthDDZ4FQLajSA6XWR8HWIK861sCfj68ggGwl83mzfMclBmAQ%2BktrqBu9wOhcD%2BB0ErSiFFyEkdcYhKD27mal9%2F5FY36b4BB%2FTvO8XdQhlUe11F3WG2fc7QLlC8wai3MGGQCGDkcZQyymCqAPSmati3s45ygWseeqADwuWS%2F3wGS5hClDMMstxvJFHQuGU26yHsY6iHtL0sIaOyZzB9hZz0hHZW71kySSl6LIJlSgj5s5LO6VG53aFgpOfOFCyoFmYsOS5HZIaxVwKYsLSbJJn2kfU%2BlNdms5WMLqQRklX0FX26eFRnKYwzX0XRsgR0uUrWxplM7oqPIq8r8cZrdLNLqaABayxZMTTx2HVfglbP4xkcvqZEMNfmglevRi1ny5mGfJfTuQiBEq%2FMBvG0NqDh2TY47sbtJAuO%2Fe9%2Fn3STRFosm2WIxsFSFrFUfwHb11JNBNcaZSp8yb%2FEhHW3suWRNZRzDGvxb0oifk5lmnX2V2J2dEJkX1Q0baZ1MvYXPXHvhAga7x9PTEyj8a%2BF%2BXbxiTn78bSQAAAABJRU5ErkJggg%3D%3D)](https://forum.omise.co)
 
-`omise-php` is Omise API library written in PHP.
+`omise-php` is a library designed specifically to connect with Omise API written in PHP.
+
+Please pop onto our [community forum](https://forum.omise.co) or contact [support@omise.co](mailto:support@omise.co) if you have any question regarding this library and the functionality it provides.
 
 ## Requirements
 
-* PHP 5.3 and above.
-* Built-in libcurl support.
+* PHP v5.4 and above.
+* Built-in [libcurl](http://php.net/manual/en/book.curl.php) support.
+
+> Note that, due to the PHP [END OF LIFE](http://php.net/supported-versions.php) cycle, we encourage you to run Omise-PHP library on a PHP version 5.6 or higher as there is no longer security support for any below 5.6 and that could cause you any security vulnerable issues in the future.
 
 ## Installation
 
@@ -43,7 +47,7 @@ You can install the library via [Composer](https://getcomposer.org/). If you don
 
 ### Manually
 
-If you're not using Composer, you can also download [the latest version of Omise-PHP](https://github.com/omise/omise-php/archive/v2.8.0.zip).
+If you're not using Composer, you can also download [the latest version of Omise-PHP](https://github.com/omise/omise-php/archive/v2.11.1.zip).
 Then, follows the instruction below to install **Omise-PHP** to the project.
 
 1. Extract the library to your project.
@@ -59,84 +63,94 @@ _However, using Composer is recommended as you can easily keep the library up-to
 
 ## Configuration
 
-### Config your public and secret keys
+### • Config your public and secret keys
 
-In order to make any request to Omise API through Omise-PHP library, you will need to config your public and secret key to the project.
-Type the following code in any place before executing the library.
+First thing first, before you make a very-first request to Omise API, you will need to config your public and secret key (can be found at the [Omise Dashboard](https://dashboard.omise.co). Log in then go to **Keys** from the sidebar menu).
+
+Place the following code next to a line where Omise-PHP library is loaded.
 
 ```php
 define('OMISE_PUBLIC_KEY', 'pkey_can_find_at_omise_dashboard');
 define('OMISE_SECRET_KEY', 'skey_can_find_at_omise_dashboard');
 ```
 
-Note, you can get your public and secret keys at Omise Dashboard.
+![configuring omise-php, public and secret keys](https://user-images.githubusercontent.com/2154669/39510239-3f9727b6-4e13-11e8-8930-e3a825c1f07c.png)
 
-_As for reference, you can check our document at [https://www.omise.co/api-authentication](https://www.omise.co/api-authentication)._
+_Reference: [https://www.omise.co/api-authentication](https://www.omise.co/api-authentication)._
 
-### API version
+ー
 
-> This parameter most uses specially for backward-compatible reason, it's not necessary to config when using the library.
-> 
-> **It is highly recommended to set this version to the current version you're using.**  
-> **(or you can just skip this section, Omise will then use your current API version as an default in any requests).**
+### • API version
 
-You can choose which API version to use with Omise. Each API version has new features and might not be compatible with previous versions. You can change the default version by visiting your Omise Dashboard.
-
-To overwrite the API version to use, you can specify it by defining `OMISE_API_VERSION`.  
-The version configured here will have **higher priority** than the version set in your Omise account.
-This is useful if you have multiple environments with different API versions for testing.
-(e.g. Development on the latest version but production is on an older version).
+In case you want to enforce API version the application use, you can specify it by defining the `OMISE_API_VERSION`.  
+The version specified by this settings will override the version setting in your account. This is useful if you have multiple environments with different API versions (e.g. development on the latest but production on the older version).
 
 ```php
-define('OMISE_API_VERSION', '2014-07-27');
+define('OMISE_API_VERSION', '2017-11-02');
 ```
 
-You can check your current API version at Omise Dashboard.
+_API version can be found at [Omise Dashboard](https://dashboard.omise.co). Log in then go to **API versions** from the top-right menu._
 
-![screen shot 2560-03-21 at 4 46 07 pm](https://cloud.githubusercontent.com/assets/2154669/24141410/ef0faf46-0e55-11e7-8e25-26e2a6fc403b.png)
+![configuring omise-php, API version](https://cloud.githubusercontent.com/assets/2154669/24141410/ef0faf46-0e55-11e7-8e25-26e2a6fc403b.png)
+
+> It is highly recommended to set `OMISE_API_VERSION` to the current version that you're using to prevent any trouble from accidentally click update Omise-API version at the dashboard.
 
 ## Quick Start
 
-The following code demonstrates how to make a charge with Omise-PHP library.
-
-Now from the above sections, your code will looks similar like the below.
+From the above sections, your code will look similar like the following code:
 
 ```php
+<?php
 require_once dirname(__FILE__).'/vendor/autoload.php';
 
 define('OMISE_PUBLIC_KEY', 'pkey_test_54ot96fkr3i2op60cng');
 define('OMISE_SECRET_KEY', 'skey_test_54ot96fkr3i2op60cng');
+define('OMISE_API_VERSION', '2017-11-02');
 ```
 
-Now, let's add the below code to create a charge through the library.
+Now, let's add the below code to retrieve your account information:
 
 ```php
-$charge = OmiseCharge::create(array(
-    'amount'   => 100000,
-    'currency' => 'THB',
-    'card'     => 'tokn_test_4xs9408a642a1htto8z'
-));
+$account = OmiseAccount::retrieve();
+
+echo $account['email']; // your email will be printed on a screen.
 ```
 
-To see a real implementation code, you can check from the link below.
-[https://github.com/omise/examples/tree/master/php](https://github.com/omise/examples/tree/master/php)
+And that's it! You have just made a request to Omise API, easy huh?
 
-After this, you can check the complete documentation at [https://www.omise.co/docs](https://www.omise.co/docs). 
+Now you are free from our instruction :D  
+Feel free to integrate Omise Payment Gateway service anyway you like to make it fit with your business flow.  
+Also, stop by [documents](https://www.omise.co/docs) or [example code](https://github.com/omise/examples/tree/master/php) sometime to get more informations if you need any helps.
+
+Have fun!
 
 ## Development and Testing
 
 To run an automated test suite, make sure you already have a [PHPUnit](https://phpunit.de) in your local machine.
 Then run the PHPUnit:
 
-```shell
+```ssh
 phpunit omise-php/tests
 ```
 
-If you want to run with a specific test, let's try
+## Contributing
 
-```bash
-phpunit omise-php/tests/omise/AccountTest
-```
+Thanks for your interest in contributing to Omise PHP. We're looking forward to hearing your thoughts and willing to review your changes.
+
+The following subjects are instructions for contributors who consider to submit changes and/or issues.
+
+### Submit the changes
+
+You're all welcome to submit a pull request.
+Please consider the [pull request template](https://github.com/omise/omise-php/blob/master/.github/PULL_REQUEST_TEMPLATE.md) and fill the form when you submit a new pull request.
+
+Learn more about submitting pull request here: [https://help.github.com/articles/about-pull-requests](https://help.github.com/articles/about-pull-requests)
+
+### Submit the issue
+
+Submit the issue through [GitHub's issue channel](https://github.com/omise/omise-php/issues).
+
+Learn more about submitting an issue here: [https://guides.github.com/features/issues](https://guides.github.com/features/issues)
 
 ## License
 

--- a/includes/libraries/omise-php/lib/Omise.php
+++ b/includes/libraries/omise-php/lib/Omise.php
@@ -1,7 +1,15 @@
 <?php
+// Cores and utilities.
+require_once dirname(__FILE__).'/omise/res/obj/OmiseObject.php';
+require_once dirname(__FILE__).'/omise/res/OmiseApiResource.php';
 
+// Errors
+require_once dirname(__FILE__).'/omise/exception/OmiseExceptions.php';
+
+// API Resources.
 require_once dirname(__FILE__).'/omise/OmiseAccount.php';
 require_once dirname(__FILE__).'/omise/OmiseBalance.php';
+require_once dirname(__FILE__).'/omise/OmiseCapabilities.php';
 require_once dirname(__FILE__).'/omise/OmiseCard.php';
 require_once dirname(__FILE__).'/omise/OmiseCardList.php';
 require_once dirname(__FILE__).'/omise/OmiseDispute.php';
@@ -11,11 +19,14 @@ require_once dirname(__FILE__).'/omise/OmiseToken.php';
 require_once dirname(__FILE__).'/omise/OmiseCharge.php';
 require_once dirname(__FILE__).'/omise/OmiseCustomer.php';
 require_once dirname(__FILE__).'/omise/OmiseOccurrence.php';
+require_once dirname(__FILE__).'/omise/OmiseOccurrenceList.php';
 require_once dirname(__FILE__).'/omise/OmiseRefund.php';
 require_once dirname(__FILE__).'/omise/OmiseRefundList.php';
 require_once dirname(__FILE__).'/omise/OmiseSearch.php';
 require_once dirname(__FILE__).'/omise/OmiseSchedule.php';
+require_once dirname(__FILE__).'/omise/OmiseScheduleList.php';
 require_once dirname(__FILE__).'/omise/OmiseScheduler.php';
+require_once dirname(__FILE__).'/omise/OmiseSource.php';
 require_once dirname(__FILE__).'/omise/OmiseTransfer.php';
 require_once dirname(__FILE__).'/omise/OmiseTransaction.php';
 require_once dirname(__FILE__).'/omise/OmiseRecipient.php';

--- a/includes/libraries/omise-php/lib/omise/OmiseAccount.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseAccount.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseAccount extends OmiseApiResource
 {
     const ENDPOINT = 'account';

--- a/includes/libraries/omise-php/lib/omise/OmiseBalance.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseBalance.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseBalance extends OmiseApiResource
 {
     const ENDPOINT = 'balance';

--- a/includes/libraries/omise-php/lib/omise/OmiseCapabilities.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseCapabilities.php
@@ -1,0 +1,184 @@
+<?php
+
+class OmiseCapabilities extends OmiseApiResource
+{
+    const ENDPOINT = 'capability';
+
+    /**
+     * @var array  of the filterable keys.
+     */
+    static $filters = [
+        'backend' => ['currency', 'type', 'chargeAmount']
+    ];
+
+    protected function __construct($publickey = null, $secretkey = null)
+    {
+        parent::__construct($publickey, $secretkey);
+        $this->setupFilterShortcuts();
+    }
+
+    /**
+     * Sets up 'shortcuts' to filters so they may be used thus:
+     *    $capabilities->backendFilter['currency']('THB')
+     * As well as the original:
+     *    $capabilities->makeBackendFilterCurrency('THB')
+     */
+    protected function setupFilterShortcuts()
+    {
+        foreach (self::$filters as $filterSubject => $availableFilters) {
+            $filterArrayName = $filterSubject . 'Filter';
+            $this->$filterArrayName = [];
+            $tempArr = &$this->$filterArrayName;
+            foreach ($availableFilters as $type) {
+                $funcName = 'make' . ucfirst($filterSubject) . 'Filter' . $type;
+                $tempArr[$type] = function () use ($funcName) {
+                    return call_user_func_array([$this, $funcName], func_get_args());
+                };
+            }
+        }
+    }
+
+    /**
+     * Retrieves capabilities.
+     *
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseCapabilities
+     */
+    public static function retrieve($publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl(), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        parent::g_reload(self::getUrl());
+    }
+
+    /**
+     * Retrieves array of payment backends. Optionally pass in as many filter functions as you want
+     * (muliple arguments, or a single array)
+     *
+     * @param [func1,fun2,...] OR func1, func2,...
+     *
+     * @return array
+     */
+    public function getBackends()
+    {
+        $backends = array_map(
+            function ($backend) {
+                $new = (object)(array_merge(reset($backend), ['_id'=>array_keys($backend)[0]]));
+                return $new;
+            },
+            $this['payment_backends']
+        );
+        // return backends (filtered if requested)
+        return ($filters = func_get_args()) ? array_filter($backends, self::combineFilters(self::argsToVariadic($filters))) : $backends;
+    }
+
+    /**
+     * Makes a filter function to check supported currency for backend.
+     *
+     * @param  string $currency
+     *
+     * @return function
+     */
+    public function makeBackendFilterCurrency($currency)
+    {
+        return function ($backend) use ($currency) {
+            return in_array(strtolower($currency), array_map('strtolower', $backend->currencies));
+        };
+    }
+
+    /**
+     * Makes a filter function to check type of backend.
+     *
+     * @param  string $type
+     *
+     * @return function
+     */
+    public function makeBackendFilterType($type)
+    {
+        return function ($backend) use ($type) {
+            return $backend->type == $type;
+        };
+    }
+
+    /**
+     * Makes a filter function to check if backends can handle given amount.
+     *
+     * @param  int $amount
+     *
+     * @return function
+     */
+    public function makeBackendFilterChargeAmount($amount)
+    {
+        $defMin = $this['limits']['charge_amount']['min'];
+        $defMax = $this['limits']['charge_amount']['max'];
+        return function ($backend) use ($amount, $defMin, $defMax) {
+            // temporary hack for now to correct min value for instalments to 500000
+            if ($backend->type == 'installment') {
+                $min = 500000;
+            } else {
+                $min = empty($backend->amount['min']) ? $defMin : $backend->amount['min'];
+            }
+            $max = empty($backend->amount['max']) ? $defMax : $backend->amount['max'];
+            return $amount >= $min && $amount <= $max;
+        };
+    }
+
+    /**
+     * Combines boolean filters.
+     *
+     * @param  [functions] $filters
+     *
+     * @return function
+     */
+    private static function combineFilters($filters)
+    {
+        return function ($value) use ($filters) {
+            foreach ($filters as $filter) {
+                if (!$filter($value)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+
+    /**
+     * Converts args to variadic fashion, rather than as a single array
+     *
+     * @param  [functions] $filters
+     *
+     * @return function
+     */
+    private static function argsToVariadic($argArray)
+    {
+        return count($argArray) == 1 && is_array($argArray[0]) ? $argArray[0] : $argArray;
+    }
+
+    /**
+     * @return string
+     */
+    private static function getUrl()
+    {
+        return OMISE_API_URL . self::ENDPOINT;
+    }
+
+    /**
+     * Returns the public key.
+     *
+     * @return string
+     */
+    protected function getResourceKey()
+    {
+        return $this->_publickey;
+    }
+}

--- a/includes/libraries/omise-php/lib/omise/OmiseCard.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseCard.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCustomer.php';
-
 class OmiseCard extends OmiseApiResource
 {
     const ENDPOINT = 'cards';

--- a/includes/libraries/omise-php/lib/omise/OmiseCardList.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseCardList.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCard.php';
-
 class OmiseCardList extends OmiseApiResource
 {
     const ENDPOINT = 'cards';
@@ -15,16 +12,11 @@ class OmiseCardList extends OmiseApiResource
      * @param string $publickey
      * @param string $secretkey
      */
-    public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
+    public function __construct($cards, $customerID, $publickey = null, $secretkey = null)
     {
         parent::__construct($publickey, $secretkey);
         $this->_customerID = $customerID;
-
-        if (is_array($options) && ! empty($options)) {
-            parent::g_reload($this->getUrl('?'.http_build_query($options)));
-        } else {
-            $this->refresh($cards);
-        }
+        $this->refresh($cards);
     }
   
     /**

--- a/includes/libraries/omise-php/lib/omise/OmiseCharge.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseCharge.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseRefundList.php';
-require_once dirname(__FILE__).'/OmiseScheduleList.php';
-
 class OmiseCharge extends OmiseApiResource
 {
     const ENDPOINT = 'charges';
@@ -102,6 +98,17 @@ class OmiseCharge extends OmiseApiResource
     }
 
     /**
+     * Refund a charge.
+     *
+     * @return OmiseRefund
+     */
+    public function refund($params)
+    {
+        $result = parent::execute(self::getUrl($this['id']) . '/refunds', parent::REQUEST_POST, parent::getResourceKey(), $params);
+        return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
+    }
+
+    /**
      * Reverses a charge.
      *
      * @return OmiseCharge
@@ -119,11 +126,15 @@ class OmiseCharge extends OmiseApiResource
      *
      * @return OmiseRefundList
      */
-    public function refunds()
+    public function refunds($options = array())
     {
-        $result = parent::execute(self::getUrl($this['id']).'/refunds', parent::REQUEST_GET, parent::getResourceKey());
+        if (is_array($options) && ! empty($options)) {
+            $refunds = parent::execute(self::getUrl($this['id']) . '/refunds?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
+        } else {
+            $refunds = $this['refunds'];
+        }
 
-        return new OmiseRefundList($result, $this['id'], $this->_publickey, $this->_secretkey);
+        return new OmiseRefundList($refunds, $this['id'], $this->_publickey, $this->_secretkey);
     }
 
     /**

--- a/includes/libraries/omise-php/lib/omise/OmiseCustomer.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseCustomer.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCardList.php';
-require_once dirname(__FILE__).'/OmiseScheduleList.php';
-
 class OmiseCustomer extends OmiseApiResource
 {
     const ENDPOINT = 'customers';
@@ -103,9 +99,13 @@ class OmiseCustomer extends OmiseApiResource
      */
     public function cards($options = array())
     {
-        if ($this['object'] === 'customer') {
-            return new OmiseCardList($this['cards'], $this['id'], $options, $this->_publickey, $this->_secretkey);
+        if (is_array($options) && ! empty($options)) {
+            $cards = parent::execute(self::getUrl($this['id']) . '/cards?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
+        } else {
+            $cards = $this['cards'];
         }
+
+        return new OmiseCardList($cards, $this['id'], $this->_publickey, $this->_secretkey);
     }
   
     /**

--- a/includes/libraries/omise-php/lib/omise/OmiseDispute.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseDispute.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseDispute extends OmiseApiResource
 {
     const ENDPOINT = 'disputes';

--- a/includes/libraries/omise-php/lib/omise/OmiseEvent.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseEvent.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseEvent extends OmiseApiResource
 {
     const ENDPOINT = 'events';

--- a/includes/libraries/omise-php/lib/omise/OmiseForex.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseForex.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseForex extends OmiseApiResource
 {
     const ENDPOINT = 'forex';

--- a/includes/libraries/omise-php/lib/omise/OmiseLink.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseLink.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseLink extends OmiseApiResource
 {
     const ENDPOINT = 'links';

--- a/includes/libraries/omise-php/lib/omise/OmiseOccurrence.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseOccurrence.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseOccurrence extends OmiseApiResource
 {
     const ENDPOINT = 'occurrences';

--- a/includes/libraries/omise-php/lib/omise/OmiseOccurrenceList.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseOccurrenceList.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseOccurrenceList extends OmiseApiResource
 {
     /**

--- a/includes/libraries/omise-php/lib/omise/OmiseRecipient.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseRecipient.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseRecipient extends OmiseApiResource
 {
     const ENDPOINT = 'recipients';

--- a/includes/libraries/omise-php/lib/omise/OmiseRefund.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseRefund.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseRefund extends OmiseApiResource
 {
     /**

--- a/includes/libraries/omise-php/lib/omise/OmiseRefundList.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseRefundList.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseRefund.php';
-
 class OmiseRefundList extends OmiseApiResource
 {
     const ENDPOINT = 'refunds';

--- a/includes/libraries/omise-php/lib/omise/OmiseSchedule.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseSchedule.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseOccurrenceList.php';
-
 class OmiseSchedule extends OmiseApiResource
 {
     const ENDPOINT = 'schedules';

--- a/includes/libraries/omise-php/lib/omise/OmiseScheduleList.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseScheduleList.php
@@ -1,16 +1,14 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseScheduleList extends OmiseApiResource
 {
-	/**
-	 * @param  string $id
-	 *
-	 * @return OmiseOccurrence
-	 */
-	public function retrieve($id)
-	{
-	    return OmiseSchedule::retrieve($id, $this->_publickey, $this->_secretkey);
-	}
+    /**
+     * @param  string $id
+     *
+     * @return OmiseOccurrence
+     */
+    public function retrieve($id)
+    {
+        return OmiseSchedule::retrieve($id, $this->_publickey, $this->_secretkey);
+    }
 }

--- a/includes/libraries/omise-php/lib/omise/OmiseScheduler.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseScheduler.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseScheduler extends OmiseApiResource
 {
     private $attributes = array();

--- a/includes/libraries/omise-php/lib/omise/OmiseSearch.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseSearch.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 /**
  * This class is not intended to be used directly from client code.
  *
@@ -96,6 +94,18 @@ class OmiseSearch extends OmiseApiResource
     public function page($page)
     {
         return $this->mergeAttributes('page', $page);
+    }
+
+    /**
+     * Update `per_page` parameter.
+     *
+     * @param  int $limit   Number of items that will be shown per page.
+     *
+     * @return OmiseSearch  This instance.
+     */
+    public function per_page($limit)
+    {
+        return $this->mergeAttributes('per_page', $limit);
     }
 
     /**

--- a/includes/libraries/omise-php/lib/omise/OmiseSource.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseSource.php
@@ -1,0 +1,28 @@
+<?php
+
+class OmiseSource extends OmiseApiResource
+{
+    const ENDPOINT = 'sources';
+
+    /**
+     * Creates a new source.
+     *
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseSource
+     */
+    public static function create($params, $publickey = null, $secretkey = null)
+    {
+        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * @return string
+     */
+    private static function getUrl()
+    {
+        return OMISE_API_URL.self::ENDPOINT;
+    }
+}

--- a/includes/libraries/omise-php/lib/omise/OmiseTest.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseTest extends OmiseApiResource
 {
     /**

--- a/includes/libraries/omise-php/lib/omise/OmiseTransaction.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseTransaction.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseTransaction extends OmiseApiResource
 {
     const ENDPOINT = 'transactions';

--- a/includes/libraries/omise-php/lib/omise/OmiseTransfer.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseTransfer.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
-require_once dirname(__FILE__).'/OmiseScheduleList.php';
-
 class OmiseTransfer extends OmiseApiResource
 {
     const ENDPOINT = 'transfers';
@@ -31,7 +27,7 @@ class OmiseTransfer extends OmiseApiResource
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = '', $secretkey = '')
+    public static function search($query = '', $publickey = null, $secretkey = null)
     {
         return OmiseSearch::scope('transfer', $publickey, $secretkey)->query($query);
     }

--- a/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
+++ b/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
@@ -1,9 +1,6 @@
 <?php
 
-require_once dirname(__FILE__).'/obj/OmiseObject.php';
-require_once dirname(__FILE__).'/../exception/OmiseExceptions.php';
-
-define('OMISE_PHP_LIB_VERSION', '2.8.0');
+define('OMISE_PHP_LIB_VERSION', '2.11.1');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
@@ -147,16 +144,28 @@ class OmiseApiResource extends OmiseObject
         $array = json_decode($result, true);
 
         // If response is invalid or not a JSON.
-        if (count($array) === 0 || ! isset($array['object'])) {
+        if (!$this->isValidAPIResponse($array)) {
             throw new Exception('Unknown error. (Bad Response)');
         }
 
         // If response is an error object.
-        if ($array['object'] === 'error') {
+        if (!empty($array['object']) && $array['object'] === 'error') {
             throw OmiseException::getInstance($array);
         }
 
         return $array;
+    }
+
+    /**
+     * Checks if response from API was valid.
+     *
+     * @param  array  $array  - decoded JSON response
+     *
+     * @return boolean
+     */
+    protected function isValidAPIResponse($array)
+    {
+        return count($array) && isset($array['object']);
     }
 
     /**
@@ -292,7 +301,7 @@ class OmiseApiResource extends OmiseObject
         }
 
         // Also merge POST parameters with the option.
-        if (count($params) > 0) {
+        if (is_array($params) && count($params) > 0) {
             $http_query = http_build_query($params);
             $http_query = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $http_query);
 

--- a/includes/libraries/omise-php/lib/omise/res/OmiseVaultResource.php
+++ b/includes/libraries/omise-php/lib/omise/res/OmiseVaultResource.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/OmiseApiResource.php';
-
 class OmiseVaultResource extends OmiseApiResource
 {
     /**


### PR DESCRIPTION
#### 1. Objective

According to the plan for the coming **Omise-WooCommerce v3.3.**
We have decided to add Installment payment method feature to the plugin.

By achieving that, we will need to use a new API from Omise, Capability API, which has been introduced in Omise-PHP since version **2.11.0**.

This pull request is aiming to upgrade Omise-PHP library to the latest version for the sake of using Capability API.

#### 2. Description of change

This pull request is huge as it removes all of Omise-PHP necessary files from the project, and then adds it back. But the actual changes were these commands:
```bash
# Removes lib, CHANGELOG.md, and READMD.md.
rm -R omise-woocommerce/includes/libraries/omise-php/lib
rm -R omise-woocommerce/includes/libraries/omise-php/CHANGELOG.md 
rm -R omise-woocommerce/includes/libraries/omise-php/README.md 

# Then copies those 1 folder and 2 files from Omise-PHP v2.11.1 to replace those files that are deleted from the above step.
cp -R ~/omise-php-2.11.1/lib omise-woocommerce/includes/libraries/omise-php/
cp -R ~/omise-php-2.11.1/CHANGELOG.md omise-woocommerce/includes/libraries/omise-php/
cp -R ~/omise-php-2.11.1/README.md omise-woocommerce/includes/libraries/omise-php/
```

So first I remove `lib` folder, `CHANGELOG.md`, and `README.md` from Omise-WooCommerce.
Then download Omise-PHP v2.11.1 and copy all files back to the plugin folder.

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.0.3
- **WooCommerce**: v3.5.3
- **PHP version**: v5.6.30

**✏️ Details:**

- Functionality tests, create a new charge, refund a charge to make sure that this upgrading won't effect any of the current functionalities.

_Charge is successfully created with `auth-only`._ 👇 

<img width="799" alt="screen shot 2562-01-17 at 10 41 09" src="https://user-images.githubusercontent.com/2154669/51294192-72585280-1a44-11e9-8bd6-7c15f03f1203.png">

_Charge is successfully captured and refunded._ 👇

<img width="1440" alt="screen shot 2562-01-17 at 10 44 07" src="https://user-images.githubusercontent.com/2154669/51294282-d549e980-1a44-11e9-8e9a-a177f0903d6d.png">


#### 4. Impact of the change

According to Omise-PHP v2.11.0. Now Omise-WooCommerce support only PHP v5.4 and above.

> Note: WooCommerce has been recommending users to use PHP version 7 or greater already.
> Ref: https://docs.woocommerce.com/document/server-requirements

#### 5. Priority of change

Normal

#### 6. Additional Notes

No