### PR TITLE
Refactoring, unify Omise key(s)-defining into one place.

### DIFF
--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -16,7 +16,7 @@ class Omise_Page_Settings {
 	 * @since 3.1
 	 */
 	public function __construct() {
-		$this->settings = new Omise_Setting;
+		$this->settings = Omise()->settings();
 	}
 
 	/**

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -8,9 +8,35 @@ if ( class_exists( 'Omise_Setting' ) ) {
 
 class Omise_Setting {
 	/**
+	 * The Omise_Setting Instance.
+	 *
+	 * @since 3.4
+	 *
+	 * @var   \Omise_Setting
+	 */
+	protected static $the_instance = null;
+
+	/**
 	 * @var null | array
 	 */
 	public $settings;
+
+	/**
+	 * The Omise_Setting Instance.
+	 *
+	 * @since  3.4
+	 *
+	 * @static
+	 *
+	 * @return \Omise_Setting - The instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$the_instance ) ) {
+			self::$the_instance = new self();
+		}
+
+		return self::$the_instance;
+	}
 
 	/**
 	 * @since 3.1

--- a/includes/class-omise-wc-myaccount.php
+++ b/includes/class-omise-wc-myaccount.php
@@ -22,7 +22,7 @@ if ( ! class_exists( 'Omise_MyAccount' ) ) {
 
 			if ( is_user_logged_in() ) {
 				$current_user = wp_get_current_user();
-				$this->omise_customer_id = Omise()->setting()->is_test() ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
+				$this->omise_customer_id = Omise()->settings()->is_test() ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
 			}
 
 			add_action( 'woocommerce_after_my_account', array( $this, 'init_panel' ) );
@@ -81,7 +81,7 @@ if ( ! class_exists( 'Omise_MyAccount' ) ) {
 				'omise-myaccount-card-handler',
 				'omise_params',
 				array(
-					'key'             => Omise()->setting->public_key(),
+					'key'             => Omise()->settings()->public_key(),
 					'ajax_url'        => admin_url( 'admin-ajax.php' ),
 					'ajax_loader_url' => plugins_url( '/assets/images/ajax-loader@2x.gif', dirname( __FILE__ ) )
 				)

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -180,7 +180,7 @@ function register_omise_alipay() {
 			$order->add_order_note( __( 'Omise: Validating the payment result..', 'omise' ) );
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 				if ( 'failed' === $charge['status'] ) {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -152,7 +152,7 @@ function register_omise_creditcard() {
 				$omise_customer_id = $this->is_test() ? $current_user->test_omise_customer_id : $current_user->live_omise_customer_id;
 				if ( ! empty( $omise_customer_id ) ) {
 					try {
-						$customer                  = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
+						$customer                  = OmiseCustomer::retrieve( $omise_customer_id );
 						$viewData['existingCards'] = $customer->cards( array( 'order' => 'reverse_chronological' ) );
 					} catch (Exception $e) {
 						// nothing
@@ -211,7 +211,7 @@ function register_omise_creditcard() {
 					if ( ! empty( $omise_customer_id ) ) {
 						try {
 							// attach a new card to customer
-							$customer = OmiseCustomer::retrieve( $omise_customer_id, '', $this->secret_key() );
+							$customer = OmiseCustomer::retrieve( $omise_customer_id );
 							$customer->update( array(
 								'card' => $token
 							) );
@@ -232,7 +232,7 @@ function register_omise_creditcard() {
 							"card"        => $token
 						);
 
-						$omise_customer = OmiseCustomer::create( $customer_data, '', $this->secret_key() );
+						$omise_customer = OmiseCustomer::create( $customer_data );
 
 						if ( $omise_customer['object'] == "error" ) {
 							throw new Exception( $omise_customer['message'] );
@@ -293,7 +293,7 @@ function register_omise_creditcard() {
 					'order_id' => version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_id() : $order->id
 				) );
 
-				$charge = OmiseCharge::create( $data, '', $this->secret_key() );
+				$charge = OmiseCharge::create( $data );
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
 
@@ -441,7 +441,7 @@ function register_omise_creditcard() {
 			);
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 				$refund = $charge->refunds()->create( array(
 					'amount' => $this->format_amount_subunit( $amount, $order->get_order_currency() )
 				) );
@@ -516,7 +516,7 @@ function register_omise_creditcard() {
 			$order->add_order_note( __( 'Omise: Validating the payment result..', 'omise' ) );
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 				switch ( strtoupper( $this->payment_action ) ) {
 					case 'MANUAL_CAPTURE':

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -195,7 +195,7 @@ function register_omise_internetbanking() {
 			$order->add_order_note( __( 'Omise: Validating the payment result..', 'omise' ) );
 
 			try {
-				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 				if ( 'failed' === $charge['status'] ) {
 					throw new Exception( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -52,7 +52,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	protected $order;
 
 	public function __construct() {
-		$this->omise_settings   = Omise()->setting();
+		$this->omise_settings   = Omise()->settings();
 		$this->payment_settings = $this->omise_settings->get_settings();
 	}
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -52,7 +52,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	protected $order;
 
 	public function __construct() {
-		$this->omise_settings   = new Omise_Setting;
+		$this->omise_settings   = Omise()->setting();
 		$this->payment_settings = $this->omise_settings->get_settings();
 	}
 
@@ -185,7 +185,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		$this->load_order( $order );
 
 		try {
-			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 			$charge->capture();
 
 			if ( ! OmisePluginHelperCharge::isPaid( $charge ) ) {
@@ -222,7 +222,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 * @return OmiseCharge
 	 */
 	public function sale( $params ) {
-		return OmiseCharge::create( $params, '', $this->secret_key() );
+		return OmiseCharge::create( $params );
 	}
 
 	/**
@@ -240,7 +240,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		$this->load_order( $order );
 
 		try {
-			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order(), '', $this->secret_key() );
+			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 
 			if ( ! $this->order()->get_transaction_id() ) {
 				/** backward compatible with WooCommerce v2.x series **/

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -69,8 +69,8 @@ class Omise {
 			return;
 		}
 
-		$this->define_constants();
 		$this->include_classes();
+		$this->define_constants();
 		$this->load_plugin_textdomain();
 		$this->register_post_types();
 		$this->init_admin();
@@ -104,7 +104,8 @@ class Omise {
 		global $wp_version;
 
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION', $this->version );
-		defined( 'OMISE_WOOCOMMERCE_PLUGIN_PATH' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_PATH', __DIR__ );
+		defined( 'OMISE_PUBLIC_KEY' ) || define( 'OMISE_PUBLIC_KEY', $this->setting()->public_key() );
+		defined( 'OMISE_SECRET_KEY' ) || define( 'OMISE_SECRET_KEY', $this->setting()->secret_key() );
 		defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2017-11-02' );
 		defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, WC()->version ) );
 	}
