### PR TITLE
Added filter hooks for charge.description and charge.metadata

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -88,17 +88,20 @@ function register_omise_alipay() {
 			$order->add_order_note( __( 'Omise: Processing a payment with Alipay solution..', 'omise' ) );
 
 			try {
-				$metadata = apply_filters( 'omise_charge_metadata', array(), $order );
 				$charge = $this->sale( array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
-					'description' => apply_filters( 'omise_charge_description', 'WooCommerce Order id ' . $order_id, $order ),
+					'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 					'offsite'     => 'alipay',
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
-					'metadata'    => array_merge( $metadata, array(
-						/** backward compatible with WooCommerce v2.x series **/
-						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-					) )
+					'metadata'    => apply_filters(
+						'omise_charge_params_metadata', 
+						array(
+							/** backward compatible with WooCommerce v2.x series **/
+							'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+						),
+						$order
+					)
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -88,16 +88,17 @@ function register_omise_alipay() {
 			$order->add_order_note( __( 'Omise: Processing a payment with Alipay solution..', 'omise' ) );
 
 			try {
+				$metadata = apply_filters( 'omise_charge_metadata', array(), $order );
 				$charge = $this->sale( array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
-					'description' => 'WooCommerce Order id ' . $order_id,
+					'description' => apply_filters( 'omise_charge_description', 'WooCommerce Order id ' . $order_id, $order ),
 					'offsite'     => 'alipay',
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
-					'metadata'    => array(
+					'metadata'    => array_merge( $metadata, array(
 						/** backward compatible with WooCommerce v2.x series **/
 						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-					)
+					) )
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -88,20 +88,18 @@ function register_omise_alipay() {
 			$order->add_order_note( __( 'Omise: Processing a payment with Alipay solution..', 'omise' ) );
 
 			try {
+				$metadata = apply_filters( 'omise_charge_params_metadata', array(), $order );
 				$charge = $this->sale( array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
 					'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 					'offsite'     => 'alipay',
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
-					'metadata'    => apply_filters(
-						'omise_charge_params_metadata', 
-						array(
-							/** backward compatible with WooCommerce v2.x series **/
-							'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-						),
-						$order
-					)
+					'metadata'    => array_merge( $metadata, array(
+						/** override order_id as a reference for webhook handlers **/
+						/** backward compatible with WooCommerce v2.x series **/
+						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+					) )
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -285,14 +285,13 @@ function register_omise_creditcard() {
 				} else if ( 'MANUAL_CAPTURE' === strtoupper( $this->payment_action ) ) {
 					$data['capture'] = false;
 				}
+				$metadata = apply_filters( 'omise_charge_params_metadata', array(), $order );
 
-				$data['metadata'] = apply_filters(
-					'omise_charge_params_metadata',
-					array(
-						/** backward compatible with WooCommerce v2.x series **/
-						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-					)
-				);
+				$data['metadata'] = array_merge( $metadata, array(
+					/** override order_id as a reference for webhook handlers **/
+					/** backward compatible with WooCommerce v2.x series **/
+					'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+				) );
 
 				$charge = OmiseCharge::create( $data, '', $this->secret_key() );
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -268,7 +268,7 @@ function register_omise_creditcard() {
 				$data    = array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
-					'description' => 'WooCommerce Order id ' . $order_id,
+					'description' => apply_filters( 'omise_charge_description', 'WooCommerce Order id ' . $order_id, $order ),
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . '?wc-api=omise_callback' )
 				);
 
@@ -285,11 +285,12 @@ function register_omise_creditcard() {
 				} else if ( 'MANUAL_CAPTURE' === strtoupper( $this->payment_action ) ) {
 					$data['capture'] = false;
 				}
+				$metadata = apply_filters( 'omise_charge_metadata', array(), $order );
 
+				$data['metadata'] = array_merge( $metadata, array(
 				/** backward compatible with WooCommerce v2.x series **/
-				$data['metadata'] = array(
 					'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-				);
+				) );
 
 				$charge = OmiseCharge::create( $data, '', $this->secret_key() );
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -268,7 +268,7 @@ function register_omise_creditcard() {
 				$data    = array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
-					'description' => apply_filters( 'omise_charge_description', 'WooCommerce Order id ' . $order_id, $order ),
+					'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . '?wc-api=omise_callback' )
 				);
 
@@ -285,12 +285,14 @@ function register_omise_creditcard() {
 				} else if ( 'MANUAL_CAPTURE' === strtoupper( $this->payment_action ) ) {
 					$data['capture'] = false;
 				}
-				$metadata = apply_filters( 'omise_charge_metadata', array(), $order );
 
-				$data['metadata'] = array_merge( $metadata, array(
-				/** backward compatible with WooCommerce v2.x series **/
-					'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-				) );
+				$data['metadata'] = apply_filters(
+					'omise_charge_params_metadata',
+					array(
+						/** backward compatible with WooCommerce v2.x series **/
+						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+					)
+				);
 
 				$charge = OmiseCharge::create( $data, '', $this->secret_key() );
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -103,20 +103,18 @@ function register_omise_internetbanking() {
 
 			$order->add_order_note( __( 'Omise: Processing a payment with Internet Banking solution..', 'omise' ) );
 			try {
+				$metadata = apply_filters( 'omise_charge_params_metadata', array(), $order );
 				$charge = $this->sale( array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
 					'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
 					'offsite'     => $_POST['omise-offsite'],
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
-					'metadata'    => apply_filters(
-						'omise_charge_params_metadata', 
-						array(
-							/** backward compatible with WooCommerce v2.x series **/
-							'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-						),
-						$order
-					)
+					'metadata'    => array_merge( $metadata, array(
+						/** override order_id as a reference for webhook handlers **/
+						/** backward compatible with WooCommerce v2.x series **/
+						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+					) )
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -103,17 +103,20 @@ function register_omise_internetbanking() {
 
 			$order->add_order_note( __( 'Omise: Processing a payment with Internet Banking solution..', 'omise' ) );
 			try {
-				$metadata = apply_filters( 'omise_charge_metadata', array(), $order );
 				$charge = $this->sale( array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
-					'description' => apply_filters('omise_charge_description', 'WooCommerce Order id ' . $order_id, $order),
+					'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
 					'offsite'     => $_POST['omise-offsite'],
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
-					'metadata'    => array_merge( $metadata, array(
-						/** backward compatible with WooCommerce v2.x series **/
-						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-					) )
+					'metadata'    => apply_filters(
+						'omise_charge_params_metadata', 
+						array(
+							/** backward compatible with WooCommerce v2.x series **/
+							'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+						),
+						$order
+					)
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -102,18 +102,18 @@ function register_omise_internetbanking() {
 			}
 
 			$order->add_order_note( __( 'Omise: Processing a payment with Internet Banking solution..', 'omise' ) );
-
 			try {
+				$metadata = apply_filters( 'omise_charge_metadata', array(), $order );
 				$charge = $this->sale( array(
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
-					'description' => 'WooCommerce Order id ' . $order_id,
+					'description' => apply_filters('omise_charge_description', 'WooCommerce Order id ' . $order_id, $order),
 					'offsite'     => $_POST['omise-offsite'],
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
-					'metadata'    => array(
+					'metadata'    => array_merge( $metadata, array(
 						/** backward compatible with WooCommerce v2.x series **/
 						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-					)
+					) )
 				) );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );


### PR DESCRIPTION
#### 1. Objective

Add ability to customize the charge metadata and description, so we can store custom data.

**Related information**:
Related issue(s): #80 

#### 2. Description of change

Added filter hooks for charge.metadata (before adding charge.metadata.order_id) and charge.description for credit/debit card, internet banking and alipay.

**Usage Example:**
Charge Metadata Filter Hook
```php
function custom_charge_metadata( $metadata, $order ) {
  // modify $metadata
  return $metadata
}
add_filter( 'omise_charge_params_metadata',  'custom_charge_metadata', 10, 2 );
```
Where the callback has the following signature
```php
function( array $metadata, WC_Order $order ) : array
```

Charge Description Filter Hook
```php
function custom_charge_description( $description, $order ) {
  // modify $description
  return $description
}
add_filter( 'omise_charge_params_description',  'custom_charge_description', 10, 2 );
```
Where the callback has the following signature
```php
function( string $description, WC_Order $order) : string
```

#### 3. Quality assurance

Manually tested by paying via credit card, internet banking and alipay using test keys.

**🔧 Environments:**
- **WordPress version**: WordPress 5.0.3
- **Platform version**: WooCommerce 3.5.4
- **Omise plugin version**: Omise-WooCommerce 1.2.3
- **PHP version**: 7.2

**✏️ Details:**
Write hooks in a custom plugin and create an order and pay via credit card, internet banking and alipay and inspect metadata and description.

#### 4. Impact of the change

none

#### 5. Priority of change

Normal

#### 6. Additional Notes

none