### PR TITLE
[WIP] Allowing 3rd-party WordPress theme to override Omise plugin templates

### DIFF
--- a/includes/class-omise-template.php
+++ b/includes/class-omise-template.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @since 3.8
+ */
+class Omise_Template {
+	/**
+	 * @var string
+	 */
+	protected $default_template_location = 'templates';
+
+	/**
+	 * @var string
+	 */
+	protected $default_override_folder = 'omise';
+
+	/**
+	 * @var WP_Theme|null
+	 */
+	protected $current_theme;
+
+	/**
+	 * @var string|null
+	 */
+	protected $view_path;
+
+	/**
+	 * @var array|null
+	 */
+	protected $view_data;
+
+	public function __construct() {
+		$this->current_theme = wp_get_theme();
+	}
+
+	/**
+	 * @param string     $path
+	 * @param mixed|null $data
+	 */
+	public static function view( $path, $data = null ) {
+		$template = new static;
+		$template->set_view_path( $path );
+		$template->set_view_data( $data );
+
+		$data     = $template->get_view_data();
+		$viewData = $data; // Backward compatible for Omise-WooCommerce v3.3 and below.
+
+		require_once $template->get_view_path();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_view_path() {
+		if ( $this->current_theme->exists() ) {
+			$path = $this->current_theme->get_template_directory() . '/' . $this->default_override_folder . '/' . $this->view_path;
+		}
+
+		return file_exists( $path )
+			? $path
+			: OMISE_WOOCOMMERCE_PLUGIN_PATH . '/' . $this->default_template_location . '/' . $this->view_path;
+	}
+
+	/**
+	 * @return array 
+	 */
+	public function get_view_data() {
+		return $this->view_data;
+	}
+
+	/**
+	 * @param string $path
+	 */	
+	public function set_view_path( $path ) {
+		$this->view_path = trim( $path, '/' );
+	}
+
+	/**
+	 * @param mixed $data
+	 */
+	public function set_view_data( $data ) {
+		$this->view_data = is_array( $data ) ? $data : array( $data );
+	}
+}

--- a/includes/class-omise-wc-myaccount.php
+++ b/includes/class-omise-wc-myaccount.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'Omise_MyAccount' ) ) {
 					$customer                  = OmiseCustomer::retrieve( $this->omise_customer_id );
 					$viewData['existingCards'] = $customer->cards();
 
-					Omise_Util::render_view( 'templates/myaccount/my-card.php', $viewData );
+					Omise_Template::view( 'myaccount/my-card.php', $viewData );
 					$this->register_omise_my_account_scripts();
 				} catch (Exception $e) {
 					// nothing.

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -165,7 +165,7 @@ function register_omise_creditcard() {
 				$viewData['user_logged_in'] = false;
 			}
 
-			Omise_Util::render_view( 'templates/payment/form.php', $viewData );
+			Omise_Template::view( 'payment/form.php', $viewData );
 		}
 
 		/**

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -74,8 +74,8 @@ function register_omise_installment() {
 			$currency   = get_woocommerce_currency();
 			$cart_total = WC()->cart->total;
 
-			Omise_Util::render_view(
-				'templates/payment/form-installment.php',
+			Omise_Template::view(
+				'payment/form-installment.php',
 				array(
 					'installment_backends' => $this->backend->get_available_providers( $currency, $cart_total ),
 					'is_zero_interest'     => $this->backend->capabilities()->is_zero_interest()

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -72,7 +72,7 @@ function register_omise_internetbanking() {
 		public function payment_fields() {
 			parent::payment_fields();
 
-			Omise_Util::render_view( 'templates/payment/form-internetbanking.php', array() );
+			Omise_Template::view( 'payment/form-internetbanking.php' );
 		}
 
 		/**

--- a/omise-util.php
+++ b/omise-util.php
@@ -4,15 +4,6 @@ defined( 'ABSPATH' ) or die( "No direct script access allowed." );
 if ( ! class_exists( 'Omise_Util' ) ) {
 	class Omise_Util {
 		/**
-		 * Renders php template
-		 * @param string $viewPath
-		 * @param Array $viewData
-		 */
-		public static function render_view( $viewPath, $viewData ) {
-			require_once( plugin_dir_path( __FILE__ ) . $viewPath );
-		}
-
-		/**
 		 * Renders error message in JSON format
 		 * @param string $message
 		 */

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -137,6 +137,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-money.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-template.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/omise-util.php';
 	}


### PR DESCRIPTION
#### 1. Objective

This pull request is aiming to solve 2 topics.
1. To have a proper place / class to handle all HTML templates that Omise-WooCommerce is currently using.
At various parts of Omise-WooCommerce, it currently renders HTML element by using a quite common approach in WordPress, which is, hard-coded HTML code into a PHP file, more specifically, hard-coded in a function.

2. 3rd-party themes should be able to override all HTML templates.
The plugin alters the WooCommerce checkout page and leave its own payment form's style there, which in fact, it should be managed by a specific active them that that store uses instead of being controlled by plugin.

This pull request is aiming to solve this sort of mess by providing a dedicated class to handle these topics.

**Related information**:
Related issue(s): #110

#### 2. Description of change

1. Introducing a new class ** Omise_Template** _(includes/class-omise-template.php)_ as a class to handle all html templates that the plugin is using.
2. Replacing all `Omise_Util::render_view()` with `Omise_Template:: render()`.
3. Deprecating all template-related method at `Omise_Util` class.

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.2.1.
- **WooCommerce**: v3.6.4.
- **PHP version**: 7.3.3.

**✏️ Details:**

All of related views should be displayed as the same for Credit Card, Internet Banking, Installment payment methods, as well as a card list element at My Account page.

However, now the current active theme should be able to override all those templates without touching the core code of Omise-WooCommerce.

#### 4. Impact of the change

none

#### 5. Priority of change

Normal

#### 6. Additional Notes

none
