### PR TITLE
Refactoring plugin-initial code structure - part 2: Relocating, renaming functions and method.

### DIFF
--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -674,17 +674,3 @@ function register_omise_creditcard() {
 		add_filter( 'woocommerce_payment_gateways', 'add_omise_creditcard' );
 	}
 }
-
-function register_omise_wc_gateway_post_type() {
-	register_post_type(
-		'omise_charge_items',
-		array(
-			'supports' => array('title','custom-fields'),
-			'label'    => 'Omise Charge Items',
-			'labels'   => array(
-				'name'          => 'Omise Charge Items',
-				'singular_name' => 'Omise Charge Item'
-			)
-		)
-	);
-}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -80,10 +80,38 @@ class Omise {
 			return;
 		}
 
+		$this->define_constants();
+		$this->include_classes();
+
+		register_omise_wc_gateway_post_type();
+		register_omise_alipay();
+		register_omise_creditcard();
+		register_omise_internetbanking();
+		prepare_omise_myaccount_panel();
+		$this->load_plugin_textdomain();
+
+		$this->init_admin();
+		$this->init_route();
+	}
+
+	/**
+	 * Define Omise necessary constants.
+	 *
+	 * @since 3.3
+	 */
+	private function define_constants() {
+		global $wp_version;
+
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION', $this->version );
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_PATH' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_PATH', __DIR__ );
 		defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2014-07-27' );
+		defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, WC()->version ) );
+	}
 
+	/**
+	 * @since 3.3
+	 */
+	private function include_classes() {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-charge.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-card-image.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-capture.php';
@@ -98,18 +126,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
-		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';		
-
-		register_omise_wc_gateway_post_type();
-		register_omise_alipay();
-		register_omise_creditcard();
-		register_omise_internetbanking();
-		prepare_omise_myaccount_panel();
-		$this->load_plugin_textdomain();
-		$this->register_user_agent();
-
-		$this->init_admin();
-		$this->init_route();
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';
 	}
 
 	/**
@@ -140,16 +157,6 @@ class Omise {
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain( 'omise', false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
-	}
-
-	/**
-	 * @since  3.0
-	 */
-	public function register_user_agent() {
-		global $wp_version;
-
-		$user_agent = sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, function_exists('WC') ? WC()->version : '' );
-		defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', $user_agent );
 	}
 
 	/**

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -47,19 +47,6 @@ class Omise {
 	}
 
 	/** 
-	 * Callback to display message about activation error
-	 * 
-	 * @since  3.2
-	 */
-	public function init_error_messages(){
-		?>
-		<div class="error">
-			<p><?php echo __( 'The Omise WooCommerce plugin requires <strong>WooCommerce</strong> to be activated.', 'omise' ); ?></p>
-		</div>
-		<?php
-	}
-
-	/** 
 	 * Check if all dependencies are loaded
 	 * properly before Omise-WooCommerce.
 	 * 
@@ -84,17 +71,28 @@ class Omise {
 
 		$this->define_constants();
 		$this->include_classes();
+		$this->load_plugin_textdomain();
+		$this->register_post_types();
+		$this->init_admin();
+		$this->init_route();
 
 		register_omise_alipay();
 		register_omise_creditcard();
 		register_omise_internetbanking();
 		prepare_omise_myaccount_panel();
+	}
 
-		$this->load_plugin_textdomain();
-		$this->register_post_types();
-
-		$this->init_admin();
-		$this->init_route();
+	/**
+	 * Callback to display message about activation error
+	 *
+	 * @since  3.2
+	 */
+	public function init_error_messages(){
+		?>
+		<div class="error">
+			<p><?php echo __( 'Omise WooCommerce plugin requires <strong>WooCommerce</strong> to be activated.', 'omise' ); ?></p>
+		</div>
+		<?php
 	}
 
 	/**

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -40,8 +40,8 @@ class Omise {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		add_action( 'plugins_loaded', array( $this, 'check_woocommerce_active' ) );
-		add_action( 'init', array( $this, 'initiate' ) );
+		add_action( 'plugins_loaded', array( $this, 'check_dependencies' ) );
+		add_action( 'init', array( $this, 'init' ) );
 
 		do_action( 'omise_initiated' );
 	}
@@ -51,7 +51,7 @@ class Omise {
 	 * 
 	 * @since  3.2
 	 */
