### PR TITLE
Removing all redundant code regarding to WC Order transaction ID assignment.

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -106,17 +106,9 @@ function register_omise_alipay() {
 
 				switch ( $charge['status'] ) {
 					case 'pending':
-						$this->attach_charge_id_to_order( $charge['id'] );
+						$this->set_order_transaction_id( $charge['id'] );
 
 						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
-
-						/** backward compatible with WooCommerce v2.x series **/
-						if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
-							$order->set_transaction_id( $charge['id'] );
-							$order->save();
-						} else {
-							update_post_meta( $order->id, '_transaction_id', $charge['id'] );
-						}
 
 						return array (
 							'result'   => 'success',

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -297,18 +297,10 @@ function register_omise_creditcard() {
 
 				$order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
 
-				$this->attach_charge_id_to_order( $charge['id'] );
+				$this->set_order_transaction_id( $charge['id'] );
 
 				if ( Omise_Charge::is_failed( $charge ) ) {
 					throw new Exception( Omise_Charge::get_error_message( $charge ) );
-				}
-
-				/** backward compatible with WooCommerce v2.x series **/
-				if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
-					$order->set_transaction_id( $charge['id'] );
-					$order->save();
-				} else {
-					update_post_meta( $order->id, '_transaction_id', $charge['id'] );
 				}
 
 				if ( $this->omise_3ds ) {

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -121,17 +121,9 @@ function register_omise_internetbanking() {
 
 				switch ( $charge['status'] ) {
 					case 'pending':
-						$this->attach_charge_id_to_order( $charge['id'] );
+						$this->set_order_transaction_id( $charge['id'] );
 
 						$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer out to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
-
-						/** backward compatible with WooCommerce v2.x series **/
-						if ( version_compare( WC()->version, '3.0.0', '>=' ) ) {
-							$order->set_transaction_id( $charge['id'] );
-							$order->save();
-						} else {
-							update_post_meta( $order->id, '_transaction_id', $charge['id'] );
-						}
 
 						return array (
 							'result'   => 'success',

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     3.3
+ * Version:     3.4-dev
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -18,7 +18,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '3.3';
+	public $version = '3.4-dev';
 
 	/**
 	 * The Omise Instance.


### PR DESCRIPTION
#### 1. Objective

Omise-WooCommerce, back to the time, was seeking for a way to retrieve Omise charge id from WooCommerce Order that has been placed. So we've decided to create a new custom-field inside a WC order.

Now, it comes to realized that actually we could simply integrate with WC order's transaction id.
This pull request is aiming to remove the mess.

#### 2. Description of change

- No more attaching Omise charge id with a custom field inside Order item.
- Refactoring the code accordingly.

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.1.1
- **WooCommerce**: v3.5.7
- **PHP version**: 7.3.3

**✏️ Details:**

Make sure that all 3 payment methods could assign Omise charge id to its order properly.
**Alipay**
<img width="1552" alt="Screen Shot 2562-03-30 at 13 42 21" src="https://user-images.githubusercontent.com/2154669/55272773-4551d700-52f4-11e9-8c37-7758d2a1d750.png">

**Credit Card**
<img width="1552" alt="Screen Shot 2562-03-30 at 13 44 18" src="https://user-images.githubusercontent.com/2154669/55272778-5bf82e00-52f4-11e9-89c0-f204883908c0.png">

**Internet Banking**
<img width="1552" alt="Screen Shot 2562-03-30 at 13 43 54" src="https://user-images.githubusercontent.com/2154669/55272776-53075c80-52f4-11e9-8510-b378d16c9eac.png">

Also make sure that a feature that requires _retrieving charge id from an order item_ would function properly.
**Capture a charge**
<img width="1552" alt="Screen Shot 2562-03-30 at 13 45 23" src="https://user-images.githubusercontent.com/2154669/55272786-7a5e2980-52f4-11e9-8918-cc56ae264682.png">

#### 4. Impact of the change

Not in particularly, but 3rd-party plugins may want to have a look if anyone has implemented with the charge-id custom field that this pull request is removing (not affect, just, deprecated code and would be nice to update the codebase)

#### 5. Priority of change

Normal

#### 6. Additional Notes

The reason that we cannot completely get rid of legacy code is because there might be someone or some 3rd-party plugins that have implemented with those code already.

Would like to keep it for a while or until WooCommerce has a new major release.