### PR TITLE
Refactoring plugin-initial code structure - part 3: Organizing Omise_Admin class

### DIFF
--- a/includes/class-omise-admin.php
+++ b/includes/class-omise-admin.php
@@ -33,10 +33,6 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		 * @return void
 		 */
 		public function register_admin_menu() {
-			if ( ! current_user_can( 'manage_options' ) ) {
-				return;
-			}
-
 			add_action( 'admin_menu', array( $this, 'wordpress_hook_admin_menu' ) );
 		}
 

--- a/includes/class-omise-admin.php
+++ b/includes/class-omise-admin.php
@@ -6,10 +6,13 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		/**
 		 * The Omise Instance.
 		 *
-		 * @var   \Omise_Admin
+		 * @var \Omise_Admin
 		 */
 		protected static $the_instance;
 
+		/**
+		 * @return \Omise_Admin  The instance.
+		 */
 		public static function get_instance() {
 			if ( ! self::$the_instance ) {
 				self::$the_instance = new self();
@@ -29,16 +32,15 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		}
 
 		/**
-		 * Register Omise to WordPress, WooCommerce
-		 * @return void
+		 * Register Omise's custom menu to WordPress admin menus.
 		 */
 		public function register_admin_menu() {
 			add_action( 'admin_menu', array( $this, 'wordpress_hook_admin_menu' ) );
 		}
 
 		/**
-		 * Add Omise menu to sidebar admin menu
-		 * @return void
+		 * Callback to $this::register_admin_menu() method.
+		 * Register Omise's custom menu to WordPress admin menus.
 		 */
 		public function wordpress_hook_admin_menu() {
 			add_menu_page( 'Omise', 'Omise', 'manage_options', 'omise', array( $this, 'page_settings') );
@@ -46,6 +48,9 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 			add_submenu_page( 'omise', __( 'Omise Settings', 'omise' ), __( 'Settings', 'omise' ), 'manage_options', 'omise-settings', array( $this, 'page_settings') );
 		}
 
+		/**
+		 * Render Omise Setting page.
+		 */
 		public function page_settings() {
 			Omise_Page_Settings::render();
 		}
@@ -58,6 +63,10 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		}
 
 		/**
+		 * Callback to $this::register_woocommerce_filters() method.
+		 *
+		 * @since  3.3
+		 *
 		 * @param  array $order_actions
 		 *
 		 * @return array

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -135,11 +135,8 @@ class Omise {
 	 */
 	protected function init_admin() {
 		if ( is_admin() ) {
-			require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/admin/class-omise-page-settings.php';
 			require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-admin.php';
-
-			Omise_Admin::get_instance()->register_admin_menu();
-			add_filter( 'woocommerce_order_actions', array( $this, 'register_order_actions' ) );
+			Omise_Admin::get_instance()->init();
 		}
 	}
 
@@ -158,26 +155,6 @@ class Omise {
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain( 'omise', false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
-	}
-
-	/**
-	 * @param  array $order_actions
-	 *
-	 * @return array
-	 */
-	public function register_order_actions( $order_actions ) {
-		global $theorder;
-
-		/** backward compatible with WooCommerce v2.x series **/
-		$payment_method = version_compare( WC()->version, '3.0.0', '>=' ) ? $theorder->get_payment_method() : $theorder->payment_method;
-
-		if ( 'omise' === $payment_method ) {
-			$order_actions[ $payment_method . '_charge_capture'] = __( 'Omise: Capture this order', 'omise' );
-		}
-
-		$order_actions[ $payment_method . '_sync_payment'] = __( 'Omise: Manual sync payment status', 'omise' );
-
-		return $order_actions;
 	}
 
 	/**


### PR DESCRIPTION
> :warning: Important: This pull request requires **#95: "Refactoring plugin-initial code structure, part 2"** to be merged first.
#### 1. Objective

Omise-WooCommerce has always been coupled with WooCommerce plugin, which the plugin cannot be used as a stand-alone plugin and always require WooCommerce plugin to be activated first. 
However, the legacy-codebase itself wasn't really aware of a case where WooCommerce plugin is disabled as much as it should be.

Although we have prevented such cases #78, and #83. But by the current design of the plugin-initial step, it still remains some issue (#90) that could be ceased out by redesigning the initial-step with a proper awareness of WooCommerce plugin.

**Related issue(s)**:
- #90 Omise-WooCommerce 3.2 can't be activated.

#### 2. Description of change

#### Part 1

See, **#94: "Refactoring plugin-initial code structure, part 1"**

#### Part 2

See, **#95: "Refactoring plugin-initial code structure, part 2"**


#### Part 3

The last piece of code,
This part is aiming to organizing `Omise_Admin` class, by moving all admin-related code from `Omise` class back to `Omise_Admin`.

### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.0.3
- **WooCommerce**: v3.5.3
- **PHP version**: v5.6.30

**✏️ Details:**

The main test-case will be separated into 3 cases as follows:
1. Attempting to install Omise-WooCommerce without WooCommerce should give you a warning message that **Omise-WooCommerce requires WooCommerce plugin to be activated first.**
**Omise-WooCommerce** plugin can be activated, but all functions should be disabled, including no Omise menu at the WordPress admin-sidebar.
<img width="1552" alt="screen shot 2562-01-18 at 00 12 26" src="https://user-images.githubusercontent.com/2154669/51335929-d9fab600-1ab5-11e9-84e0-e471c0da4ea2.png">

2. Install Omise-WooCommere plugin while WooCommerce plugin is enabled should give you a full-access to all Omise-WooCommerce feature, including the setting page.
<img width="1552" alt="screen shot 2562-01-17 at 23 32 33" src="https://user-images.githubusercontent.com/2154669/51333417-378c0400-1ab0-11e9-9b06-9af6075853af.png">

3. Attempting to disable WooCommerce plugin while Omise-WooCommerce is still enabled should give you a same result as the case [1].
<img width="1552" alt="screen shot 2562-01-18 at 00 12 26" src="https://user-images.githubusercontent.com/2154669/51335929-d9fab600-1ab5-11e9-84e0-e471c0da4ea2.png">

4. After the change, charge must be created, captured, refunded as usual.

### 4. Impact of the change

No

### 5. Priority of change

Normal

### 6. Additional Notes

No
