### PR TITLE
Introducing Bill Payment, Tesco Lotus (only available in Thailand)

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -47,6 +47,13 @@ fieldset.card-exists {
 	line-height: 1;
 }
 
+/**
+ * Omise Bill Payment Tesco
+ * CSS for the 'Thank You' (order-received) page.
+ */
+.omise-billpayment-tesco-details     { margin-bottom: 4em; text-align:center; }
+.omise-billpayment-tesco-barcode img { margin: auto; }
+
 
 /**
  * 2). Components

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -134,6 +134,7 @@
 								<?php
 								$available_gateways = array(
 									new Omise_Payment_Alipay,
+									new Omise_Payment_Billpayment_Tesco,
 									new Omise_Payment_Creditcard,
 									new Omise_Payment_Installment,
 									new Omise_Payment_Internetbanking

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -64,12 +64,42 @@ function register_omise_billpayment_tesco() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
+			$metadata = array_merge(
+				apply_filters( 'omise_charge_params_metadata', array(), $order ),
+				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
+			);
+
+			return OmiseCharge::create( array(
+				'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
+				'currency'    => $order->get_order_currency(),
+				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
+				'source'      => array( 'type' => 'bill_payment_tesco_lotus' ),
+				'return_uri'  => add_query_arg( 'order_id', $order_id, site_url() . "?wc-api=omise_billpayment_tesco_callback" ),
+				'metadata'    => $metadata
+			) );
 		}
 
 		/**
 		 * @inheritdoc
 		 */
 		public function result( $order_id, $order, $charge ) {
+			if ( 'failed' == $charge['status'] ) {
+				return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+			}
+
+			if ( 'pending' == $charge['status'] ) {
+				return [
+					'result'   => 'success',
+					'redirect' => $this->get_return_url( $order )
+				];
+			}
+
+			return $this->payment_failed(
+				sprintf(
+					__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
+					$order_id
+				)
+			);
 		}
 	}
 

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -28,6 +28,8 @@ function register_omise_billpayment_tesco() {
 
 			$this->title       = $this->get_option( 'title' );
 			$this->description = $this->get_option( 'description' );
+
+			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		}
 
 		/**

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -1,0 +1,87 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+function register_omise_billpayment_tesco() {
+	require_once dirname( __FILE__ ) . '/class-omise-payment.php';
+
+	if ( ! class_exists( 'WC_Payment_Gateway' ) || class_exists( 'Omise_Payment_Billpayment_Tesco' ) ) {
+		return;
+	}
+
+	/**
+	 * @since 3.7
+	 */
+	class Omise_Payment_Billpayment_Tesco extends Omise_Payment {
+		public function __construct() {
+			parent::__construct();
+
+			$this->id                 = 'omise_billpayment_tesco';
+			$this->has_fields         = false;
+			$this->method_title       = __( 'Omise Bill Payment: Tesco', 'omise' );
+			$this->method_description = wp_kses(
+				__( 'Accept payments through <strong>Tesco Bill Payment</strong> via Omise payment gateway.', 'omise' ),
+				array( 'strong' => array() )
+			);
+
+			$this->init_form_fields();
+			$this->init_settings();
+
+			$this->title       = $this->get_option( 'title' );
+			$this->description = $this->get_option( 'description' );
+		}
+
+		/**
+		 * @see WC_Settings_API::init_form_fields()
+		 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled' => array(
+					'title'   => __( 'Enable/Disable', 'omise' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable Omise Tesco Bill Payment', 'omise' ),
+					'default' => 'no'
+				),
+
+				'title' => array(
+					'title'       => __( 'Title', 'omise' ),
+					'type'        => 'text',
+					'description' => __( 'This controls the title which the user sees during checkout.', 'omise' ),
+					'default'     => __( 'Bill Payment: Tesco', 'omise' ),
+				),
+
+				'description' => array(
+					'title'       => __( 'Description', 'omise' ),
+					'type'        => 'textarea',
+					'description' => __( 'This controls the description which the user sees during checkout.', 'omise' )
+				),
+			);
+		}
+
+		/**
+		 * @inheritdoc
+		 */
+		public function charge( $order_id, $order ) {
+		}
+
+		/**
+		 * @inheritdoc
+		 */
+		public function result( $order_id, $order, $charge ) {
+		}
+	}
+
+	if ( ! function_exists( 'add_omise_billpayment_tesco' ) ) {
+		/**
+		 * @param  array $methods
+		 *
+		 * @return array
+		 */
+		function add_omise_billpayment_tesco( $methods ) {
+			$methods[] = 'Omise_Payment_Billpayment_Tesco';
+			return $methods;
+		}
+
+		add_filter( 'woocommerce_payment_gateways', 'add_omise_billpayment_tesco' );
+	}
+}

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -30,6 +30,7 @@ function register_omise_billpayment_tesco() {
 			$this->description = $this->get_option( 'description' );
 
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+			add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_barcode' ) );
 		}
 
 		/**
@@ -100,6 +101,34 @@ function register_omise_billpayment_tesco() {
 					$order_id
 				)
 			);
+		}
+
+		/**
+		 * @param  int $order_id
+		 */
+		public function display_barcode( $order_id ) {
+			if ( ! $order = $this->load_order( $order_id ) ) {
+				return;
+			}
+
+			$charge_id = $this->get_charge_id_from_order();
+			$charge    = OmiseCharge::retrieve( $charge_id );
+
+			$amount  = $charge['amount'];
+			$barcode = $charge['source']['references']['barcode'];
+			$tax_id  = $charge['source']['references']['omise_tax_id'];
+			$ref_1   = $charge['source']['references']['reference_number_1'];
+			$ref_2   = $charge['source']['references']['reference_number_2'];
+			?>
+
+			<div class="omise omise-billpayment-tesco-details">
+				<p><?php echo __( 'Use this barcode to pay at Tesco Lotus.', 'omise' ); ?></p>
+				<div class="omise-billpayment-tesco-barcode">
+					<img src="<?php echo $barcode; ?>" title="Omise Tesco Bill Payment Barcode" alt="Omise Tesco Bill Payment Barcode">
+				</div>
+				<small class="omise-billpayment-tesco-reference-number">|&nbsp;&nbsp;&nbsp; <?php echo $tax_id; ?> &nbsp;&nbsp;&nbsp; 00 &nbsp;&nbsp;&nbsp; <?php echo $ref_1; ?> &nbsp;&nbsp;&nbsp; <?php echo $ref_2; ?> &nbsp;&nbsp;&nbsp; <?php echo $amount; ?></small>
+			</div>
+			<?php
 		}
 	}
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -77,6 +77,7 @@ class Omise {
 		$this->init_route();
 
 		register_omise_alipay();
+		register_omise_billpayment_tesco();
 		register_omise_creditcard();
 		register_omise_installment();
 		register_omise_internetbanking();
@@ -125,6 +126,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-complete.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-create.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-alipay.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-billpayment-tesco.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-creditcard.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-installment.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-internetbanking.php';


### PR DESCRIPTION
#### 1. Objective

As the statement Omise put at the releasing article: 

Our focus is to help you boost sales by offering payment solutions that put customers choice and experience ahead. We’re super excited to let you know that starting today, Omise merchants in Thailand will be able to offer cash payments at Tesco Lotus as an option for customers to pay.

Increasingly we see consumers shifting over to online payments, however a large percentage still prefer to pay by cash over-the-counter. Tesco Lotus is currently the most preferred outlet by consumers, with more than 1800 locations across the country including 24-hour Lotus Express stores.

The objective of this pull request is to bring this feature to our lovely WooCommerce.

https://www.omise.co/now-supporting-over-the-counter-payments-at-tesco-lotus

#### 2. Description of change

Adding all the needs in order to integrate Omise Bill Payment to WooCommerce.
- Implementing all the foundation code to list the payment at WooCommerce payment setting page.
- Displaying Bill Payment payment method at Omise setting page.
- Integrating Bill Payment to WooCommerce checkout page
- Display Bill Payment's barcode at the "order-received" page.

#### 3. Quality assurance

**🔧 Environments:**

- **WordPress**: v5.2.2 (latest)
- **WooCommerce**: v3.6.5 (latest)
- **PHP version**: v7.3.3

**✏️ Details:**

After installed this patch, you will be able to use Omise Bill Payment Tesco.
The below quality assurance steps is to make sure that all functions are properly work as expected.

1. At Omise Payment Setting page (logged in to WordPress admin page first), there will be a new payment method, **"Bill Payment: Tesco"**.
![billpayment-setting](https://user-images.githubusercontent.com/2154669/62186625-242bf080-b391-11e9-96b7-751ffefabb8f.jpg)

2. Once the payment is enabled, new payment method will be displayed at the checkout page.
![billpayment-checkout](https://user-images.githubusercontent.com/2154669/62186628-242bf080-b391-11e9-9f18-724c34843b59.jpg)

3. Bill Payment uses the "offline" flow, meaning that there is no redirect to any 3rd party page but create a new charge with `authorize: pending`, and `paid: pending` status then redirect buyer to the order-received page.
<img width="1552" alt="billpayment-completed" src="https://user-images.githubusercontent.com/2154669/62186692-52a9cb80-b391-11e9-9bbc-c14cac98abd0.png">

<img width="1552" alt="billpayment-charge" src="https://user-images.githubusercontent.com/2154669/62186695-53426200-b391-11e9-8765-416402082e15.png">

<img width="1552" alt="billpayment-log" src="https://user-images.githubusercontent.com/2154669/62186696-53daf880-b391-11e9-87c7-06f921b228da.png">

4. At WooCommerce Order Admin page, a new order will be created with `pending payment` status.
<img width="1552" alt="Screen Shot 2562-07-31 at 13 56 40" src="https://user-images.githubusercontent.com/2154669/62190277-2c892900-b39b-11e9-80b1-a07828cda864.png">

**IMPORTANT**

5. If Webhook is set, Omise-WooCommerce will catch a `charge.complete` event and update a pending-payment order accordingly. If no, then merchants have to update an order status manually.

Successful case, order status get updated to `processing`.
![billpayment-order-paid](https://user-images.githubusercontent.com/2154669/62190851-86d6b980-b39c-11e9-80ed-3cd7b93e2118.jpg)

Failure case, order status get updated to `failed`.
![billpayment-order-failed](https://user-images.githubusercontent.com/2154669/62191339-85f25780-b39d-11e9-8523-73574ec67d43.jpg)


#### 4. Impact of the change

Nothing

#### 5. Priority of change

Normal

#### 6. Additional Notes

There are 2 more PRs coming regarding to Omise Bill Payment, which are:
1. Hook and display Bill Payment's barcode at the WC order confirmation email.
2. Adding 'printing' button, buyer can print out the barcode after completed the purchase.

Also, according to the Quality assurance section, case [5].
There is one solution that I would like to provide in the future pull request (after the above 2 coming pull requests). Update order status when buyers open an order history page.

The flow is simple, when buyers open an order history page then, plugin will first, check if there is any pending-payment status remains. Then request to Omise Charge API to check for a new status and update those orders accordingly before display it on a screen.