### PR TITLE
[WIP, Testing] Refactoring, simplify payment processors

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -108,13 +108,7 @@ function register_omise_alipay() {
 
 						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
 
-						/** backward compatible with WooCommerce v2.x series **/
-						if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
-							$order->set_transaction_id( $charge['id'] );
-							$order->save();
-						} else {
-							update_post_meta( $order->id, '_transaction_id', $charge['id'] );
-						}
+						$this->set_order_transaction_id( $charge['id'] );
 
 						return array (
 							'result'   => 'success',

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -96,7 +96,7 @@ function register_omise_alipay() {
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
 					'metadata'    => array(
 						/** backward compatible with WooCommerce v2.x series **/
-						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+						'order_id' => $order_id
 					)
 				) );
 

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -89,11 +89,7 @@ function register_omise_alipay() {
 		public function handle_payment_result( $order_id, $order, $charge ) {
 			switch ( $charge['status'] ) {
 				case 'pending':
-					$this->attach_charge_id_to_order( $charge['id'] );
-
 					$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
-
-					$this->set_order_transaction_id( $charge['id'] );
 
 					return array (
 						'result'   => 'success',

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -61,94 +61,58 @@ function register_omise_alipay() {
 		}
 
 		/**
-		 * @param  int $order_id
+		 * @param  int      $order_id
+		 * @param  WC_Order $order
 		 *
-		 * @see    WC_Payment_Gateway::process_payment( $order_id )
-		 * @see    woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
-		 *
-		 * @return array
+		 * @return OmiseCharge|OmiseException
 		 */
-		public function process_payment( $order_id ) {
-			if ( ! $order = $this->load_order( $order_id ) ) {
-				wc_add_notice(
-					sprintf(
-						wp_kses(
-							__( 'We cannot process your payment.<br/>Note that nothing wrong by you, this might be from our store issue.<br/><br/>Please feel free to try submit your order again or report our support team that you have found this problem (Your temporary order id is \'%s\')', 'omise' ),
-							array(
-								'br' => array()
-							)
-						),
-						$order_id
-					),
-					'error'
-				);
-				return;
-			}
+		public function charge( $order_id, $order ) {
+			return OmiseCharge::create( array(
+				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+				'currency'    => $order->get_order_currency(),
+				'description' => 'WooCommerce Order id ' . $order_id,
+				'offsite'     => 'alipay',
+				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
+				'metadata'    => array(
+					'order_id' => $order_id
+				)
+			) );
+		}
 
-			$order->add_order_note( __( 'Omise: Processing a payment with Alipay solution..', 'omise' ) );
+		/**
+		 * @param  int         $order_id
+		 * @param  WC_Order    $order
+		 * @param  OmiseCharge $charge
+		 *
+		 * @return array|Exception
+		 */
+		public function handle_payment_result( $order_id, $order, $charge ) {
+			switch ( $charge['status'] ) {
+				case 'pending':
+					$this->attach_charge_id_to_order( $charge['id'] );
 
-			try {
-				$charge = $this->sale( array(
-					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
-					'currency'    => $order->get_order_currency(),
-					'description' => 'WooCommerce Order id ' . $order_id,
-					'offsite'     => 'alipay',
-					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
-					'metadata'    => array(
-						/** backward compatible with WooCommerce v2.x series **/
-						'order_id' => $order_id
-					)
-				) );
+					$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
 
-				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
+					$this->set_order_transaction_id( $charge['id'] );
 
-				switch ( $charge['status'] ) {
-					case 'pending':
-						$this->attach_charge_id_to_order( $charge['id'] );
+					return array (
+						'result'   => 'success',
+						'redirect' => $charge['authorize_uri'],
+					);
+					break;
 
-						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
+				case 'failed':
+					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+					break;
 
-						$this->set_order_transaction_id( $charge['id'] );
-
-						return array (
-							'result'   => 'success',
-							'redirect' => $charge['authorize_uri'],
-						);
-						break;
-
-					case 'failed':
-						throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
-						break;
-
-					default:
-						throw new Exception(
-							sprintf(
-								__( 'Please feel free to try submit your order again or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
-								$order_id
-							)
-						);
-						break;
-				}
-			} catch ( Exception $e ) {
-				wc_add_notice(
-					sprintf(
-						wp_kses(
-							__( 'Seems we cannot process your payment properly:<br/>%s', 'omise' ),
-							array( 'br' => array() )
-						),
-						$e->getMessage()
-					),
-					'error'
-				);
-
-				$order->add_order_note(
-					sprintf(
-						__( 'Omise: Payment failed, %s', 'omise' ),
-						$e->getMessage()
-					)
-				);
-
-				return;
+				default:
+					throw new Exception(
+						sprintf(
+							__( 'Please feel free to try submit your order again or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
+							$order_id
+						)
+					);
+					break;
 			}
 		}
 

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -178,7 +178,7 @@ function register_omise_alipay() {
 			$order->add_order_note( __( 'Omise: Validating the payment result..', 'omise' ) );
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 				if ( 'failed' === $charge['status'] ) {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -281,12 +281,9 @@ function register_omise_creditcard() {
 		 * @return array|Exception
 		 */
 		public function handle_payment_result( $order_id, $order, $charge ) {
-			$this->attach_charge_id_to_order( $charge['id'] );
 			if ( Omise_Charge::is_failed( $charge ) ) {
 				throw new Exception( Omise_Charge::get_error_message( $charge ) );
 			}
-
-			$this->set_order_transaction_id( $charge['id'] );
 
 			if ( $this->omise_3ds ) {
 				$order->add_order_note(

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -152,7 +152,7 @@ function register_omise_creditcard() {
 				$omise_customer_id = $this->is_test() ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
 				if ( ! empty( $omise_customer_id ) ) {
 					try {
-						$customer                  = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
+						$customer                  = OmiseCustomer::retrieve( $omise_customer_id );
 						$viewData['existingCards'] = $customer->cards( array( 'order' => 'reverse_chronological' ) );
 					} catch (Exception $e) {
 						// nothing
@@ -211,7 +211,7 @@ function register_omise_creditcard() {
 					if ( ! empty( $omise_customer_id ) ) {
 						try {
 							// attach a new card to customer
-							$customer = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
+							$customer = OmiseCustomer::retrieve( $omise_customer_id );
 							$customer->update( array(
 								'card' => $token
 							) );
@@ -232,7 +232,7 @@ function register_omise_creditcard() {
 							"card"        => $token
 						);
 
-						$omise_customer = OmiseCustomer::create( $customer_data, '', $this->secret_key() );
+						$omise_customer = OmiseCustomer::create( $customer_data );
 
 						if ( $omise_customer['object'] == "error" ) {
 							throw new Exception( $omise_customer['message'] );
@@ -291,7 +291,7 @@ function register_omise_creditcard() {
 					'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
 				);
 
-				$charge = OmiseCharge::create( $data, '', $this->secret_key() );
+				$charge = OmiseCharge::create( $data );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
 
@@ -439,7 +439,7 @@ function register_omise_creditcard() {
 			);
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 				$refund = $charge->refunds()->create( array(
 					'amount' => $this->format_amount_subunit( $amount, $order->get_order_currency() )
 				) );
@@ -514,7 +514,7 @@ function register_omise_creditcard() {
 			$order->add_order_note( __( 'Omise: Validating the payment result..', 'omise' ) );
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 				switch ( strtoupper( $this->payment_action ) ) {
 					case 'MANUAL_CAPTURE':

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -301,13 +301,7 @@ function register_omise_creditcard() {
 					throw new Exception( Omise_Charge::get_error_message( $charge ) );
 				}
 
-				/** backward compatible with WooCommerce v2.x series **/
-				if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
-					$order->set_transaction_id( $charge['id'] );
-					$order->save();
-				} else {
-					update_post_meta( $order->id, '_transaction_id', $charge['id'] );
-				}
+				$this->set_order_transaction_id( $charge['id'] );
 
 				if ( $this->omise_3ds ) {
 					$order->add_order_note(

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -38,7 +38,7 @@ function register_omise_creditcard() {
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'omise_assets' ) );
-			add_action( 'woocommerce_order_action_' . $this->id . '_charge_capture', array( $this, 'capture' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_charge_capture', array( $this, 'process_capture' ) );
 			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 
 			/** @deprecated 3.0 */
@@ -357,6 +357,51 @@ function register_omise_creditcard() {
 				return array (
 					'result'   => 'success',
 					'redirect' => $this->get_return_url( $order )
+				);
+			}
+		}
+
+		/**
+		 * Capture an authorized charge.
+		 *
+		 * @param  WC_Order $order WooCommerce's order object
+		 *
+		 * @return void
+		 *
+		 * @see    WC_Meta_Box_Order_Actions::save( $post_id, $post )
+		 * @see    woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+		 */
+		public function process_capture( $order ) {
+			$this->load_order( $order );
+
+			try {
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
+				$charge->capture();
+
+				if ( ! OmisePluginHelperCharge::isPaid( $charge ) ) {
+					throw new Exception( $charge['failure_message'] );
+				}
+
+				$this->order()->add_order_note(
+					sprintf(
+						wp_kses(
+							__( 'Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid', 'omise' ),
+							array( 'br' => array() )
+						),
+						$this->order()->get_total(),
+						$this->order()->get_order_currency()
+					)
+				);
+				$this->order()->payment_complete();
+			} catch ( Exception $e ) {
+				$this->order()->add_order_note(
+					sprintf(
+						wp_kses(
+							__( 'Omise: Payment failed (manual capture).<br/>%s', 'omise' ),
+							array( 'br' => array() )
+						),
+						$e->getMessage()
+					)
 				);
 			}
 		}

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -112,7 +112,7 @@ function register_omise_internetbanking() {
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
 					'metadata'    => array(
 						/** backward compatible with WooCommerce v2.x series **/
-						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+						'order_id' => $order_id
 					)
 				) );
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -194,7 +194,7 @@ function register_omise_internetbanking() {
 			$order->add_order_note( __( 'Omise: Validating the payment result..', 'omise' ) );
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 				if ( 'failed' === $charge['status'] ) {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -124,13 +124,7 @@ function register_omise_internetbanking() {
 
 						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
 
-						/** backward compatible with WooCommerce v2.x series **/
-						if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
-							$order->set_transaction_id( $charge['id'] );
-							$order->save();
-						} else {
-							update_post_meta( $order->id, '_transaction_id', $charge['id'] );
-						}
+						$this->set_order_transaction_id( $charge['id'] );
 
 						return array (
 							'result'   => 'success',

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -105,11 +105,7 @@ function register_omise_internetbanking() {
 		public function handle_payment_result( $order_id, $order, $charge ) {
 			switch ( $charge['status'] ) {
 				case 'pending':
-					$this->attach_charge_id_to_order( $charge['id'] );
-
 					$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
-
-					$this->set_order_transaction_id( $charge['id'] );
 
 					return array (
 						'result'   => 'success',

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -192,51 +192,6 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * Capture an authorized charge.
-	 *
-	 * @param  WC_Order $order WooCommerce's order object
-	 *
-	 * @return void
-	 *
-	 * @see    WC_Meta_Box_Order_Actions::save( $post_id, $post )
-	 * @see    woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
-	 */
-	public function capture( $order ) {
-		$this->load_order( $order );
-
-		try {
-			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
-			$charge->capture();
-
-			if ( ! OmisePluginHelperCharge::isPaid( $charge ) ) {
-				throw new Exception( $charge['failure_message'] );
-			}
-
-			$this->order()->add_order_note(
-				sprintf(
-					wp_kses(
-						__( 'Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid', 'omise' ),
-						array( 'br' => array() )
-					),
-					$this->order()->get_total(),
-					$this->order()->get_order_currency()
-				)
-			);
-			$this->order()->payment_complete();
-		} catch ( Exception $e ) {
-			$this->order()->add_order_note(
-				sprintf(
-					wp_kses(
-						__( 'Omise: Payment failed (manual capture).<br/>%s', 'omise' ),
-						array( 'br' => array() )
-					),
-					$e->getMessage()
-				)
-			);
-		}
-	}
-
-	/**
 	 * @since  3.3
 	 *
 	 * @param  int $order_id

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -219,6 +219,8 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$order->add_order_note( sprintf( __( 'Omise: Processing a payment with %s', 'omise' ), $this->method_title ) );
 
 			$charge = $this->charge( $order_id, $order );
+			$this->attach_charge_id_to_order( $charge['id'] );
+			$this->set_order_transaction_id( $charge['id'] );
 
 			$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -86,6 +86,14 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function order_id() {
+		/** backward compatible with WooCommerce v2.x series **/
+		return version_compare( WC()->version, '3.0.0', '>=' ) ? $this->order()->get_id() : $this->order()->id;
+	}
+
+	/**
 	 * Whether Sandbox (test) mode is enabled or not.
 	 *
 	 * @return bool
@@ -145,14 +153,11 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @param string $charge_id
 	 */
 	public function attach_charge_id_to_order( $charge_id ) {
-		/** backward compatible with WooCommerce v2.x series **/
-		$order_id = version_compare( WC()->version, '3.0.0', '>=' ) ? $this->order()->get_id() : $this->order()->id;
-
 		if ( $this->get_charge_id_from_order() ) {
-			delete_post_meta( $order_id, self::CHARGE_ID );
+			delete_post_meta( $this->order_id(), self::CHARGE_ID );
 		}
 
-		add_post_meta( $order_id, self::CHARGE_ID, $charge_id );
+		add_post_meta( $this->order_id(), self::CHARGE_ID, $charge_id );
 	}
 
 	/**
@@ -161,10 +166,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_charge_id_from_order() {
-		/** backward compatible with WooCommerce v2.x series **/
-		$order_id  = version_compare( WC()->version, '3.0.0', '>=' ) ? $this->order()->get_id() : $this->order()->id;
-
-		$charge_id = get_post_meta( $order_id, self::CHARGE_ID, true );
+		$charge_id = get_post_meta( $this->order_id(), self::CHARGE_ID, true );
 
 		// Backward compatible for Omise v1.2.3
 		if ( empty( $charge_id ) ) {
@@ -323,16 +325,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return     string
 	 */
 	protected function deprecated_get_charge_id_from_post() {
-		/** backward compatible with WooCommerce v2.x series **/
-		$order_id  = version_compare( WC()->version, '3.0.0', '>=' ) ? $this->order()->get_id() : $this->order()->id;
-
 		$posts = get_posts(
 			array(
 				'post_type'  => 'omise_charge_items',
 				'meta_query' => array(
 					array(
 						'key'     => '_wc_order_id',
-						'value'   => $order_id,
+						'value'   => $this->order_id(),
 						'compare' => '='
 					)
 				)

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -161,6 +161,21 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * @since 3.3
+	 *
+	 * @param string $transaction_id
+	 */
+	public function set_order_transaction_id( $transaction_id ) {
+		/** backward compatible with WooCommerce v2.x series **/
+		if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
+			$this->order()->set_transaction_id( $transaction_id );
+			$this->order()->save();
+		} else {
+			update_post_meta( $this->order_id(), '_transaction_id', $transaction_id );
+		}
+	}
+
+	/**
 	 * Retrieve an attached charge id.
 	 *
 	 * @return string
@@ -248,13 +263,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 			if ( ! $this->order()->get_transaction_id() ) {
-				/** backward compatible with WooCommerce v2.x series **/
-				if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
-					$this->order()->set_transaction_id( $charge['id'] );
-					$this->order()->save();
-				} else {
-					update_post_meta( $this->order()->id, '_transaction_id', $charge['id'] );
-				}
+				$this->set_transaction_id( $charge['id'] );
 			}
 
 			if ( 'failed' === $charge['status'] ) {

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -54,6 +54,9 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	public function __construct() {
 		$this->omise_settings   = new Omise_Setting;
 		$this->payment_settings = $this->omise_settings->get_settings();
+
+		defined( 'OMISE_PUBLIC_KEY' ) || define( 'OMISE_PUBLIC_KEY', $this->public_key() );
+		defined( 'OMISE_SECRET_KEY' ) || define( 'OMISE_SECRET_KEY', $this->secret_key() );
 	}
 
 	/**
@@ -185,7 +188,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		$this->load_order( $order );
 
 		try {
-			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 			$charge->capture();
 
 			if ( ! OmisePluginHelperCharge::isPaid( $charge ) ) {
@@ -222,7 +225,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return OmiseCharge
 	 */
 	public function sale( $params ) {
-		return OmiseCharge::create( $params, '', $this->secret_key() );
+		return OmiseCharge::create( $params );
 	}
 
 	/**
@@ -240,7 +243,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		$this->load_order( $order );
 
 		try {
-			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 			if ( ! $this->order()->get_transaction_id() ) {
 				/** backward compatible with WooCommerce v2.x series **/


### PR DESCRIPTION
### 1. Objective

Alipay, Credit Card, Internet Banking payments are behaving almost the same in many aspects (except for the charge-creating and handling the charge response).

However, they are completely separated from each other while some part of code could have been shared among each payment method and reduce those redundant code.

### 2. Description of change

The main highlight of the change would be, sharing some part of `process_payment` behaviour.
By removing `process_payment` method out from each payment processor classes and implementing it at the core `Omise_Payment` class. (https://github.com/omise/omise-woocommerce/pull/97/commits/01a844e983bf1c2672073cfe9bcfd70ce6c38ac6)

Previously, each of payment method's class will have its own `process_payment` which 3 of them have the same structure that can be written as follows:
```php
public function process_payment( $order_id ) {
    // 1. Loading WooCommerce Order from the $order_id into $order

    try {
        // 2. Logging an initiating message to WooCommerce Order
        // 3. Gathering all data and create a new charge
        // 4. Logging that charge has been created, attaching OmiseCharge.id as WooCommerce Order's transaction id.
        // 5. Validating a charge result, result will be depending on its charge.status (successful, failed, pending).
    } catch (Exception $e) {
        // 6. Notify an error message to the checkout page (wc_add_notice())
        // 7. Then, logging an error message to WooCommerce Order.
    }
}
```

By the above structure, we can simply take those redundant code out and group it into one method.
```php
class Omise_Payment {
    public function process_payment( $order_id ) {
        // 1. Loading WooCommerce Order from the $order_id into $order

        try {
            // 2. Logging an initiating message to WooCommerce Order

            $charge = $this->charge( $order_id, $order );

            // 4. Logging that charge has been created, attaching OmiseCharge.id as WooCommerce Order's transaction id.

            return $this->handle_payment_result( $order_id, $order, $charge );
        } catch (Exception $e) {
            // 6. Notify an error message to the checkout page (wc_add_notice())
            // 7. Then, logging an error message to WooCommerce Order.
        }
    }
}
```

And let those payment processors concern only **Gathering all data and create a new charge** and **Validating a charge result, result will be depending on its charge.status (successful, failed, pending).**

```php
class Omise_Payment_Alipay extends Omise_Payment {
    public function charge( $order_id, $order ) { }
    public function handle_payment_result( $order_id, $order, $charge ) { }
}

class Omise_Payment_Creditcard extends Omise_Payment {
    public function charge( $order_id, $order ) { }
    public function handle_payment_result( $order_id, $order, $charge ) { }
}

class Omise_Payment_Internetbanking extends Omise_Payment {
    public function charge( $order_id, $order ) { }
    public function handle_payment_result( $order_id, $order, $charge ) { }
}
```
..
.

For the rest, you can simply check from each commit.
- Define global OMISE_PUBLIC_KEY, OMISE_SECRET_KEY keys instead of passing through Omise lib each time the code is executed. (https://github.com/omise/omise-woocommerce/pull/97/commits/3fe6b1b2ed06c99fe20ebeb6b0487a1b1c8662e3)
.
- class Omise_Payment, providing 'order_id()' method for all those code that need to check backward compatibility before retrieve an id from WC_Order object. (https://github.com/omise/omise-woocommerce/pull/97/commits/7147942175bf08e6268edf27cef218ba98f681a4)
.
- Simplify those backward-compatible checking for '->set_transaction_id()' to a proper 'Omise_Payment::set_order_transaction_id()' method. (https://github.com/omise/omise-woocommerce/pull/97/commits/83c54cfaa495e017a5687ee25b9f1ff84427b3c2)
.
- Relocating 'Omise_Payment::capture()' method to 'Omise_Payment_Creditcard' class. (https://github.com/omise/omise-woocommerce/pull/97/commits/eddd6f9808a2e559ac0995f6a2f05e710b45f58b)

### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.0.3
- **WooCommerce**: v3.5.3
- **PHP version**: 5.6.30

**✏️ Details:**

**Because this pull request is refactoring on both 3 payment processor classes, it requires a serious test on both 3 payment methods' functionalities.**
Test details are as follows:

#### • Alipay Payment
There are 4 important cases that need to be tested.
1. Making a new order with Alipay payment and mark as successful

2. Making a new order with Alipay payment and mark as failed

3. Making a new order with Alipay payment and test in case of `charge.status` = `pending`.

4. Make sure that Webhook feature still works properly.

#### • Credit Card Payment
There are 7 important cases that need to be tested.
1. Making a new order with `auth-only`.

2. Test capturing an authorized charge at WooCommerce Order Detail page.

3. Test refunding a captured charge at WooCommerce Order Detail page.

4. Making a new order with `auto-capture`.

5. Making a new order and save a card

6. Making a new order and use a saved-card

7. Make sure that Webhook feature still works properly.

#### • Internet Banking Payment
There are 4 important cases that need to be tested.
1. Making a new order with Internet Banking payment and mark as successful

2. Making a new order with Internet Banking payment and mark as failed

3. Making a new order with Internet Banking payment and test in case of `charge.status` = `pending`.

4. Make sure that Webhook feature still works properly.[drafting]

### 4. Impact of the change

- Some log messages are changed, the list of effected-messages are as follows:
[drafting]

### 5. Priority of change

Normal

### 6. Additional Notes

No