### PR TITLE
Refactoring, simplifying payment processors

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -61,14 +61,7 @@ function register_omise_alipay() {
 		}
 
 		/**
-		 * @since  3.4
-		 *
-		 * @see    Omise_Payment::process_payment( $order_id )
-		 *
-		 * @param  int $order_id
-		 * @param  WC_Order $order
-		 *
-		 * @return OmiseCharge|OmiseException
+		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
 			$metadata = array_merge(
@@ -87,15 +80,7 @@ function register_omise_alipay() {
 		}
 
 		/**
-		 * @since  3.4
-		 *
-		 * @see    Omise_Payment::process_payment( $order_id )
-		 *
-		 * @param  int         $order_id
-		 * @param  WC_Order    $order
-		 * @param  OmiseCharge $charge
-		 *
-		 * @return array|Exception
+		 * @inheritdoc
 		 */
 		public function result( $order_id, $order, $charge ) {
 			if ( 'failed' == $charge['status'] ) {

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -83,11 +83,11 @@ function register_omise_alipay() {
 		 * @inheritdoc
 		 */
 		public function result( $order_id, $order, $charge ) {
-			if ( 'failed' == $charge['status'] ) {
+			if ( self::STATUS_FAILED == $charge['status'] ) {
 				return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 			}
 
-			if ( 'pending' == $charge['status'] ) {
+			if ( self::STATUS_PENDING == $charge['status'] ) {
 				$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
 
 				return array (
@@ -126,11 +126,11 @@ function register_omise_alipay() {
 			try {
 				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
-				if ( 'failed' === $charge['status'] ) {
+				if ( self::STATUS_FAILED === $charge['status'] ) {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 				}
 
-				if ( 'pending' === $charge['status'] && ! $charge['paid'] ) {
+				if ( self::STATUS_PENDING === $charge['status'] && ! $charge['paid'] ) {
 					$order->add_order_note(
 						wp_kses(
 							__( 'Omise: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual \'Sync Payment Status\' action from the Order Actions panel or check the payment status directly at Omise dashboard again later', 'omise' ),
@@ -145,7 +145,7 @@ function register_omise_alipay() {
 					die();
 				}
 
-				if ( 'successful' === $charge['status'] && $charge['paid'] ) {
+				if ( self::STATUS_SUCCESSFUL === $charge['status'] && $charge['paid'] ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -13,6 +13,9 @@ function register_omise_creditcard() {
 	}
 
 	class Omise_Payment_Creditcard extends Omise_Payment {
+		const PAYMENT_ACTION_AUTHORIZE         = 'manual_capture';
+		const PAYMENT_ACTION_AUTHORIZE_CAPTURE = 'auto_capture';
+
 		public function __construct() {
 			parent::__construct();
 
@@ -81,11 +84,11 @@ function register_omise_creditcard() {
 						'title'       => __( 'Payment action', 'omise' ),
 						'type'        => 'select',
 						'description' => __( 'Capture automatically during the checkout process or manually after order has been placed', 'omise' ),
-						'default'     => 'auto_capture',
+						'default'     => self::PAYMENT_ACTION_AUTHORIZE_CAPTURE,
 						'class'       => 'wc-enhanced-select',
 						'options'     => array(
-							'auto_capture'   => __( 'Auto Capture', 'omise' ),
-							'manual_capture' => __( 'Manual Capture', 'omise' )
+							self::PAYMENT_ACTION_AUTHORIZE_CAPTURE => __( 'Auto Capture', 'omise' ),
+							self::PAYMENT_ACTION_AUTHORIZE         => __( 'Manual Capture', 'omise' )
 						),
 						'desc_tip'    => true
 					),
@@ -257,9 +260,9 @@ function register_omise_creditcard() {
 			}
 
 			// Set capture status (otherwise, use API's default behaviour)
-			if ( 'AUTO_CAPTURE' === strtoupper( $this->payment_action ) ) {
+			if ( self::PAYMENT_ACTION_AUTHORIZE_CAPTURE === $this->payment_action ) {
 				$data['capture'] = true;
-			} else if ( 'MANUAL_CAPTURE' === strtoupper( $this->payment_action ) ) {
+			} else if ( self::PAYMENT_ACTION_AUTHORIZE === $this->payment_action ) {
 				$data['capture'] = false;
 			}
 			$metadata = apply_filters( 'omise_charge_params_metadata', array(), $order );
@@ -295,8 +298,8 @@ function register_omise_creditcard() {
 				);
 			}
 
-			switch ( strtoupper( $this->payment_action ) ) {
-				case 'MANUAL_CAPTURE':
+			switch ( $this->payment_action ) {
+				case self::PAYMENT_ACTION_AUTHORIZE:
 					$success = Omise_Charge::is_authorized( $charge );
 					if ( $success ) {
 						$order->add_order_note(
@@ -313,7 +316,7 @@ function register_omise_creditcard() {
 
 					break;
 
-				case 'AUTO_CAPTURE':
+				case self::PAYMENT_ACTION_AUTHORIZE_CAPTURE:
 					$success = Omise_Charge::is_paid( $charge );
 					if ( $success ) {
 						$order->payment_complete();
@@ -512,8 +515,8 @@ function register_omise_creditcard() {
 			try {
 				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
-				switch ( strtoupper( $this->payment_action ) ) {
-					case 'MANUAL_CAPTURE':
+				switch ( $this->payment_action ) {
+					case self::PAYMENT_ACTION_AUTHORIZE:
 						$success = Omise_Charge::is_authorized( $charge );
 						if ( $success ) {
 							$order->add_order_note(
@@ -530,7 +533,7 @@ function register_omise_creditcard() {
 
 						break;
 
-					case 'AUTO_CAPTURE':
+					case self::PAYMENT_ACTION_AUTHORIZE_CAPTURE:
 						$success = Omise_Charge::is_paid( $charge );
 						if ( $success ) {
 							$order->add_order_note(

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -166,14 +166,7 @@ function register_omise_creditcard() {
 		}
 
 		/**
-		 * @since  3.4
-		 *
-		 * @see    Omise_Payment::process_payment( $order_id )
-		 *
-		 * @param  int $order_id
-		 * @param  WC_Order $order
-		 *
-		 * @return OmiseCharge|OmiseException
+		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
 			$token   = isset( $_POST['omise_token'] ) ? wc_clean( $_POST['omise_token'] ) : '';
@@ -281,15 +274,7 @@ function register_omise_creditcard() {
 		}
 
 		/**
-		 * @since  3.4
-		 *
-		 * @see    Omise_Payment::process_payment( $order_id )
-		 *
-		 * @param  int         $order_id
-		 * @param  WC_Order    $order
-		 * @param  OmiseCharge $charge
-		 *
-		 * @return array|Exception
+		 * @inheritdoc
 		 */
 		public function result( $order_id, $order, $charge ) {
 			if ( Omise_Charge::is_failed( $charge ) ) {

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -166,235 +166,207 @@ function register_omise_creditcard() {
 		}
 
 		/**
+		 * @since  3.4
+		 *
+		 * @see    Omise_Payment::process_payment( $order_id )
+		 *
 		 * @param  int $order_id
+		 * @param  WC_Order $order
 		 *
-		 * @see    WC_Payment_Gateway::process_payment( $order_id )
-		 * @see    woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
-		 *
-		 * @return array
+		 * @return OmiseCharge|OmiseException
 		 */
-		public function process_payment( $order_id ) {
-			if ( ! $order = $this->load_order( $order_id ) ) {
-				wc_add_notice(
-					sprintf(
-						wp_kses(
-							__( 'We have been unable to process your payment.<br/>Please note that you\'ve done nothing wrong - this is likely an issue with our store.<br/><br/>Feel free to try submitting your order again, or report this problem to our support team (Your temporary order id is \'%s\')', 'omise' ),
-							array(
-								'br' => array()
-							)
-						),
-						$order_id
-					),
-					'error'
-				);
-				return;
+		public function charge( $order_id, $order ) {
+			$token   = isset( $_POST['omise_token'] ) ? wc_clean( $_POST['omise_token'] ) : '';
+			$card_id = isset( $_POST['card_id'] ) ? wc_clean( $_POST['card_id'] ) : '';
+
+			if ( empty( $token ) && empty( $card_id ) ) {
+				throw new Exception( __( 'Please select an existing card or enter new card information.', 'omise' ) );
 			}
 
-			$order->add_order_note( __( 'Omise: Processing a payment with Credit Card solution..', 'omise' ) );
+			$user              = $order->get_user();
+			$omise_customer_id = $this->is_test() ? $user->test_omise_customer_id : $user->live_omise_customer_id;
 
-			try {
-				$token   = isset( $_POST['omise_token'] ) ? wc_clean( $_POST['omise_token'] ) : '';
-				$card_id = isset( $_POST['card_id'] ) ? wc_clean( $_POST['card_id'] ) : '';
-
-				if ( empty( $token ) && empty( $card_id ) ) {
-					throw new Exception( __( 'Please select an existing card or enter new card information.', 'omise' ) );
+			// Saving card.
+			if ( isset( $_POST['omise_save_customer_card'] ) && empty( $card_id ) ) {
+				if ( empty( $token ) ) {
+					throw new Exception( __( 'Unable to process the card. Please make sure that the information is correct, or contact our support team if you have any questions.', 'omise' ) );
 				}
 
-				$user              = $order->get_user();
-				$omise_customer_id = $this->is_test() ? $user->test_omise_customer_id : $user->live_omise_customer_id;
+				if ( ! empty( $omise_customer_id ) ) {
+					try {
+						// attach a new card to customer
+						$customer = OmiseCustomer::retrieve( $omise_customer_id );
+						$customer->update( array(
+							'card' => $token
+						) );
 
-				if ( isset( $_POST['omise_save_customer_card'] ) && empty( $card_id ) ) {
-					if ( empty( $token ) ) {
-						throw new Exception( __( 'Unable to process the card. Please make sure that the information is correct, or contact our support team if you have any questions.', 'omise' ) );
+						$cards = $customer->cards( array(
+							'limit' => 1,
+							'order' => 'reverse_chronological'
+						) );
+
+						$card_id = $cards['data'][0]['id'];
+					} catch (Exception $e) {
+						throw new Exception( $e->getMessage() );
+					}
+				} else {
+					$description   = "WooCommerce customer " . $user->ID;
+					$customer_data = array(
+						"description" => $description,
+						"card"        => $token
+					);
+
+					$omise_customer = OmiseCustomer::create( $customer_data );
+
+					if ( $omise_customer['object'] == "error" ) {
+						throw new Exception( $omise_customer['message'] );
 					}
 
-					if ( ! empty( $omise_customer_id ) ) {
-						try {
-							// attach a new card to customer
-							$customer = OmiseCustomer::retrieve( $omise_customer_id );
-							$customer->update( array(
-								'card' => $token
-							) );
-
-							$cards = $customer->cards( array(
-								'limit' => 1,
-								'order' => 'reverse_chronological'
-							) );
-
-							$card_id = $cards['data'][0]['id'];
-						} catch (Exception $e) {
-							throw new Exception( $e->getMessage() );
-						}
+					$omise_customer_id = $omise_customer['id'];
+					if ( $this->is_test() ) {
+						update_user_meta( $user->ID, 'test_omise_customer_id', $omise_customer_id );
 					} else {
-						$description   = "WooCommerce customer " . $user->ID;
-						$customer_data = array(
-							"description" => $description,
-							"card"        => $token
+						update_user_meta( $user->ID, 'live_omise_customer_id', $omise_customer_id );
+					}
+
+					if ( 0 == sizeof( $omise_customer['cards']['data'] ) ) {
+						throw new Exception(
+							sprintf(
+								wp_kses(
+									__( 'Please note that you\'ve done nothing wrong - this is likely an issue with our store.<br/><br/>Feel free to try submitting your order again, or report this problem to our support team (Your temporary order id is \'%s\')', 'omise' ),
+									array(
+										'br' => array()
+									)
+								),
+								$order_id
+							)
 						);
-
-						$omise_customer = OmiseCustomer::create( $customer_data );
-
-						if ( $omise_customer['object'] == "error" ) {
-							throw new Exception( $omise_customer['message'] );
-						}
-
-						$omise_customer_id = $omise_customer['id'];
-						if ( $this->is_test() ) {
-							update_user_meta( $user->ID, 'test_omise_customer_id', $omise_customer_id );
-						} else {
-							update_user_meta( $user->ID, 'live_omise_customer_id', $omise_customer_id );
-						}
-
-						if ( 0 == sizeof( $omise_customer['cards']['data'] ) ) {
-							throw new Exception(
-								sprintf(
-									wp_kses(
-										__( 'Please note that you\'ve done nothing wrong - this is likely an issue with our store.<br/><br/>Feel free to try submitting your order again, or report this problem to our support team (Your temporary order id is \'%s\')', 'omise' ),
-										array(
-											'br' => array()
-										)
-									),
-									$order_id
-								)
-							);
-						}
-
-						$cards   = $omise_customer->cards( array( 'order' => 'reverse_chronological' ) );
-						$card_id = $cards['data'][0]['id']; //use the latest card
-					}
-				}
-
-				$success = false;
-				$data    = array(
-					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
-					'currency'    => $order->get_order_currency(),
-					'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
-					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . '?wc-api=omise_callback' )
-				);
-
-				if ( ! empty( $omise_customer_id ) && ! empty( $card_id ) ) {
-					$data['customer'] = $omise_customer_id;
-					$data['card']     = $card_id;
-				} else {
-					$data['card'] = $token;
-				}
-
-				// Set capture status (otherwise, use API's default behaviour)
-				if ( 'AUTO_CAPTURE' === strtoupper( $this->payment_action ) ) {
-					$data['capture'] = true;
-				} else if ( 'MANUAL_CAPTURE' === strtoupper( $this->payment_action ) ) {
-					$data['capture'] = false;
-				}
-				$metadata = apply_filters( 'omise_charge_params_metadata', array(), $order );
-
-				$data['metadata'] = array_merge( $metadata, array(
-					/** override order_id as a reference for webhook handlers **/
-					/** backward compatible with WooCommerce v2.x series **/
-					'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-				) );
-
-				$charge = OmiseCharge::create( $data );
-
-				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
-
-				$this->set_order_transaction_id( $charge['id'] );
-
-				if ( Omise_Charge::is_failed( $charge ) ) {
-					throw new Exception( Omise_Charge::get_error_message( $charge ) );
-				}
-
-				if ( $this->omise_3ds ) {
-					$order->add_order_note(
-						sprintf(
-							__( 'Omise: Processing a 3-D Secure payment, redirecting buyer to %s', 'omise' ),
-							esc_url( $charge['authorize_uri'] )
-						)
-					);
-
-					return array(
-						'result'   => 'success',
-						'redirect' => $charge['authorize_uri'],
-					);
-				} else {
-					switch ( strtoupper( $this->payment_action ) ) {
-						case 'MANUAL_CAPTURE':
-							$success = Omise_Charge::is_authorized( $charge );
-							if ( $success ) {
-								$order->add_order_note(
-									sprintf(
-										wp_kses(
-											__( 'Omise: Payment processing.<br/>An amount of %1$s %2$s has been authorized', 'omise' ),
-											array( 'br' => array() )
-										),
-										$order->get_total(),
-										$order->get_order_currency()
-									)
-								);
-							}
-
-							break;
-
-						case 'AUTO_CAPTURE':
-							$success = Omise_Charge::is_paid( $charge );
-							if ( $success ) {
-								$order->payment_complete();
-								$order->add_order_note(
-									sprintf(
-										wp_kses(
-											__( 'Omise: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ),
-											array( 'br' => array() )
-										),
-										$order->get_total(),
-										$order->get_order_currency()
-									)
-								);
-							}
-
-							break;
-
-						default:
-							// Default behaviour is, check if it paid first.
-							$success = Omise_Charge::is_paid( $charge );
-
-							// Then, check is authorized after if the first condition is false.
-							if ( ! $success )
-								$success = Omise_Charge::is_authorized( $charge );
-
-							break;
 					}
 
-					if ( ! $success ) {
-						throw new Exception( __( 'Note that your payment may have already been processed. Please contact our support team if you have any questions.', 'omise' ) );
-					}
-
-					// Remove cart
-					WC()->cart->empty_cart();
-					return array (
-						'result'   => 'success',
-						'redirect' => $this->get_return_url( $order )
-					);
+					$cards   = $omise_customer->cards( array( 'order' => 'reverse_chronological' ) );
+					$card_id = $cards['data'][0]['id']; //use the latest card
 				}
-			} catch( Exception $e ) {
-				wc_add_notice(
-					sprintf(
-						wp_kses(
-							__( 'It seems we\'ve been unable to process your payment properly:<br/>%s', 'omise' ),
-							array( 'br' => array() )
-						),
-						$e->getMessage()
-					),
-					'error'
-				);
+			}
 
+			$success = false;
+			$data    = array(
+				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+				'currency'    => $order->get_order_currency(),
+				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
+				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . '?wc-api=omise_callback' )
+			);
+
+			if ( ! empty( $omise_customer_id ) && ! empty( $card_id ) ) {
+				$data['customer'] = $omise_customer_id;
+				$data['card']     = $card_id;
+			} else {
+				$data['card'] = $token;
+			}
+
+			// Set capture status (otherwise, use API's default behaviour)
+			if ( 'AUTO_CAPTURE' === strtoupper( $this->payment_action ) ) {
+				$data['capture'] = true;
+			} else if ( 'MANUAL_CAPTURE' === strtoupper( $this->payment_action ) ) {
+				$data['capture'] = false;
+			}
+			$metadata = apply_filters( 'omise_charge_params_metadata', array(), $order );
+
+			$data['metadata'] = array_merge( $metadata, array(
+				/** override order_id as a reference for webhook handlers **/
+				/** backward compatible with WooCommerce v2.x series **/
+				'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
+			) );
+
+			return OmiseCharge::create( $data );
+		}
+
+		/**
+		 * @since  3.4
+		 *
+		 * @see    Omise_Payment::process_payment( $order_id )
+		 *
+		 * @param  int         $order_id
+		 * @param  WC_Order    $order
+		 * @param  OmiseCharge $charge
+		 *
+		 * @return array|Exception
+		 */
+		public function result( $order_id, $order, $charge ) {
+			if ( Omise_Charge::is_failed( $charge ) ) {
+				return $this->payment_failed( Omise_Charge::get_error_message( $charge ) );
+			}
+
+			if ( $this->omise_3ds ) {
 				$order->add_order_note(
 					sprintf(
-						__( 'Omise: Payment failed, %s', 'omise' ),
-						$e->getMessage()
+						__( 'Omise: Processing a 3-D Secure payment, redirecting buyer to %s', 'omise' ),
+						esc_url( $charge['authorize_uri'] )
 					)
 				);
 
-				return;
+				return array(
+					'result'   => 'success',
+					'redirect' => $charge['authorize_uri'],
+				);
 			}
+
+			switch ( strtoupper( $this->payment_action ) ) {
+				case 'MANUAL_CAPTURE':
+					$success = Omise_Charge::is_authorized( $charge );
+					if ( $success ) {
+						$order->add_order_note(
+							sprintf(
+								wp_kses(
+									__( 'Omise: Payment processing.<br/>An amount of %1$s %2$s has been authorized', 'omise' ),
+									array( 'br' => array() )
+								),
+								$order->get_total(),
+								$order->get_order_currency()
+							)
+						);
+					}
+
+					break;
+
+				case 'AUTO_CAPTURE':
+					$success = Omise_Charge::is_paid( $charge );
+					if ( $success ) {
+						$order->payment_complete();
+						$order->add_order_note(
+							sprintf(
+								wp_kses(
+									__( 'Omise: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ),
+									array( 'br' => array() )
+								),
+								$order->get_total(),
+								$order->get_order_currency()
+							)
+						);
+					}
+
+					break;
+
+				default:
+					// Default behaviour is, check if it paid first.
+					$success = Omise_Charge::is_paid( $charge );
+
+					// Then, check is authorized after if the first condition is false.
+					if ( ! $success )
+						$success = Omise_Charge::is_authorized( $charge );
+
+					break;
+			}
+
+			if ( ! $success ) {
+				return $this->payment_failed( __( 'Note that your payment may have already been processed. Please contact our support team if you have any questions.', 'omise' ) );
+			}
+
+			// Remove cart
+			WC()->cart->empty_cart();
+			return array (
+				'result'   => 'success',
+				'redirect' => $this->get_return_url( $order )
+			);
 		}
 
 		/**

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -89,7 +89,7 @@ function register_omise_internetbanking() {
 				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
-				'source'      => array( 'type' => $_POST['omise-offsite'] ),
+				'source'      => array( 'type' => sanitize_text_field( $_POST['omise-offsite'] ) ),
 				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
 				'metadata'    => $metadata
 			) );

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -77,14 +77,7 @@ function register_omise_internetbanking() {
 		}
 
 		/**
-		 * @since  3.4
-		 *
-		 * @see    Omise_Payment::process_payment( $order_id )
-		 *
-		 * @param  int $order_id
-		 * @param  WC_Order $order
-		 *
-		 * @return OmiseCharge|OmiseException
+		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
 			$metadata = array_merge(
@@ -103,15 +96,7 @@ function register_omise_internetbanking() {
 		}
 
 		/**
-		 * @since  3.4
-		 *
-		 * @see    Omise_Payment::process_payment( $order_id )
-		 *
-		 * @param  int         $order_id
-		 * @param  WC_Order    $order
-		 * @param  OmiseCharge $charge
-		 *
-		 * @return array|Exception
+		 * @inheritdoc
 		 */
 		public function result( $order_id, $order, $charge ) {
 			if ( 'failed' == $charge['status'] ) {

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -77,94 +77,62 @@ function register_omise_internetbanking() {
 		}
 
 		/**
+		 * @since  3.4
+		 *
+		 * @see    Omise_Payment::process_payment( $order_id )
+		 *
 		 * @param  int $order_id
+		 * @param  WC_Order $order
 		 *
-		 * @see    WC_Payment_Gateway::process_payment( $order_id )
-		 * @see    woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
-		 *
-		 * @return array
+		 * @return OmiseCharge|OmiseException
 		 */
-		public function process_payment( $order_id ) {
-			if ( ! $order = $this->load_order( $order_id ) ) {
-				wc_add_notice(
-					sprintf(
-						wp_kses(
-							__( 'We have been unable to process your payment.<br/>Please note that you\'ve done nothing wrong - this is likely an issue with our store.<br/><br/>Feel free to try submitting your order again, or report this problem to our support team (Your temporary order id is \'%s\')', 'omise' ),
-							array(
-								'br' => array()
-							)
-						),
-						$order_id
-					),
-					'error'
-				);
-				return;
+		public function charge( $order_id, $order ) {
+			$metadata = array_merge(
+				apply_filters( 'omise_charge_params_metadata', array(), $order ),
+				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
+			);
+
+			return OmiseCharge::create( array(
+				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+				'currency'    => $order->get_order_currency(),
+				'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
+				'source'      => array( 'type' => $_POST['omise-offsite'] ),
+				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
+				'metadata'    => $metadata
+			) );
+		}
+
+		/**
+		 * @since  3.4
+		 *
+		 * @see    Omise_Payment::process_payment( $order_id )
+		 *
+		 * @param  int         $order_id
+		 * @param  WC_Order    $order
+		 * @param  OmiseCharge $charge
+		 *
+		 * @return array|Exception
+		 */
+		public function result( $order_id, $order, $charge ) {
+			if ( 'failed' == $charge['status'] ) {
+				return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 			}
 
-			$order->add_order_note( __( 'Omise: Processing a payment with Internet Banking solution..', 'omise' ) );
-			try {
-				$metadata = apply_filters( 'omise_charge_params_metadata', array(), $order );
-				$charge = $this->sale( array(
-					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
-					'currency'    => $order->get_order_currency(),
-					'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
-					'source'      => array( 'type' => $_POST['omise-offsite'] ),
-					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
-					'metadata'    => array_merge( $metadata, array(
-						/** override order_id as a reference for webhook handlers **/
-						/** backward compatible with WooCommerce v2.x series **/
-						'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
-					) )
-				) );
+			if ( 'pending' == $charge['status'] ) {
+				$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
 
-				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
-
-				switch ( $charge['status'] ) {
-					case 'pending':
-						$this->set_order_transaction_id( $charge['id'] );
-
-						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
-
-						return array (
-							'result'   => 'success',
-							'redirect' => $charge['authorize_uri'],
-						);
-						break;
-
-					case 'failed':
-						throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
-						break;
-
-					default:
-						throw new Exception(
-							sprintf(
-								__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
-								$order_id
-							)
-						);
-						break;
-				}
-			} catch ( Exception $e ) {
-				wc_add_notice(
-					sprintf(
-						wp_kses(
-							__( 'It seems we\'ve been unable to process your payment properly:<br/>%s', 'omise' ),
-							array( 'br' => array() )
-						),
-						$e->getMessage()
-					),
-					'error'
+				return array (
+					'result'   => 'success',
+					'redirect' => $charge['authorize_uri'],
 				);
-
-				$order->add_order_note(
-					sprintf(
-						__( 'Omise: Payment failed, %s', 'omise' ),
-						$e->getMessage()
-					)
-				);
-
-				return;
 			}
+
+			return $this->payment_failed(
+				sprintf(
+					__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
+					$order_id
+				)
+			);
 		}
 
 		/**

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -99,11 +99,11 @@ function register_omise_internetbanking() {
 		 * @inheritdoc
 		 */
 		public function result( $order_id, $order, $charge ) {
-			if ( 'failed' == $charge['status'] ) {
+			if ( self::STATUS_FAILED == $charge['status'] ) {
 				return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 			}
 
-			if ( 'pending' == $charge['status'] ) {
+			if ( self::STATUS_PENDING == $charge['status'] ) {
 				$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
 
 				return array (
@@ -142,11 +142,11 @@ function register_omise_internetbanking() {
 			try {
 				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
-				if ( 'failed' === $charge['status'] ) {
+				if ( self::STATUS_FAILED === $charge['status'] ) {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 				}
 
-				if ( 'pending' === $charge['status'] && ! $charge['paid'] ) {
+				if ( self::STATUS_PENDING === $charge['status'] && ! $charge['paid'] ) {
 					$order->add_order_note(
 						wp_kses(
 							__( 'Omise: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual \'Sync Payment Status\' action from the Order Actions panel or check the payment status directly at Omise dashboard again later', 'omise' ),
@@ -161,7 +161,7 @@ function register_omise_internetbanking() {
 					die();
 				}
 
-				if ( 'successful' === $charge['status'] && $charge['paid'] ) {
+				if ( self::STATUS_SUCCESSFUL === $charge['status'] && $charge['paid'] ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -14,6 +14,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	const CHARGE_ID = 'omise_charge_id';
 
 	/**
+	 * @var string Omise charge statuses
+	 */
+	const STATUS_SUCCESSFUL = 'successful';
+	const STATUS_FAILED     = 'failed';
+	const STATUS_PENDING    = 'pending';
+
+	/**
 	 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
 	 *
 	 * @var string

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -137,13 +137,58 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * @param  array $params
+	 * @since  3.4
 	 *
-	 * @return OmiseCharge
+	 * @see    WC_Payment_Gateway::process_payment( $order_id )
+	 * @see    woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+	 *
+	 * @param  int $order_id
+	 *
+	 * @return array
 	 */
-	public function sale( $params ) {
-		return OmiseCharge::create( $params );
+	public function process_payment( $order_id ) {
+		if ( ! $order = $this->load_order( $order_id ) ) {
+			return $this->payment_failed_no_order( $order_id );
+		}
+
+		$order->add_order_note( sprintf( __( 'Omise: Processing a payment with %s', 'omise' ), $this->method_title ) );
+
+		try {
+			$charge = $this->charge( $order_id, $order );
+		} catch ( Exception $e ) {
+			return $this->payment_failed( $e->getMessage() );
+		}
+
+		$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
+		$this->set_order_transaction_id( $charge['id'] );
+
+		return $this->result( $order_id, $order, $charge );
 	}
+
+	/**
+	 * @since  3.4
+	 *
+	 * @see    Omise_Payment::process_payment( $order_id )
+	 *
+	 * @param  int $order_id
+	 * @param  WC_Order $order
+	 *
+	 * @return OmiseCharge|OmiseException
+	 */
+	abstract public function charge( $order_id, $order );
+
+	/**
+	 * @since  3.4
+	 *
+	 * @see    Omise_Payment::process_payment( $order_id )
+	 *
+	 * @param  int         $order_id
+	 * @param  WC_Order    $order
+	 * @param  OmiseCharge $charge
+	 *
+	 * @return array|Exception
+	 */
+	abstract public function result( $order_id, $order, $charge );
 
 	/**
 	 * Retrieve a charge by a given charge id (that attach to an order).
@@ -244,6 +289,46 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$this->order()->save();
 		} else {
 			update_post_meta( $this->order()->id, '_transaction_id', $transaction_id );
+		}
+	}
+
+	/**
+	 * @param int|mixed $order_id
+	 */
+	protected function payment_failed_no_order( $order_id ) {
+		wc_add_notice(
+			sprintf(
+				wp_kses(
+					__( 'We have been unable to process your payment.<br/>Please note that you\'ve done nothing wrong - this is likely an issue with our store.<br/><br/>Feel free to try submitting your order again, or report this problem to our support team (Your temporary order id is \'%s\')', 'omise' ),
+					array(
+						'br' => array()
+					)
+				),
+				$order_id
+			),
+			'error'
+		);
+	}
+
+	/**
+	 * @param string $message
+	 */
+	protected function payment_failed( $message ) {
+		wc_add_notice(
+			sprintf(
+				wp_kses(
+					__( 'It seems we\'ve been unable to process your payment properly:<br/>%s', 'omise' ),
+					array( 'br' => array() )
+				),
+				$message
+			),
+			'error'
+		);
+
+		if ( $this->order() ) {
+			$this->order()->add_order_note(
+				sprintf( __( 'Omise: Payment failed, %s', 'omise' ), $message )
+			);
 		}
 	}
 


### PR DESCRIPTION
> Note: This pull request requires PR #111 to be merged first.

### 1. Objective

Alipay, Credit Card, Internet Banking payments are currently behaving almost the same in many aspects (except for some part such as charge-creating and handling the charge response).

However, they are completely separated from each other while some part of code could have been shared among each payment method to reduce those redundant code and make the payment processor more easy to maintain.

### 2. Description of change

Previously, each of payment method's class will have its own `process_payment` which have the same structure that can be written as follows:
```php
public function process_payment( $order_id ) {
    // 1. Loading WooCommerce Order from the $order_id into $order

    try {
        // 2. Logging an initiating message to WooCommerce Order
        // 3. Gathering all data and create a new charge
        // 4. Logging that charge has been created, attaching OmiseCharge.id as WooCommerce Order's transaction id.
        // 5. Validating a charge result, result will be depending on its charge.status (successful, failed, pending).
    } catch (Exception $e) {
        // 6. Notify an error message to the checkout page (wc_add_notice())
        // 7. Then, logging an error message to WooCommerce Order.
    }
}
```

By the above structure, we can simply take those redundant code out and group it into one method.
```php
class Omise_Payment {
    public function process_payment( $order_id ) {
        // 1. Loading WooCommerce Order from the $order_id into $order

        try {
            // 2. Logging an initiating message to WooCommerce Order

            $charge = $this->charge( $order_id, $order );

            // 4. Logging that charge has been created, attaching OmiseCharge.id as WooCommerce Order's transaction id.

            return $this->result( $order_id, $order, $charge );
        } catch (Exception $e) {
            // 6. Notify an error message to the checkout page (wc_add_notice())
            // 7. Then, logging an error message to WooCommerce Order.
        }
    }
}
```

And let those payment processors concern only _how to create its own charge_ and _validating a charge result._

```php
class Omise_Payment_Alipay extends Omise_Payment {
    public function charge( $order_id, $order ) { }
    public function result( $order_id, $order, $charge ) { }
}

class Omise_Payment_Creditcard extends Omise_Payment {
    public function charge( $order_id, $order ) { }
    public function result( $order_id, $order, $charge ) { }
}

class Omise_Payment_Internetbanking extends Omise_Payment {
    public function charge( $order_id, $order ) { }
    public function result( $order_id, $order, $charge ) { }
}
```

By this approach, those payment processor classes would be much more smaller and have less responsibility, reducing unnecessary code & easy to maintain. Bonus point is also to decoupling the code, would make it more easy to test (either by manual test or unit test)

### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.0.3
- **WooCommerce**: v3.5.3
- **PHP version**: 5.6.30

**✏️ Details:**

**Because this pull request is refactoring on both 3 payment processor classes, it requires a serious test on both 3 payment methods' functionalities.**
Test details are as follows:

#### • Alipay Payment
There are 4 important cases that need to be tested.
**1. Making a new order with Alipay payment and mark as successful**
By placing an order as normal process, and choose **Alipay** as a payment method.
<img width="1552" alt="Screen Shot 2562-04-01 at 22 35 23" src="https://user-images.githubusercontent.com/2154669/55340134-450d3380-54ce-11e9-9a22-98297c2adbcf.png">

[Screenshot: Mark as success](https://user-images.githubusercontent.com/2154669/55340132-44749d00-54ce-11e9-8abb-c00f31b9e018.png), [Screenshot: order successfully](https://user-images.githubusercontent.com/2154669/55340133-44749d00-54ce-11e9-8e64-7f6db98a98a8.png)

**2. Making a new order with Alipay payment and mark as failed**
By placing an order as normal process, and choose **Alipay** as a payment method but mark the charge as failed.
<img width="1552" alt="Screen Shot 2562-04-01 at 22 35 00" src="https://user-images.githubusercontent.com/2154669/55340391-c664c600-54ce-11e9-94ee-d0f3e5c7f67b.png">

[Screenshot: Order failed](https://user-images.githubusercontent.com/2154669/55340365-bc42c780-54ce-11e9-9a32-89af9180d66e.png)

**3. Making a new order with Alipay payment and test in case of `charge.status` = `pending`.**
This test requires a tester to do hard-code a charge result to **"pending"** (as we don't have a proper way to mark a charge transaction as pending at the moment)

Add the following code to the line as in the below link:
```php
$charge['status']     = 'pending';
$charge['authorized'] = false;
$charge['paid']       = false;
```
https://github.com/omise/omise-woocommerce/blob/master/includes/gateway/class-omise-payment-alipay.php#L184

This to fake a charge result and force it into a race-condition where the result of a particular charge is not neither `successful` nor `failed`.

<img width="1552" alt="Screen Shot 2562-04-01 at 22 48 28" src="https://user-images.githubusercontent.com/2154669/55341712-49871b80-54d1-11e9-9366-24375028bf55.png">

**4. Make sure that Webhook feature still works properly.**

#### • Credit Card Payment
There are 7 important cases that need to be tested.
**1. Making a new order with `auth-only`.**
<img width="1552" alt="Screen Shot 2562-04-02 at 00 47 26" src="https://user-images.githubusercontent.com/2154669/55348230-f026e880-54e0-11e9-8702-4f8acc68362d.png">

[Screenshot: Order received](https://user-images.githubusercontent.com/2154669/55348252-fa48e700-54e0-11e9-9352-9ee6f285c1a4.png)

**2. Test capturing an authorized charge at WooCommerce Order Detail page.**
<img width="1552" alt="Screen Shot 2562-04-02 at 00 49 17" src="https://user-images.githubusercontent.com/2154669/55348360-3e3bec00-54e1-11e9-8dde-6402a1105666.png">

**3. Test refunding a captured charge at WooCommerce Order Detail page.**
<img width="1552" alt="Screen Shot 2562-04-02 at 00 51 01" src="https://user-images.githubusercontent.com/2154669/55348455-6e838a80-54e1-11e9-9948-49ec9d398df9.png">

**4. Making a new order with `auto-capture`.**
<img width="1552" alt="Screen Shot 2562-04-04 at 10 16 38" src="https://user-images.githubusercontent.com/2154669/55527333-c75e4900-56c2-11e9-9e01-f3642716c541.png">

**5. Making a new order and save a card**
<img width="1552" alt="Screen Shot 2562-04-04 at 10 23 28" src="https://user-images.githubusercontent.com/2154669/55527571-d5609980-56c3-11e9-868b-1dd566de4909.png">

<img width="1552" alt="Screen Shot 2562-04-04 at 10 24 12" src="https://user-images.githubusercontent.com/2154669/55527572-d5609980-56c3-11e9-996f-a6c04f5e995c.png">

**6. Making a new order and use a saved-card**

**7. Make sure that Webhook feature still works properly.**

#### • Internet Banking Payment
There are 4 important cases that need to be tested.
**1. Making a new order with Internet Banking payment and mark as successful**
By placing an order as normal process, and choose **Internet Banking** as a payment method.

<img width="1552" alt="Screen Shot 2562-04-01 at 23 49 00" src="https://user-images.githubusercontent.com/2154669/55344949-fa44e900-54d8-11e9-94f6-f8d273c4cbf0.png">

[Screenshot: Mark as success](https://user-images.githubusercontent.com/2154669/55344967-04ff7e00-54d9-11e9-8d95-f0fd0da28a2d.png), [Screenshot: Order detail page](https://user-images.githubusercontent.com/2154669/55344968-04ff7e00-54d9-11e9-84e4-746079a35b0d.png)

**2. Making a new order with Internet Banking payment and mark as failed**
By placing an order as normal process, and choose **Internet Banking** as a payment method but mark the charge as failed.
<img width="1552" alt="Screen Shot 2562-04-01 at 23 53 15" src="https://user-images.githubusercontent.com/2154669/55345169-73444080-54d9-11e9-9ba8-d8a0e8d57ede.png">

[Screenshot: Order detail page](https://user-images.githubusercontent.com/2154669/55345170-73dcd700-54d9-11e9-8cb3-1a516f0bf849.png)

**3. Making a new order with Internet Banking payment and test in case of `charge.status` = `pending`.**
This test requires a tester to do hard-code a charge result to **"pending"** (as we don't have a proper way to mark a charge transaction as pending at the moment)

Add the following code to the line as in the below link:
```php
$charge['status']     = 'pending';
$charge['authorized'] = false;
$charge['paid']       = false;
```
https://github.com/omise/omise-woocommerce/blob/master/includes/gateway/class-omise-payment-internetbanking.php#L199

This to fake a charge result and force it into a race-condition where the result of a particular charge is not neither `successful` nor `failed`.
<img width="1552" alt="Screen Shot 2562-04-02 at 00 41 55" src="https://user-images.githubusercontent.com/2154669/55347939-316ac880-54e0-11e9-8850-4e7aba22d51b.png">

**4. Make sure that Webhook feature still works properly.**

### 4. Impact of the change

- Some log messages are changed, the list of effected-messages are as follows:
[drafting]

### 5. Priority of change

Normal

### 6. Additional Notes

No