### PR TITLE
Updating npm vulnerable dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -479,9 +479,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "loud-rejection": {


### PR DESCRIPTION
#### 1. Objective

According to the alarming of `npm audit`:
![Screen Shot 2562-08-01 at 02 12 43](https://user-images.githubusercontent.com/2154669/62240845-106ca280-b402-11e9-8a0c-19aea64d2cd0.png)

This pull request is providing an update to those vulnerable dependencies.

#### 2. Description of change

Just executed command `npm audit fix`.

#### 3. Quality assurance

Executing `npm audit` command to check if there is any vulnerable dependencies remains.
<img width="449" alt="Screen Shot 2562-08-01 at 02 14 30" src="https://user-images.githubusercontent.com/2154669/62240910-3eea7d80-b402-11e9-8384-bcc034b2e97d.png">

#### 4. Impact of the change

Nothing.

#### 5. Priority of change

High

#### 6. Additional Notes

Note that these dependencies aren't (and never) included in the releasing file (on https://wordpress.org/plugins/omise). We are using `grunt-wp-i18n` package in dev environment as for generating a translation file only.