### PR TITLE
fixed internetbanking status fail after successful order

### DIFF
--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -70,9 +70,9 @@ class Omise_Event_Charge_Complete {
 						$data->failure_message . ' (code: ' . $data->failure_code . ')'
 					)
 				);
-				if( $order->get_status() !== 'successful'){
+				if (!in_array( $order->get_status(), array('processing', 'completed' ))) {
 					$order->update_status( 'failed' );
-				}		
+				}
 				break;
 
 			case 'successful':

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -70,8 +70,9 @@ class Omise_Event_Charge_Complete {
 						$data->failure_message . ' (code: ' . $data->failure_code . ')'
 					)
 				);
-
-				$order->update_status( 'failed' );
+				if( $order->get_status() !== 'successful'){
+					$order->update_status( 'failed' );
+				}		
 				break;
 
 			case 'successful':


### PR DESCRIPTION
#### 1. Objective

When a customer tries to pay using internet banking and does not complete the process, but created a new charge (using any method) successfully.
The order will be marked as completed when the second charge is successful, but when the first charge is timed out. The successful order will be updated as failed.

**Related information**:
Related issue(s): #100

#### 2. Description of change

The `charge.complete` event handler checks whether the order is already completed before updating the order as failed.

#### 3. Quality assurance

Tested manually by selecting internet banking as the payment method.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **Platform version**: WooCommerce 3.4.4.
- **Omise plugin version**: Omise-WooCommerce 3.2.
- **PHP version**: 7.0.14.

**✏️ Details:**

- Select Internet banking as payment method without proceeding to payment
- Go back to checkout page
- Pay with Debit/Credit Card
- Wait for the first charge to time out

#### 4. Impact of the change
none

#### 5. Priority of change

Normal
