### PR TITLE
Better way to handle amount subunit

### DIFF
--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -2,7 +2,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * @since 3.5
+ * @since 3.6
  */
 class Omise_Money {
 	/**

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -48,7 +48,7 @@ class Omise_Money {
 	}
 
 	/**
-	 * @param mixed $amount
+	 * @param  int|float|string $amount
 	 *
 	 * @return int|float|string
 	 */
@@ -72,7 +72,7 @@ class Omise_Money {
 	}
 
 	/**
-	 * @return float
+	 * @return int|float|string  Depending on what type of value that is passed through the construction.
 	 */
 	public function getAmount() {
 		return $this->amount;

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -43,16 +43,16 @@ class Omise_Money {
 			throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
 		}
 
-		$this->amount   = (float) $this->purifyAmount( $amount );
+		$this->amount   = $this->purify_amount( $amount );
 		$this->currency = strtoupper( $currency );
 	}
 
 	/**
 	 * @param  int|float|string $amount
 	 *
-	 * @return int|float|string
+	 * @return float
 	 */
-	public function purifyAmount( $amount ) {
+	public function purify_amount( $amount ) {
 		if ( ! is_string( $amount ) && ! is_float( $amount ) && ! is_numeric( $amount ) ) {
 			throw new Exception( __( 'An amount has to be integer, float, or string.', 'omise' ) );
 		} 
@@ -61,27 +61,27 @@ class Omise_Money {
 			$amount = preg_replace("/[^0-9.]/", '', $amount);
 		}
 
-		return $amount;
+		return (float) $amount;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function toSubunit() {
+	public function to_subunit() {
 		return (int) ( ( floor( $this->amount * 100 ) / 100 ) * $this->subunit_multiplier[ $this->currency ] );
 	}
 
 	/**
-	 * @return int|float|string  Depending on what type of value that is passed through the construction.
+	 * @return float
 	 */
-	public function getAmount() {
+	public function get_amount() {
 		return $this->amount;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getCurrency() {
+	public function get_currency() {
 		return $this->currency;
 	}
 }

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -28,7 +28,14 @@ class Omise_Money {
 	 * @param  int|float|string $amount
 	 * @param  string           $currency
 	 *
-	 * @return int
+	 * @return int|float  Note that the expected output value's type of this method is to be `int` as Omise Charge API requires.
+	 *                    However, there is a case that this method will return a `float` regarding to
+	 *                    the improper WooCommerce currency setting, which considered as an invalid type of amount.
+	 *
+	 *                    And we would like to let the API raises an error out loud instead of silently remove
+	 *                    or casting a `float` value to `int` subunit.
+	 *                    This is to prevent any miscalculation for those fractional subunits
+	 *                    between the amount that is charged, and the actual amount from the store.
 	 */
 	public function to_subunit( $amount, $currency ) {
 		$amount   = static::purify_amount( $amount );

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -25,8 +25,8 @@ class Omise_Money {
 	);
 
 	/**
-	 * @param  int|float $amount
-	 * @param  string    $currency
+	 * @param  int|float|string $amount
+	 * @param  string           $currency
 	 *
 	 * @return int
 	 */
@@ -38,7 +38,7 @@ class Omise_Money {
 			throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
 		}
 
-		return (int) ( ( floor( $amount * 100 ) / 100 ) * static::$subunit_multiplier[ $currency ] );
+		return $amount * static::$subunit_multiplier[ $currency ];
 	}
 
 	/**
@@ -48,7 +48,7 @@ class Omise_Money {
 	 */
 	private static function purify_amount( $amount ) {
 		if ( ! is_numeric( $amount ) ) {
-			throw new Exception( __( 'Invalid amount. An amount has to be in a number format.', 'omise' ) );
+			throw new Exception( __( 'Invalid amount type given. Should be int, float, or numeric string.', 'omise' ) );
 		}
 
 		return (float) $amount;

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -1,0 +1,87 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 3.5
+ */
+class Omise_Money {
+	/**
+	 * @var float
+	 */
+	protected $amount;
+
+	/**
+	 * @var string
+	 */
+	protected $currency;
+
+	/**
+	 * @var array
+	 */
+	private $subunit_multiplier = array(
+		'AUD' => 100,
+		'CAD' => 100,
+		'CHF' => 100,
+		'CNY' => 100,
+		'DKK' => 100,
+		'EUR' => 100,
+		'GBP' => 100,
+		'HKD' => 100,
+		'JPY' => 1,
+		'MYR' => 100,
+		'SGD' => 100,
+		'THB' => 100,
+		'USD' => 100
+	);
+
+	/**
+	 * @param int|float|string $amount
+	 * @param string           $currency
+	 */
+	public function __construct( $amount, $currency ) {
+		if ( ! isset( $this->subunit_multiplier[ strtoupper( $currency ) ] ) ) {
+			throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
+		}
+
+		$this->amount   = (float) $this->purifyAmount( $amount );
+		$this->currency = strtoupper( $currency );
+	}
+
+	/**
+	 * @param mixed $amount
+	 *
+	 * @return int|float|string
+	 */
+	public function purifyAmount( $amount ) {
+		if ( ! is_string( $amount ) && ! is_float( $amount ) && ! is_numeric( $amount ) ) {
+			throw new Exception( __( 'An amount has to be integer, float, or string.', 'omise' ) );
+		} 
+
+		if ( is_string( $amount ) ) {
+			$amount = preg_replace("/[^0-9.]/", '', $amount);
+		}
+
+		return $amount;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function toSubunit() {
+		return (int) ( ( floor( $this->amount * 100 ) / 100 ) * $this->subunit_multiplier[ $this->currency ] );
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getAmount() {
+		return $this->amount;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCurrency() {
+		return $this->currency;
+	}
+}

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -26,19 +26,6 @@ class Omise_Money {
 
 	/**
 	 * @param  int|float $amount
-	 *
-	 * @return float
-	 */
-	public static function purify_amount( $amount ) {
-		if ( ! is_numeric( $amount ) ) {
-			throw new Exception( __( 'An amount has to be integer, or float.', 'omise' ) );
-		}
-
-		return (float) $amount;
-	}
-
-	/**
-	 * @param  int|float $amount
 	 * @param  string    $currency
 	 *
 	 * @return int
@@ -52,5 +39,18 @@ class Omise_Money {
 		}
 
 		return (int) ( ( floor( $amount * 100 ) / 100 ) * static::$subunit_multiplier[ $currency ] );
+	}
+
+	/**
+	 * @param  int|float $amount
+	 *
+	 * @return float
+	 */
+	private static function purify_amount( $amount ) {
+		if ( ! is_numeric( $amount ) ) {
+			throw new Exception( __( 'Invalid amount. An amount has to be in a number format.', 'omise' ) );
+		}
+
+		return (float) $amount;
 	}
 }

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -6,19 +6,9 @@ defined( 'ABSPATH' ) || exit;
  */
 class Omise_Money {
 	/**
-	 * @var float
-	 */
-	protected $amount;
-
-	/**
-	 * @var string
-	 */
-	protected $currency;
-
-	/**
 	 * @var array
 	 */
-	private $subunit_multiplier = array(
+	private static $subunit_multiplier = array(
 		'AUD' => 100,
 		'CAD' => 100,
 		'CHF' => 100,
@@ -35,53 +25,32 @@ class Omise_Money {
 	);
 
 	/**
-	 * @param int|float|string $amount
-	 * @param string           $currency
-	 */
-	public function __construct( $amount, $currency ) {
-		if ( ! isset( $this->subunit_multiplier[ strtoupper( $currency ) ] ) ) {
-			throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
-		}
-
-		$this->amount   = $this->purify_amount( $amount );
-		$this->currency = strtoupper( $currency );
-	}
-
-	/**
-	 * @param  int|float|string $amount
+	 * @param  int|float $amount
 	 *
 	 * @return float
 	 */
-	public function purify_amount( $amount ) {
-		if ( ! is_string( $amount ) && ! is_float( $amount ) && ! is_numeric( $amount ) ) {
-			throw new Exception( __( 'An amount has to be integer, float, or string.', 'omise' ) );
-		} 
-
-		if ( is_string( $amount ) ) {
-			$amount = preg_replace("/[^0-9.]/", '', $amount);
+	public static function purify_amount( $amount ) {
+		if ( ! is_numeric( $amount ) ) {
+			throw new Exception( __( 'An amount has to be integer, or float.', 'omise' ) );
 		}
 
 		return (float) $amount;
 	}
 
 	/**
+	 * @param  int|float $amount
+	 * @param  string    $currency
+	 *
 	 * @return int
 	 */
-	public function to_subunit() {
-		return (int) ( ( floor( $this->amount * 100 ) / 100 ) * $this->subunit_multiplier[ $this->currency ] );
-	}
+	public function to_subunit( $amount, $currency ) {
+		$amount   = static::purify_amount( $amount );
+		$currency = strtoupper( $currency );
 
-	/**
-	 * @return float
-	 */
-	public function get_amount() {
-		return $this->amount;
-	}
+		if ( ! isset( static::$subunit_multiplier[ $currency ] ) ) {
+			throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
+		}
 
-	/**
-	 * @return string
-	 */
-	public function get_currency() {
-		return $this->currency;
+		return (int) ( ( floor( $amount * 100 ) / 100 ) * static::$subunit_multiplier[ $currency ] );
 	}
 }

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -78,7 +78,7 @@ function register_omise_alipay() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'      => $money->toSubunit(),
+				'amount'      => $money->to_subunit(),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'source'      => array( 'type' => 'alipay' ),

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -64,7 +64,6 @@ function register_omise_alipay() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
-			$money    = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$metadata = array_merge(
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
@@ -78,7 +77,7 @@ function register_omise_alipay() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'      => $money->to_subunit(),
+				'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'source'      => array( 'type' => 'alipay' ),

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -64,6 +64,7 @@ function register_omise_alipay() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
+			$money    = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$metadata = array_merge(
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
@@ -77,7 +78,7 @@ function register_omise_alipay() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+				'amount'      => $money->toSubunit(),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'source'      => array( 'type' => 'alipay' ),

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -252,8 +252,9 @@ function register_omise_creditcard() {
 				),
 				home_url()
 			);
+			$money   = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$data    = array(
-				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+				'amount'      => $money->toSubunit(),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'return_uri'  => $return_uri
@@ -446,8 +447,9 @@ function register_omise_creditcard() {
 
 			try {
 				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
+				$money  = new Omise_Money( $amount, $order->get_order_currency() );
 				$refund = $charge->refunds()->create( array(
-					'amount' => $this->format_amount_subunit( $amount, $order->get_order_currency() )
+					'amount' => $money->toSubunit()
 				) );
 
 				if ( $refund['voided'] ) {

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -254,7 +254,7 @@ function register_omise_creditcard() {
 			);
 			$money   = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$data    = array(
-				'amount'      => $money->toSubunit(),
+				'amount'      => $money->to_subunit(),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'return_uri'  => $return_uri
@@ -449,7 +449,7 @@ function register_omise_creditcard() {
 				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
 				$money  = new Omise_Money( $amount, $order->get_order_currency() );
 				$refund = $charge->refunds()->create( array(
-					'amount' => $money->toSubunit()
+					'amount' => $money->to_subunit()
 				) );
 
 				if ( $refund['voided'] ) {

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -252,9 +252,8 @@ function register_omise_creditcard() {
 				),
 				home_url()
 			);
-			$money   = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$data    = array(
-				'amount'      => $money->to_subunit(),
+				'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'return_uri'  => $return_uri
@@ -447,9 +446,8 @@ function register_omise_creditcard() {
 
 			try {
 				$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
-				$money  = new Omise_Money( $amount, $order->get_order_currency() );
 				$refund = $charge->refunds()->create( array(
-					'amount' => $money->to_subunit()
+					'amount' => Omise_Money::to_subunit( $amount, $order->get_order_currency() )
 				) );
 
 				if ( $refund['voided'] ) {

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -103,7 +103,7 @@ function register_omise_installment() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'            => $money->toSubunit(),
+				'amount'            => $money->to_subunit(),
 				'currency'          => $order->get_order_currency(),
 				'description'       => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'source'            => array(

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -89,6 +89,7 @@ function register_omise_installment() {
 		public function charge( $order_id, $order ) {
 			$source_type       = isset( $_POST['source']['type'] ) ? $_POST['source']['type'] : '';
 			$installment_terms = isset( $_POST[ $source_type . '_installment_terms'] ) ? $_POST[ $source_type . '_installment_terms'] : '';
+			$money             = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$metadata          = array_merge(
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
@@ -102,7 +103,7 @@ function register_omise_installment() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'            => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+				'amount'            => $money->toSubunit(),
 				'currency'          => $order->get_order_currency(),
 				'description'       => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'source'            => array(

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -89,7 +89,6 @@ function register_omise_installment() {
 		public function charge( $order_id, $order ) {
 			$source_type       = isset( $_POST['source']['type'] ) ? $_POST['source']['type'] : '';
 			$installment_terms = isset( $_POST[ $source_type . '_installment_terms'] ) ? $_POST[ $source_type . '_installment_terms'] : '';
-			$money             = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$metadata          = array_merge(
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
@@ -103,7 +102,7 @@ function register_omise_installment() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'            => $money->to_subunit(),
+				'amount'            => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'          => $order->get_order_currency(),
 				'description'       => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'source'            => array(

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -93,7 +93,7 @@ function register_omise_internetbanking() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'      => $money->toSubunit(),
+				'amount'      => $money->to_subunit(),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
 				'source'      => array( 'type' => sanitize_text_field( $_POST['omise-offsite'] ) ),

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -79,7 +79,6 @@ function register_omise_internetbanking() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
-			$money    = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$metadata = array_merge(
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
@@ -93,7 +92,7 @@ function register_omise_internetbanking() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'      => $money->to_subunit(),
+				'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
 				'source'      => array( 'type' => sanitize_text_field( $_POST['omise-offsite'] ) ),

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -79,6 +79,7 @@ function register_omise_internetbanking() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
+			$money    = new Omise_Money( $order->get_total(), $order->get_order_currency() );
 			$metadata = array_merge(
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
@@ -92,7 +93,7 @@ function register_omise_internetbanking() {
 			);
 
 			return OmiseCharge::create( array(
-				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
+				'amount'      => $money->toSubunit(),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
 				'source'      => array( 'type' => sanitize_text_field( $_POST['omise-offsite'] ) ),

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -148,20 +148,6 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * @param  int    $amount
-	 * @param  string $currency
-	 *
-	 * @return int
-	 */
-	protected function format_amount_subunit( $amount, $currency ) {
-		if ( isset( $this->currency_subunits[ strtoupper( $currency ) ] ) ) {
-			return $amount * $this->currency_subunits[ $currency ];
-		}
-
-		return $amount;
-	}
-
-	/**
 	 * @since  3.4
 	 *
 	 * @see    WC_Payment_Gateway::process_payment( $order_id )

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -132,6 +132,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-plugin/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-capabilities.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-events.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-money.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';

--- a/tests/unit/class-omise-unit-test.php
+++ b/tests/unit/class-omise-unit-test.php
@@ -1,4 +1,5 @@
 <?php
+define( 'ABSPATH', '' );
 
 class Omise_Unit_Test {
 	public static function include_class( $path ): void {

--- a/tests/unit/includes/class-omise-money-test.php
+++ b/tests/unit/includes/class-omise-money-test.php
@@ -14,11 +14,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 849;
 		$currency = 'thb';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 849, $money->get_amount() );
-		$this->assertEquals( 84900, $money->to_subunit() );
+		$this->assertEquals( 84900, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -28,11 +24,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 350.49;
 		$currency = 'thb';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 350.49, $money->get_amount() );
-		$this->assertEquals( 35049, $money->to_subunit() );
+		$this->assertEquals( 35049, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -42,11 +34,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 4780.0409;
 		$currency = 'thb';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 4780.0409, $money->get_amount() );
-		$this->assertEquals( 478004, $money->to_subunit() );
+		$this->assertEquals( 478004, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -56,11 +44,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 688.123456789;
 		$currency = 'thb';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 688.123456789, $money->get_amount() );
-		$this->assertEquals( 68812, $money->to_subunit() );
+		$this->assertEquals( 68812, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -70,53 +54,18 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 14900.987654321;
 		$currency = 'thb';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 14900.987654321, $money->get_amount() );
-		$this->assertEquals( 1490098, $money->to_subunit() );
+		$this->assertEquals( 1490098, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
 	 * @test
 	 */
-	public function convert_string_amount() {
+	public function convert_string_as_numeric() {
 		$amount   = '5400';
 		$currency = 'thb';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 5400, $money->get_amount() );
-		$this->assertEquals( 540000, $money->to_subunit() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function convert_string_amount_with_decimal() {
-		$amount   = '350.49';
-		$currency = 'thb';
-
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 350.49, $money->get_amount() );
-		$this->assertEquals( 35049, $money->to_subunit() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function convert_string_amount_with_crazy_decimal() {
-		$amount   = '฿46,000.4951 THB';
-		$currency = 'thb';
-
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 46000.4951, $money->get_amount() );
-		$this->assertEquals( 4600049, $money->to_subunit() );
+		$money = Omise_Money::to_subunit( $amount, $currency );
+		$this->assertEquals( 540000, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -124,12 +73,12 @@ class Omise_Money_Test extends TestCase {
 	 */
 	public function preventing_a_troll_case() {
 		$this->expectException( 'Exception' );
-		$this->expectExceptionMessage( 'An amount has to be integer, float, or string.' );
+		$this->expectExceptionMessage( 'An amount has to be integer, or float.' );
 
 		$amount   = [ 'yahhhhh' ];
 		$currency = 'thb';
 
-		$money = new Omise_Money( $amount, $currency );
+		$money = Omise_Money::to_subunit( $amount, $currency );
 	}
 
 	/**
@@ -142,7 +91,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 890.52;
 		$currency = 'omg';
 
-		$money = new Omise_Money( $amount, $currency );
+		$money = Omise_Money::to_subunit( $amount, $currency );
 	}
 
 	/**
@@ -152,23 +101,17 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 999.49;
 		$currency = 'aud';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'AUD', $money->get_currency() );
-		$this->assertEquals( 99949, $money->to_subunit() );
+		$this->assertEquals( 99949, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
 	 * @test
 	 */
 	public function CAD_to_subunit() {
-		$amount   = '2,749';
+		$amount   = 2749;
 		$currency = 'cad';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'CAD', $money->get_currency() );
-		$this->assertEquals( 274900, $money->to_subunit() );
+		$this->assertEquals( 274900, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -178,10 +121,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 300.99;
 		$currency = 'chf';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'CHF', $money->get_currency() );
-		$this->assertEquals( 30099, $money->to_subunit() );
+		$this->assertEquals( 30099, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -191,10 +131,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 9999.50;
 		$currency = 'CNY';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'CNY', $money->get_currency() );
-		$this->assertEquals( 999950, $money->to_subunit() );
+		$this->assertEquals( 999950, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -204,10 +141,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 20;
 		$currency = 'DKK';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'DKK', $money->get_currency() );
-		$this->assertEquals( 2000, $money->to_subunit() );
+		$this->assertEquals( 2000, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -217,10 +151,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 9;
 		$currency = 'EUR';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'EUR', $money->get_currency() );
-		$this->assertEquals( 900, $money->to_subunit() );
+		$this->assertEquals( 900, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -230,10 +161,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 12.95450;
 		$currency = 'gbp';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'GBP', $money->get_currency() );
-		$this->assertEquals( 1295, $money->to_subunit() );
+		$this->assertEquals( 1295, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -243,23 +171,17 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 11.99;
 		$currency = 'hkd';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'HKD', $money->get_currency() );
-		$this->assertEquals( 1199, $money->to_subunit() );
+		$this->assertEquals( 1199, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
 	 * @test
 	 */
 	public function JPY_to_subunit() {
-		$amount   = '34,980 円';
+		$amount   = 34980;
 		$currency = 'jpy';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'JPY', $money->get_currency() );
-		$this->assertEquals( 34980, $money->to_subunit() );
+		$this->assertEquals( 34980, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -269,23 +191,17 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 90.99;
 		$currency = 'MYR';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'MYR', $money->get_currency() );
-		$this->assertEquals( 9099, $money->to_subunit() );
+		$this->assertEquals( 9099, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
 	 * @test
 	 */
 	public function SGD_to_subunit() {
-		$amount   = 'S$10';
+		$amount   = 10;
 		$currency = 'SGD';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'SGD', $money->get_currency() );
-		$this->assertEquals( 1000, $money->to_subunit() );
+		$this->assertEquals( 1000, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -295,10 +211,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 20;
 		$currency = 'THB';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'THB', $money->get_currency() );
-		$this->assertEquals( 2000, $money->to_subunit() );
+		$this->assertEquals( 2000, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -308,9 +221,6 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 99.09;
 		$currency = 'USD';
 
-		$money = new Omise_Money( $amount, $currency );
-
-		$this->assertEquals( 'USD', $money->get_currency() );
-		$this->assertEquals( 9909, $money->to_subunit() );
+		$this->assertEquals( 9909, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 }

--- a/tests/unit/includes/class-omise-money-test.php
+++ b/tests/unit/includes/class-omise-money-test.php
@@ -34,7 +34,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 4780.0409;
 		$currency = 'thb';
 
-		$this->assertEquals( 478004, Omise_Money::to_subunit( $amount, $currency ) );
+		$this->assertEquals( 478004.09, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 688.123456789;
 		$currency = 'thb';
 
-		$this->assertEquals( 68812, Omise_Money::to_subunit( $amount, $currency ) );
+		$this->assertEquals( 68812.3456789, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -54,7 +54,7 @@ class Omise_Money_Test extends TestCase {
 		$amount   = 14900.987654321;
 		$currency = 'thb';
 
-		$this->assertEquals( 1490098, Omise_Money::to_subunit( $amount, $currency ) );
+		$this->assertEquals( 1490098.7654321, Omise_Money::to_subunit( $amount, $currency ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Omise_Money_Test extends TestCase {
 	 */
 	public function preventing_a_troll_case() {
 		$this->expectException( 'Exception' );
-		$this->expectExceptionMessage( 'Invalid amount. An amount has to be in a number format.' );
+		$this->expectExceptionMessage( 'Invalid amount type given. Should be int, float, or numeric string.' );
 
 		$amount   = [ 'yahhhhh' ];
 		$currency = 'thb';
@@ -108,7 +108,7 @@ class Omise_Money_Test extends TestCase {
 	 * @test
 	 */
 	public function CAD_to_subunit() {
-		$amount   = 2749;
+		$amount   = 2749.00;
 		$currency = 'cad';
 
 		$this->assertEquals( 274900, Omise_Money::to_subunit( $amount, $currency ) );
@@ -158,7 +158,7 @@ class Omise_Money_Test extends TestCase {
 	 * @test
 	 */
 	public function GBP_to_subunit() {
-		$amount   = 12.95450;
+		$amount   = 12.95;
 		$currency = 'gbp';
 
 		$this->assertEquals( 1295, Omise_Money::to_subunit( $amount, $currency ) );

--- a/tests/unit/includes/class-omise-money-test.php
+++ b/tests/unit/includes/class-omise-money-test.php
@@ -73,7 +73,7 @@ class Omise_Money_Test extends TestCase {
 	 */
 	public function preventing_a_troll_case() {
 		$this->expectException( 'Exception' );
-		$this->expectExceptionMessage( 'An amount has to be integer, or float.' );
+		$this->expectExceptionMessage( 'Invalid amount. An amount has to be in a number format.' );
 
 		$amount   = [ 'yahhhhh' ];
 		$currency = 'thb';

--- a/tests/unit/includes/class-omise-money-test.php
+++ b/tests/unit/includes/class-omise-money-test.php
@@ -16,9 +16,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 849, $money->getAmount() );
-		$this->assertEquals( 84900, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 849, $money->get_amount() );
+		$this->assertEquals( 84900, $money->to_subunit() );
 	}
 
 	/**
@@ -30,9 +30,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 350.49, $money->getAmount() );
-		$this->assertEquals( 35049, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 350.49, $money->get_amount() );
+		$this->assertEquals( 35049, $money->to_subunit() );
 	}
 
 	/**
@@ -44,9 +44,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 4780.0409, $money->getAmount() );
-		$this->assertEquals( 478004, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 4780.0409, $money->get_amount() );
+		$this->assertEquals( 478004, $money->to_subunit() );
 	}
 
 	/**
@@ -58,9 +58,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 688.123456789, $money->getAmount() );
-		$this->assertEquals( 68812, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 688.123456789, $money->get_amount() );
+		$this->assertEquals( 68812, $money->to_subunit() );
 	}
 
 	/**
@@ -72,9 +72,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 14900.987654321, $money->getAmount() );
-		$this->assertEquals( 1490098, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 14900.987654321, $money->get_amount() );
+		$this->assertEquals( 1490098, $money->to_subunit() );
 	}
 
 	/**
@@ -86,9 +86,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 5400, $money->getAmount() );
-		$this->assertEquals( 540000, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 5400, $money->get_amount() );
+		$this->assertEquals( 540000, $money->to_subunit() );
 	}
 
 	/**
@@ -100,9 +100,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 350.49, $money->getAmount() );
-		$this->assertEquals( 35049, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 350.49, $money->get_amount() );
+		$this->assertEquals( 35049, $money->to_subunit() );
 	}
 
 	/**
@@ -114,9 +114,9 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 46000.4951, $money->getAmount() );
-		$this->assertEquals( 4600049, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 46000.4951, $money->get_amount() );
+		$this->assertEquals( 4600049, $money->to_subunit() );
 	}
 
 	/**
@@ -154,8 +154,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'AUD', $money->getCurrency() );
-		$this->assertEquals( 99949, $money->toSubunit() );
+		$this->assertEquals( 'AUD', $money->get_currency() );
+		$this->assertEquals( 99949, $money->to_subunit() );
 	}
 
 	/**
@@ -167,8 +167,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'CAD', $money->getCurrency() );
-		$this->assertEquals( 274900, $money->toSubunit() );
+		$this->assertEquals( 'CAD', $money->get_currency() );
+		$this->assertEquals( 274900, $money->to_subunit() );
 	}
 
 	/**
@@ -180,8 +180,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'CHF', $money->getCurrency() );
-		$this->assertEquals( 30099, $money->toSubunit() );
+		$this->assertEquals( 'CHF', $money->get_currency() );
+		$this->assertEquals( 30099, $money->to_subunit() );
 	}
 
 	/**
@@ -193,8 +193,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'CNY', $money->getCurrency() );
-		$this->assertEquals( 999950, $money->toSubunit() );
+		$this->assertEquals( 'CNY', $money->get_currency() );
+		$this->assertEquals( 999950, $money->to_subunit() );
 	}
 
 	/**
@@ -206,8 +206,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'DKK', $money->getCurrency() );
-		$this->assertEquals( 2000, $money->toSubunit() );
+		$this->assertEquals( 'DKK', $money->get_currency() );
+		$this->assertEquals( 2000, $money->to_subunit() );
 	}
 
 	/**
@@ -219,8 +219,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'EUR', $money->getCurrency() );
-		$this->assertEquals( 900, $money->toSubunit() );
+		$this->assertEquals( 'EUR', $money->get_currency() );
+		$this->assertEquals( 900, $money->to_subunit() );
 	}
 
 	/**
@@ -232,8 +232,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'GBP', $money->getCurrency() );
-		$this->assertEquals( 1295, $money->toSubunit() );
+		$this->assertEquals( 'GBP', $money->get_currency() );
+		$this->assertEquals( 1295, $money->to_subunit() );
 	}
 
 	/**
@@ -245,8 +245,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'HKD', $money->getCurrency() );
-		$this->assertEquals( 1199, $money->toSubunit() );
+		$this->assertEquals( 'HKD', $money->get_currency() );
+		$this->assertEquals( 1199, $money->to_subunit() );
 	}
 
 	/**
@@ -258,8 +258,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'JPY', $money->getCurrency() );
-		$this->assertEquals( 34980, $money->toSubunit() );
+		$this->assertEquals( 'JPY', $money->get_currency() );
+		$this->assertEquals( 34980, $money->to_subunit() );
 	}
 
 	/**
@@ -271,8 +271,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'MYR', $money->getCurrency() );
-		$this->assertEquals( 9099, $money->toSubunit() );
+		$this->assertEquals( 'MYR', $money->get_currency() );
+		$this->assertEquals( 9099, $money->to_subunit() );
 	}
 
 	/**
@@ -284,8 +284,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'SGD', $money->getCurrency() );
-		$this->assertEquals( 1000, $money->toSubunit() );
+		$this->assertEquals( 'SGD', $money->get_currency() );
+		$this->assertEquals( 1000, $money->to_subunit() );
 	}
 
 	/**
@@ -297,8 +297,8 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'THB', $money->getCurrency() );
-		$this->assertEquals( 2000, $money->toSubunit() );
+		$this->assertEquals( 'THB', $money->get_currency() );
+		$this->assertEquals( 2000, $money->to_subunit() );
 	}
 
 	/**
@@ -310,7 +310,7 @@ class Omise_Money_Test extends TestCase {
 
 		$money = new Omise_Money( $amount, $currency );
 
-		$this->assertEquals( 'USD', $money->getCurrency() );
-		$this->assertEquals( 9909, $money->toSubunit() );
+		$this->assertEquals( 'USD', $money->get_currency() );
+		$this->assertEquals( 9909, $money->to_subunit() );
 	}
 }

--- a/tests/unit/includes/class-omise-money-test.php
+++ b/tests/unit/includes/class-omise-money-test.php
@@ -1,0 +1,316 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../class-omise-unit-test.php';
+
+class Omise_Money_Test extends TestCase {
+	public static function setUpBeforeClass(): void {
+		require_once __DIR__ . '/../../../includes/class-omise-money.php';
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_amount_with_ideal_inputs() {
+		$amount   = 849;
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 849, $money->getAmount() );
+		$this->assertEquals( 84900, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_amount_with_decimal() {
+		$amount   = 350.49;
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 350.49, $money->getAmount() );
+		$this->assertEquals( 35049, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_amount_with_4_decimal_points() {
+		$amount   = 4780.0409;
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 4780.0409, $money->getAmount() );
+		$this->assertEquals( 478004, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_amount_with_123456789_as_decimals() {
+		$amount   = 688.123456789;
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 688.123456789, $money->getAmount() );
+		$this->assertEquals( 68812, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_amount_with_987654321_as_decimals() {
+		$amount   = 14900.987654321;
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 14900.987654321, $money->getAmount() );
+		$this->assertEquals( 1490098, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_string_amount() {
+		$amount   = '5400';
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 5400, $money->getAmount() );
+		$this->assertEquals( 540000, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_string_amount_with_decimal() {
+		$amount   = '350.49';
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 350.49, $money->getAmount() );
+		$this->assertEquals( 35049, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function convert_string_amount_with_crazy_decimal() {
+		$amount   = '฿46,000.4951 THB';
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 46000.4951, $money->getAmount() );
+		$this->assertEquals( 4600049, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function preventing_a_troll_case() {
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage( 'An amount has to be integer, float, or string.' );
+
+		$amount   = [ 'yahhhhh' ];
+		$currency = 'thb';
+
+		$money = new Omise_Money( $amount, $currency );
+	}
+
+	/**
+	 * @test
+	 */
+	public function preventing_unsupport_currency() {
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage( 'We do not support the currency you are using.' );
+
+		$amount   = 890.52;
+		$currency = 'omg';
+
+		$money = new Omise_Money( $amount, $currency );
+	}
+
+	/**
+	 * @test
+	 */
+	public function AUD_to_subunit() {
+		$amount   = 999.49;
+		$currency = 'aud';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'AUD', $money->getCurrency() );
+		$this->assertEquals( 99949, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function CAD_to_subunit() {
+		$amount   = '2,749';
+		$currency = 'cad';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'CAD', $money->getCurrency() );
+		$this->assertEquals( 274900, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function CHF_to_subunit() {
+		$amount   = 300.99;
+		$currency = 'chf';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'CHF', $money->getCurrency() );
+		$this->assertEquals( 30099, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function CNY_to_subunit() {
+		$amount   = 9999.50;
+		$currency = 'CNY';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'CNY', $money->getCurrency() );
+		$this->assertEquals( 999950, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function DKK_to_subunit() {
+		$amount   = 20;
+		$currency = 'DKK';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'DKK', $money->getCurrency() );
+		$this->assertEquals( 2000, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function EUR_to_subunit() {
+		$amount   = 9;
+		$currency = 'EUR';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'EUR', $money->getCurrency() );
+		$this->assertEquals( 900, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function GBP_to_subunit() {
+		$amount   = 12.95450;
+		$currency = 'gbp';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'GBP', $money->getCurrency() );
+		$this->assertEquals( 1295, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function HKD_to_subunit() {
+		$amount   = 11.99;
+		$currency = 'hkd';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'HKD', $money->getCurrency() );
+		$this->assertEquals( 1199, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function JPY_to_subunit() {
+		$amount   = '34,980 円';
+		$currency = 'jpy';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'JPY', $money->getCurrency() );
+		$this->assertEquals( 34980, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function MYR_to_subunit() {
+		$amount   = 90.99;
+		$currency = 'MYR';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'MYR', $money->getCurrency() );
+		$this->assertEquals( 9099, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function SGD_to_subunit() {
+		$amount   = 'S$10';
+		$currency = 'SGD';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'SGD', $money->getCurrency() );
+		$this->assertEquals( 1000, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function THB_to_subunit() {
+		$amount   = 20;
+		$currency = 'THB';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'THB', $money->getCurrency() );
+		$this->assertEquals( 2000, $money->toSubunit() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function USD_to_subunit() {
+		$amount   = 99.09;
+		$currency = 'USD';
+
+		$money = new Omise_Money( $amount, $currency );
+
+		$this->assertEquals( 'USD', $money->getCurrency() );
+		$this->assertEquals( 9909, $money->toSubunit() );
+	}
+}


### PR DESCRIPTION
#### 1. Objective

As increasing of currencies that can be used with Omise Payment, and as a better and a bit more complex of the code that will be used to handle amount subunit converting and to prevent some unexpected situation.

This pull request is aiming to provide a bit of a better place to house those code and logic.

Bonus point is now we can write a unit test to make sure that the converted-amount will be treated correctly before passing to Omise API.

#### 2. Description of change

1. Introducing `Omise_Money` as a dedicated class to handle those converting WC order amount to the subunit format that Omise API requires.

2. Replacing all `Omise_Payment::format_amount_subunit()` with `Omise_Money`.

3. Adding test cases.

#### 3. Quality assurance

**🔧 Environments:**

- **PHP**: v7.3.3
- **WordPress**: v5.2.2
- **WooCommerce**: v3.6.5

**✏️ Details:**

According to the test cases, the unit test script should be green. 
<img width="796" alt="Screen Shot 2562-07-07 at 14 16 15" src="https://user-images.githubusercontent.com/2154669/60788365-179bea00-a18f-11e9-870c-85418e49a891.png">

<img width="914" alt="Screen Shot 2562-07-07 at 14 16 32" src="https://user-images.githubusercontent.com/2154669/60788368-18cd1700-a18f-11e9-86f0-5dd15064707f.png">

Also tested by creating a new charge with Alipay, Credit Card, Installment, Internet Banking to make sure that the order amount is converted properly.

#### 4. Impact of the change

Nothing.

#### 5. Priority of change

Normal.

#### 6. Additional Notes

1. Note, seems now the unit test configuration is broken.
All test cases won't be executed if run the following command:  `vendor/bin/phpunit tests`.
  For now, need to specify the exact test script's path, in order to test each cases.
  ```ssh
  vendor/bin/phpunit tests/unit/includes/class-omise-money-test.php
   
  vendor/bin/phpunit tests/unit/includes/backends/class-omise-backend-installment-test.php
  ```

2. Also note that this pull request doesn't touch on "preventing unsupported currency for each payment method" perspective, but just to improve the way to handle converting WC order amount to Omise subunit amount format.
Some code may still remains and look a bit off (i.e. `is_currency_support` method), but it will be removed / refactored in the next coming PR.