### PR TITLE
Omise Setting Page, sanitizing input fields before save

### DIFF
--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -34,6 +34,10 @@ class Omise_Page_Settings {
 	 * @since  3.1
 	 */
 	protected function save( $data ) {
+		if ( ! isset( $data['omise_setting_page_nonce'] ) || ! wp_verify_nonce( $data['omise_setting_page_nonce'], 'omise-setting' ) ) {
+			wp_die( __( 'You are not allowed to modify the settings from a suspicious source.', 'omise' ) );
+		}
+
 		$this->settings->update_settings( $data );
 	}
 

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -175,6 +175,7 @@
 			</tbody>
 		</table>
 
+		<input type="hidden" name="omise_setting_page_nonce" value="<?= wp_create_nonce( 'omise-setting' ); ?>" />
 		<?php submit_button( __( 'Save Settings', 'omise' ) ); ?>
 
 	</form>

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -84,7 +84,12 @@ class Omise_Setting {
 	 * @since  3.1
 	 */
 	public function update_settings( $data ) {
+		$data            = array_intersect_key( $data, $this->get_default_settings() );
 		$data['sandbox'] = isset( $data['sandbox'] ) && ! is_null( $data['sandbox'] ) ? 'yes' : 'no';
+
+		array_walk( $data, function( &$input, $key ) {
+			$input = esc_html( sanitize_text_field( $input ) );
+		} );
 
 		$this->settings = array_merge(
 			$this->settings,


### PR DESCRIPTION
### 1. Objective

To prevent any suspicious sources from trying to alter Omise options, this pull request is aiming to add a validation and sanitizing the input fields.

**Related information**:
Internal ticket: T10248
Related issue(s): -

#### 2. Description of change

- Validating WP Nonce before allowing a particular post-request pass through the rest of the code.
- Sanitizing inputs before  save a new value to the database.

#### 3. Quality assurance

**🔧 Environments:**

- **PHP version**: 7.3.3.
- **WordPress**: v5.1.1.
- **WooCommerce**:  v3.5.7.

**✏️ Details:**

At the Omise Setting page, you may try to edit a nonce value directly via browser's `inspect element` feature then, submit the form.

<img width="1551" alt="Screen Shot 2562-03-25 at 23 13 49" src="https://user-images.githubusercontent.com/2154669/54935825-b2134d00-4f53-11e9-815b-1c7878720dee.png">

Omise will raise an error message warning that you cannot update the setting.
<img width="1364" alt="Screen Shot 2562-03-25 at 23 06 21" src="https://user-images.githubusercontent.com/2154669/54935419-d7ec2200-4f52-11e9-80a2-be442c719f55.png">

You may also try to update any of the setting's field with the following value:
```html
<script type="text/javascript">alert("Hello! I am an alert box!!");</script>
```
or
```
%3Cscript+type=%22text/javascript%22%3Ealert(%22Hello!+I+am+an+alert+box!!%22);%3C/script%3E
```

The plugin will then sanitize it to
```
script+type=text/javascriptalert(Hello!+I+am+an+alert+box!!);/script
```

#### 4. Impact of the change

No

#### 5. Priority of change

High.

#### 6. Additional Notes

Alternatively, I think there is a better way to handle & validate HTTP Request than adding a condition at `class-omise-page-settings.php`.

Maybe can have a class 
```php
$request = new Omise_Http_Request;

print_r( $request->is_post() ); // true

$request->input( 'omise_setting_page_nonce' )->sanitize();
$this->settings->update_settings( $request->to_array() );
```

Just idea.