### PR TITLE
Properly assigning querystrings for the payment callback endpoints

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -68,13 +68,20 @@ function register_omise_alipay() {
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
 			);
+			$return_uri = add_query_arg(
+				array(
+					'wc-api'   => 'omise_alipay_callback',
+					'order_id' => $order_id
+				),
+				home_url()
+			);
 
 			return OmiseCharge::create( array(
 				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 				'source'      => array( 'type' => 'alipay' ),
-				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" ),
+				'return_uri'  => $return_uri,
 				'metadata'    => $metadata
 			) );
 		}

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -244,12 +244,19 @@ function register_omise_creditcard() {
 				}
 			}
 
-			$success = false;
+			$success    = false;
+			$return_uri = add_query_arg(
+				array(
+					'wc-api'   => 'omise_callback',
+					'order_id' => $order_id
+				),
+				home_url()
+			);
 			$data    = array(
 				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
-				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . '?wc-api=omise_callback' )
+				'return_uri'  => $return_uri
 			);
 
 			if ( ! empty( $omise_customer_id ) && ! empty( $card_id ) ) {

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -93,6 +93,13 @@ function register_omise_installment() {
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
 			);
+			$return_uri = add_query_arg(
+				array(
+					'wc-api'   => 'omise_installment_callback',
+					'order_id' => $order_id
+				),
+				home_url()
+			);
 
 			return OmiseCharge::create( array(
 				'amount'            => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
@@ -102,7 +109,7 @@ function register_omise_installment() {
 					'type'              => sanitize_text_field( $source_type ),
 					'installment_terms' => sanitize_text_field( $installment_terms )
 				),
-				'return_uri'        => add_query_arg( 'order_id', $order_id, site_url() . '?wc-api=omise_installment_callback' ),
+				'return_uri'        => $return_uri,
 				'metadata'          => $metadata
 			) );
 		}

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -83,13 +83,20 @@ function register_omise_internetbanking() {
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
 			);
+			$return_uri = add_query_arg(
+				array(
+					'wc-api'   => 'omise_internetbanking_callback',
+					'order_id' => $order_id
+				),
+				home_url()
+			);
 
 			return OmiseCharge::create( array(
 				'amount'      => $this->format_amount_subunit( $order->get_total(), $order->get_order_currency() ),
 				'currency'    => $order->get_order_currency(),
 				'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
 				'source'      => array( 'type' => sanitize_text_field( $_POST['omise-offsite'] ) ),
-				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_internetbanking_callback" ),
+				'return_uri'  => $return_uri,
 				'metadata'    => $metadata
 			) );
 		}


### PR DESCRIPTION
#### 1. Objective

The current code is using a redundant approach to assign a querystring to the payment callback endpoints.

```php
add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_alipay_callback" );
```

See that we use a function provided by WordPress, `add_query_arg()` to create a querystring for `order_id` but manually set a querystring for `wc-api` argument: `?wc-api=omise_alipay_callback`.

#### 2. Description of change

Assigning querystrings with a proper way that WordPress has provided.

```php
$return_uri = add_query_arg(
	array(
		'wc-api'   => 'omise_alipay_callback',
		'order_id' => $order_id
	),
	home_url()
);
```

This is to avoid any conflict in case if `home_url` provides any of itself a querystring.

Also, `site_url()` has been replaced with `home_url()` as `site_url` just purely returns a `base` url of an accessible domain name, while `home_url` will be returning whatever url that is set as a `homepage` for WordPress setting.

This likely is to eliminating a potential incompatible URL that may have been hooked by other 3rd-party plugins. 

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.2.2.
- **WooCommerce**: v3.6.5.
- **PHP**: v7.3.3.

**✏️ Details:**

Just test create a charge with Alipay, Credit Card, Installment, Internet Banking payments to see if the `return_uri` is properly set the same as before.

Alipay
<img width="806" alt="Screen Shot 2562-07-22 at 21 39 19" src="https://user-images.githubusercontent.com/2154669/61641365-30e18200-acc9-11e9-91f0-3954eb2b7905.png">

Credit Card
<img width="807" alt="Screen Shot 2562-07-22 at 21 36 11" src="https://user-images.githubusercontent.com/2154669/61641168-d9dbad00-acc8-11e9-96e1-779758a094a5.png">

Installment
<img width="805" alt="Screen Shot 2562-07-22 at 21 37 40" src="https://user-images.githubusercontent.com/2154669/61641323-1f987580-acc9-11e9-814a-c90c48f00a25.png">

Internet Banking
<img width="807" alt="Screen Shot 2562-07-22 at 21 34 53" src="https://user-images.githubusercontent.com/2154669/61641166-d9dbad00-acc8-11e9-9db9-3d74bc1d6653.png">

#### 4. Impact of the change

Nothing

#### 5. Priority of change

Normal

#### 6. Additional Notes

Nothing