@@ -113,6 +114,8 @@ class Omise {
 	 * @since 3.3
 	 */
 	private function include_classes() {
+		defined( 'OMISE_WOOCOMMERCE_PLUGIN_PATH' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_PATH', __DIR__ );
+
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-charge.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-card-image.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-capture.php';
@@ -199,6 +202,17 @@ class Omise {
 		}
 
 		return self::$the_instance;
+	}
+
+	/**
+	 * Get setting class.
+	 *
+	 * @since  3.4
+	 *
+	 * @return Omise_Setting
+	 */
+	public function setting() {
+		return Omise_Setting::instance();
 	}
 }
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -104,8 +104,8 @@ class Omise {
 		global $wp_version;
 
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION', $this->version );
-		defined( 'OMISE_PUBLIC_KEY' ) || define( 'OMISE_PUBLIC_KEY', $this->setting()->public_key() );
-		defined( 'OMISE_SECRET_KEY' ) || define( 'OMISE_SECRET_KEY', $this->setting()->secret_key() );
+		defined( 'OMISE_PUBLIC_KEY' ) || define( 'OMISE_PUBLIC_KEY', $this->settings()->public_key() );
+		defined( 'OMISE_SECRET_KEY' ) || define( 'OMISE_SECRET_KEY', $this->settings()->secret_key() );
 		defined( 'OMISE_API_VERSION' ) || define( 'OMISE_API_VERSION', '2017-11-02' );
 		defined( 'OMISE_USER_AGENT_SUFFIX' ) || define( 'OMISE_USER_AGENT_SUFFIX', sprintf( 'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, WC()->version ) );
 	}
@@ -211,7 +211,7 @@ class Omise {
 	 *
 	 * @return Omise_Setting
 	 */
-	public function setting() {
+	public function settings() {
 		return Omise_Setting::instance();
 	}
 }


### PR DESCRIPTION
#### 1. Objective

Currently in Omise-WooCommerce code base, the public key and the secret key have been spread all over the places. By that, it has a high risk and a potential of any bug from code maintenance in the future (as there are many places that need to be taken care of).  

This pull request is to unifying Omise-Keys declaration into one place to reduce any potential bug & code mess.

#### 2. Description of change

- Defining Omise secret key and public key at the plugin initial step.
- Removing all related code.

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.1.1.
- **WooCommerce**: v3.5.7.
- **PHP version**: v7.3.3.

**✏️ Details:**

All of cases that we should test would be really huge as this pull request is removing all key-assigning out from all of Omise class. However, the main test could be listed as below:

1. Make sure that Alipay payment method works properly by creating a new charge with Alipay payment method.

2. Make sure that Internet Banking payment method works properly by creating a new charge with Internet Banking payment method.

3. Make sure that Credit Card payment method works properly by creating a new charge with Credit Card payment method on both `auth only` and `auto capture`.

4. Make sure that an order can be funded properly

5. Make sure that user can save a card properly.

6. Make sure that user can delete a card properly.

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

This change will help on https://github.com/omise/omise-woocommerce/pull/101 as well (as there is no keys tied up in those methods anymore after this change).