### PR TITLE
Migrating all related code to support Omise API version v2017-11-02.

### DIFF
--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -41,10 +41,7 @@ class Omise_Event_Charge_Capture {
 
 		switch ($data->status) {
 			case 'successful':
-				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
-				$paid = isset( $data->captured ) ? $data->captured : $data->paid;
-
-				if ( $data->authorized && $paid ) {
+				if ( $data->authorized && $data->paid ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -75,10 +75,7 @@ class Omise_Event_Charge_Complete {
 				break;
 
 			case 'successful':
-				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
-				$paid = isset( $data->captured ) ? $data->captured : $data->paid;
-
-				if ( $data->authorized && $paid ) {
+				if ( $data->authorized && $data->paid ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -93,7 +93,7 @@ function register_omise_alipay() {
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
 					'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
-					'offsite'     => 'alipay',
+					'source'      => array( 'type' => 'alipay' ),
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
 					'metadata'    => array_merge( $metadata, array(
 						/** override order_id as a reference for webhook handlers **/
@@ -186,10 +186,7 @@ function register_omise_alipay() {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 				}
 
-				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
-				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
-
-				if ( 'pending' === $charge['status'] && ! $paid ) {
+				if ( 'pending' === $charge['status'] && ! $charge['paid'] ) {
 					$order->add_order_note(
 						wp_kses(
 							__( 'Omise: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual \'Sync Payment Status\' action from the Order Actions panel or check the payment status directly at Omise dashboard again later', 'omise' ),
@@ -204,10 +201,7 @@ function register_omise_alipay() {
 					die();
 				}
 
-				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
-				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
-
-				if ( 'successful' === $charge['status'] && $paid ) {
+				if ( 'successful' === $charge['status'] && $charge['paid'] ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -108,7 +108,7 @@ function register_omise_internetbanking() {
 					'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 					'currency'    => $order->get_order_currency(),
 					'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
-					'offsite'     => $_POST['omise-offsite'],
+					'source'      => array( 'type' => $_POST['omise-offsite'] ),
 					'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
 					'metadata'    => array_merge( $metadata, array(
 						/** override order_id as a reference for webhook handlers **/
@@ -201,10 +201,7 @@ function register_omise_internetbanking() {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
 				}
 
-				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
-				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
-
-				if ( 'pending' === $charge['status'] && ! $paid ) {
+				if ( 'pending' === $charge['status'] && ! $charge['paid'] ) {
 					$order->add_order_note(
 						wp_kses(
 							__( 'Omise: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual \'Sync Payment Status\' action from the Order Actions panel or check the payment status directly at Omise dashboard again later', 'omise' ),
@@ -219,10 +216,7 @@ function register_omise_internetbanking() {
 					die();
 				}
 
-				// Backward compatible with Omise API version 2014-07-27 by checking if 'captured' exist.
-				$paid = isset( $charge['captured'] ) ? $charge['captured'] : $charge['paid'];
-
-				if ( 'successful' === $charge['status'] && $paid ) {
+				if ( 'successful' === $charge['status'] && $charge['paid'] ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(

--- a/includes/libraries/omise-plugin/helpers/charge.php
+++ b/includes/libraries/omise-plugin/helpers/charge.php
@@ -35,9 +35,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
         public static function isPaid($charge)
         {
             if (self::isChargeObject($charge)) {
-                // support Omise API version '2014-07-27' by checking if 'captured' exist.
-                $paid = isset($charge['captured']) ? $charge['captured'] : $charge['paid'];
-                if ($paid === true)
+                if ($charge['paid'] === true)
                     return true;
             }
 

--- a/includes/libraries/omise-plugin/helpers/charge.php
+++ b/includes/libraries/omise-plugin/helpers/charge.php
@@ -20,12 +20,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
          */
         public static function isAuthorized($charge)
         {
-            if (self::isChargeObject($charge)) {
-                if ($charge['authorized'] === true)
-                    return true;
-            }
-
-            return false;
+            return self::isChargeObject($charge) && $charge['authorized'];
         }
 
         /**
@@ -34,12 +29,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
          */
         public static function isPaid($charge)
         {
-            if (self::isChargeObject($charge)) {
-                if ($charge['paid'] === true)
-                    return true;
-            }
-
-            return false;
+            return self::isChargeObject($charge) && $charge['paid'];
         }
 
         /**

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -105,7 +105,7 @@ class Omise {
 
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION', $this->version );
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_PATH' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_PATH', __DIR__ );
-		defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2014-07-27' );
+		defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2017-11-02' );
 		defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, WC()->version ) );
 	}
 


### PR DESCRIPTION
#### 1. Objective

The upcoming implementation for the Installment payment is required for the latest Omise API version, `2017-11-02` which the current core-code of the plugin doesn't support. 

This pull request is aiming to migrate all related code to support the Omise API version `2017-11-02`.

#### 2. Description of change

All code should function the same except now we are switching Omise API to the latest version, `2017-11-02`, which support Source API.

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**:  v5.0.3.
- **WooCommerce**:  v3.5.4.
- **PHP**: v5.6.30.

**✏️ Details:**

1. Test create a new charge using Alipay payment method.
  **Expected result:**
  To make sure that the plugin would still be able to create a new Alipay charge after migrate to the new API version.
  <img width="1552" alt="screen shot 2562-02-21 at 17 09 58" src="https://user-images.githubusercontent.com/2154669/53153439-9a1a7780-35fb-11e9-850c-b9780ba64b45.png">

2. Test create a new charge using Internet Banking payment method.
  **Expected result:**
  To make sure that the plugin would still be able to create a new Internet Banking charge after migrate to the new API version.
  <img width="1552" alt="screen shot 2562-02-21 at 17 13 21" src="https://user-images.githubusercontent.com/2154669/53153612-10b77500-35fc-11e9-9c3e-1b65af7d6711.png">

3. Test manual capture an authorized charge via Omise Dashboard
  **Expected result:**
  To make sure that the `charge.captured` event handler can make a proper decision as some part of this code has bene migrated to support the latest Omise API version as well.
  <img width="1152" alt="screen shot 2562-02-21 at 17 19 40" src="https://user-images.githubusercontent.com/2154669/53154088-4741bf80-35fd-11e9-9d53-72d23ce70b32.png">

4. Test create a new offsite charge to trigger `charge.complete` event & observe its behaviour
  **Expected result:**
  To make sure that the `charge.complete` event handler can make a proper decision as some part of this code has bene migrated to support the latest Omise API version as well.
  .
  The left, for successful case, and the right side is for failure case.
  <img width="1375" alt="screen shot 2562-02-21 at 17 33 05" src="https://user-images.githubusercontent.com/2154669/53154860-0ba7f500-35ff-11e9-979e-169f4aa8b963.png">


#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No