-	public function woocommerce_plugin_notice(){
+	public function init_error_messages(){
 		?>
 		<div class="error">
 			<p><?php echo __( 'The Omise WooCommerce plugin requires <strong>WooCommerce</strong> to be activated.', 'omise' ); ?></p>
@@ -60,23 +60,25 @@ class Omise {
 	}
 
 	/** 
-	 * Callback checking if WooCommerce is active
+	 * Check if all dependencies are loaded
+	 * properly before Omise-WooCommerce.
 	 * 
 	 * @since  3.2
 	 */
-	public function check_woocommerce_active() {
-		if ( function_exists( 'WC' ) ) {
-			static::$can_initiate = true;
+	public function check_dependencies() {
+		if ( ! function_exists( 'WC' ) ) {
 			return;
 		}
+
+		static::$can_initiate = true;
 	}
 
 	/**
 	 * @since  3.0
 	 */
-	public function initiate() {
+	public function init() {
 		if ( ! static::$can_initiate ) {
-			add_action( 'admin_notices', array($this, 'woocommerce_plugin_notice') );
+			add_action( 'admin_notices', array($this, 'init_error_messages') );
 			return;
 		}
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -83,12 +83,13 @@ class Omise {
 		$this->define_constants();
 		$this->include_classes();
 
-		register_omise_wc_gateway_post_type();
 		register_omise_alipay();
 		register_omise_creditcard();
 		register_omise_internetbanking();
 		prepare_omise_myaccount_panel();
+
 		$this->load_plugin_textdomain();
+		$this->register_post_types();
 
 		$this->init_admin();
 		$this->init_route();
@@ -177,6 +178,31 @@ class Omise {
 		$order_actions[ $payment_method . '_sync_payment'] = __( 'Omise: Manual sync payment status', 'omise' );
 
 		return $order_actions;
+	}
+
+	/**
+	 * Register necessary post-types
+	 *
+	 * @deprecated 3.0  Omise-WooCommerce was once storing Omise's charge id
+	 *                  with WooCommerce's order id together in a
+	 *                  customed-post-type, 'omise_charge_items'.
+	 *
+	 *                  Since Omise-WooCoomerce v3.0, now the plugin stores
+	 *                  Omise's charge id as a 'customed-post-meta' in the
+	 *                  WooCommerce's 'order' post-type instead.
+	 */
+	public function register_post_types() {
+		register_post_type(
+			'omise_charge_items',
+			array(
+				'supports' => array('title','custom-fields'),
+				'label'    => 'Omise Charge Items',
+				'labels'   => array(
+					'name'          => 'Omise Charge Items',
+					'singular_name' => 'Omise Charge Item'
+				)
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
> :warning: Important: This pull request requires **#94: "Refactoring plugin-initial code structure, part 1"** to be merged first.
#### 1. Objective

Omise-WooCommerce has always been coupled with WooCommerce plugin, which the plugin cannot be used as a stand-alone plugin and always require WooCommerce plugin to be activated first. 
However, the legacy-codebase itself wasn't really aware of a case where WooCommerce plugin is disabled as much as it should be.

Although we have prevented such cases #78, and #83. But by the current design of the plugin-initial step, it still remains some issue (#90) that could be ceased out by redesigning the initial-step with a proper awareness of WooCommerce plugin.

**Related issue(s)**:
- #90 Omise-WooCommerce 3.2 can't be activated.

#### 2. Description of change

#### Part 1

See, **#94: "Refactoring plugin-initial code structure - part 1: Enhancing the behavior of checking dependency plugin"**

#### Part 2

Chore works in part 2:
Relocating functions, renaming method names to be more generic, and grouping code to a proper place (method).

#### Part 3

See, **#96: "Refactoring plugin-initial code structure - part 3: Organizing Omise_Admin class."**

### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.0.3
- **WooCommerce**: v3.5.3
- **PHP version**: v5.6.30

**✏️ Details:**

The main test-case will be separated into 3 cases as follows:
1. Attempting to install Omise-WooCommerce without WooCommerce should give you a warning message that **Omise-WooCommerce requires WooCommerce plugin to be activated first.**
**Omise-WooCommerce** plugin can be activated, but all functions should be disabled, including no Omise menu at the WordPress admin-sidebar.
<img width="1552" alt="screen shot 2562-01-18 at 00 12 26" src="https://user-images.githubusercontent.com/2154669/51335929-d9fab600-1ab5-11e9-84e0-e471c0da4ea2.png">

2. Install Omise-WooCommere plugin while WooCommerce plugin is enabled should give you a full-access to all Omise-WooCommerce feature, including the setting page.
<img width="1552" alt="screen shot 2562-01-17 at 23 32 33" src="https://user-images.githubusercontent.com/2154669/51333417-378c0400-1ab0-11e9-9b06-9af6075853af.png">

3. Attempting to disable WooCommerce plugin while Omise-WooCommerce is still enabled should give you a same result as the case [1].
<img width="1552" alt="screen shot 2562-01-18 at 00 12 26" src="https://user-images.githubusercontent.com/2154669/51335929-d9fab600-1ab5-11e9-84e0-e471c0da4ea2.png">

4. After the change, charge must be created, captured, refunded as usual.

### 4. Impact of the change

No

### 5. Priority of change

Normal

### 6. Additional Notes

No
