### PR TITLE
🧹 Code Cleaning: Relocating 'capture' method from Omise_Payment class to Omise_Payment_Creditcard.

### DIFF
--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -38,7 +38,7 @@ function register_omise_creditcard() {
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'omise_assets' ) );
-			add_action( 'woocommerce_order_action_' . $this->id . '_charge_capture', array( $this, 'capture' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_charge_capture', array( $this, 'process_capture' ) );
 			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 
 			/** @deprecated 3.0 */
@@ -402,6 +402,51 @@ function register_omise_creditcard() {
 				);
 
 				return;
+			}
+		}
+
+		/**
+		 * Capture an authorized charge.
+		 *
+		 * @param  WC_Order $order WooCommerce's order object
+		 *
+		 * @return void
+		 *
+		 * @see    WC_Meta_Box_Order_Actions::save( $post_id, $post )
+		 * @see    woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+		 */
+		public function process_capture( $order ) {
+			$this->load_order( $order );
+
+			try {
+				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
+				$charge->capture();
+
+				if ( ! OmisePluginHelperCharge::isPaid( $charge ) ) {
+					throw new Exception( $charge['failure_message'] );
+				}
+
+				$this->order()->add_order_note(
+					sprintf(
+						wp_kses(
+							__( 'Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid', 'omise' ),
+							array( 'br' => array() )
+						),
+						$this->order()->get_total(),
+						$this->order()->get_order_currency()
+					)
+				);
+				$this->order()->payment_complete();
+			} catch ( Exception $e ) {
+				$this->order()->add_order_note(
+					sprintf(
+						wp_kses(
+							__( 'Omise: Payment failed (manual capture).<br/>%s', 'omise' ),
+							array( 'br' => array() )
+						),
+						$e->getMessage()
+					)
+				);
 			}
 		}
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -172,51 +172,6 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * Capture an authorized charge.
-	 *
-	 * @param  WC_Order $order WooCommerce's order object
-	 *
-	 * @return void
-	 *
-	 * @see    WC_Meta_Box_Order_Actions::save( $post_id, $post )
-	 * @see    woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
-	 */
-	public function capture( $order ) {
-		$this->load_order( $order );
-
-		try {
-			$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
-			$charge->capture();
-
-			if ( ! OmisePluginHelperCharge::isPaid( $charge ) ) {
-				throw new Exception( $charge['failure_message'] );
-			}
-
-			$this->order()->add_order_note(
-				sprintf(
-					wp_kses(
-						__( 'Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid', 'omise' ),
-						array( 'br' => array() )
-					),
-					$this->order()->get_total(),
-					$this->order()->get_order_currency()
-				)
-			);
-			$this->order()->payment_complete();
-		} catch ( Exception $e ) {
-			$this->order()->add_order_note(
-				sprintf(
-					wp_kses(
-						__( 'Omise: Payment failed (manual capture).<br/>%s', 'omise' ),
-						array( 'br' => array() )
-					),
-					$e->getMessage()
-				)
-			);
-		}
-	}
-
-	/**
 	 * @param  array $params
 	 *
 	 * @return OmiseCharge


### PR DESCRIPTION
#### 1. Objective

I was working on https://github.com/omise/omise-woocommerce/pull/101 and found out that this `Omise_Payment::capture` method can be relocated to `Omise_Payment_Creditcard::capture` as it has been used only for Credit Card payment method only.

Here is to prevent a huge change in one pull request by submitting a small-independent code separately.

#### 2. Description of change

Relocating `capture` method from `Omise_Payment` to `Omise_Payment_Creditcard`.

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.1.1.
- **WooCommerce**: v3.5.7.
- **PHP version**: 7.3.3.

**✏️ Details:**

Make sure that the capture feature still works properly. (tested)
<img width="1552" alt="Screen Shot 2562-03-28 at 16 21 33" src="https://user-images.githubusercontent.com/2154669/55145988-58d73380-5176-11e9-863a-766a87999361.png">

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No