### PR TITLE
 Bill Payment: Adding a 'Print barcode' button.

### DIFF
--- a/assets/css/omise-billpayment-print.css
+++ b/assets/css/omise-billpayment-print.css
@@ -1,0 +1,34 @@
+.omise-billpayment-tesco-print-detail {
+    visibility: hidden;
+    width: 100%;
+    height: 0;
+    text-align: center;
+}
+
+@media print {
+    body * {
+        display: none;
+        visibility: hidden;
+    }
+
+    body .omise-billpayment-tesco-print-detail {
+        display: block;
+        visibility: visible;
+        position: static;
+        left: 0;
+        top: 0;
+        width: 100%;
+    }
+    
+    .omise-billpayment-tesco-print-detail * {
+        display: block;
+        visibility: visible;
+        width: auto;
+        margin: auto;
+        height: auto;
+    }
+
+    .omise-billpayment-tesco-barcode {
+        display: inline-block;
+    }
+}

--- a/assets/css/omise-billpayment-print.css
+++ b/assets/css/omise-billpayment-print.css
@@ -1,4 +1,5 @@
 .omise-billpayment-tesco-print-detail {
+    display: none;
     visibility: hidden;
     width: 100%;
     height: 0;
@@ -26,6 +27,64 @@
         width: auto;
         margin: auto;
         height: auto;
+    }
+
+    /**
+     * Reset elements for printing screen.
+     */
+    .omise-billpayment-tesco-print-detail h1,
+    .omise-billpayment-tesco-print-detail h2,
+    .omise-billpayment-tesco-print-detail h3,
+    .omise-billpayment-tesco-print-detail p {
+        width: 100%;
+    }
+
+    .omise-billpayment-tesco-print-detail strong,
+    .omise-billpayment-tesco-print-detail small,
+    .omise-billpayment-tesco-print-detail span,
+    .omise-billpayment-tesco-print-detail del,
+    .omise-billpayment-tesco-print-detail ins {
+        display: inline;
+    }
+
+    .omise-billpayment-tesco-print-detail ul,
+    .omise-billpayment-tesco-print-detail ul li {
+        width: 100%;
+    }
+    /** END reset elements. **/
+
+    .omise-billpayment-tesco-print-detail ul li {
+        padding: .65 0em;
+    }
+
+    .omise-billpayment-tesco-print-order-overview {
+        padding-top: 6em;
+    }
+
+    .omise-billpayment-tesco-print-order-overview::after {
+        visibility: hidden;
+        display: block;
+        height: 0;
+        content: ".";
+        clear: both;
+    }
+
+    .omise-billpayment-tesco-print-order-overview-item {
+        float: left;
+        width: 50%;
+        padding: 1em 0;
+    }
+
+    .omise-billpayment-tesco-print-order-payment-method {
+        margin: 3em 0;
+    }
+
+    .omise-billpayment-tesco-print-barcode-message {
+        margin-bottom: 1em;
+    }
+
+    .omise-billpayment-tesco-print-barcode-wrapper {
+        margin-bottom: 1em;
     }
 
     .omise-billpayment-tesco-barcode {

--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -51,15 +51,16 @@ fieldset.card-exists {
  * Omise Bill Payment Tesco
  * CSS for the 'Thank You' (order-received) page.
  */
-.omise-billpayment-tesco-details      { margin-bottom: 4em; text-align:center; }
-.omise-billpayment-tesco-barcode img  { margin: auto; }
-.omise-billpayment-tesco-print-button { margin-top: 1em; }
-@media print {
-	.omise-billpayment-tesco-print-button {
-		display: none;
-	}
+.omise-billpayment-tesco-details {
+	margin-bottom: 4em;
+	text-align: center;
 }
-
+.omise-billpayment-tesco-barcode {
+	display: inline-block;
+}
+.omise-billpayment-tesco-print-button {
+	margin-top: 2em;
+}
 
 /**
  * 2). Components

--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -51,8 +51,14 @@ fieldset.card-exists {
  * Omise Bill Payment Tesco
  * CSS for the 'Thank You' (order-received) page.
  */
-.omise-billpayment-tesco-details     { margin-bottom: 4em; text-align:center; }
-.omise-billpayment-tesco-barcode img { margin: auto; }
+.omise-billpayment-tesco-details      { margin-bottom: 4em; text-align:center; }
+.omise-billpayment-tesco-barcode img  { margin: auto; }
+.omise-billpayment-tesco-print-button { margin-top: 1em; }
+@media print {
+	.omise-billpayment-tesco-print-button {
+		display: none;
+	}
+}
 
 
 /**

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -160,47 +160,50 @@ function register_omise_billpayment_tesco() {
 			<?php if ( 'email' !== $context ) : ?>
 
 				<div class="omise-billpayment-tesco-print-detail">
-					<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received"><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ), $order ); ?></p>
-					<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+					<div>
+						<h2><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ), $order ); ?></h2>
+					</div>
 
-						<li class="woocommerce-order-overview__order order">
+					<div class="omise-billpayment-tesco-print-order-overview">
+						<div class="omise-billpayment-tesco-print-order-overview-item">
 							<?php _e( 'Order number:', 'woocommerce' ); ?>
-							<strong><?php echo $this->order()->get_order_number(); ?></strong>
-						</li>
+							<br/><strong><?php echo $this->order()->get_order_number(); ?></strong>
+						</div>
 
-						<li class="woocommerce-order-overview__date date">
-							<?php _e( 'Date:', 'woocommerce' ); ?>
-							<strong><?php echo wc_format_datetime( $this->order()->get_date_created() ); ?></strong>
-						</li>
+						<div class="omise-billpayment-tesco-print-order-overview-item">
+							<?php _e( 'Date:', 'woocommerce' ); ?>:
+							<br/><strong><?php echo wc_format_datetime( $this->order()->get_date_created() ); ?></strong>
+						</div>
 
 						<?php if ( is_user_logged_in() && $this->order()->get_user_id() === get_current_user_id() && $this->order()->get_billing_email() ) : ?>
-							<li class="woocommerce-order-overview__email email">
-								<?php _e( 'Email:', 'woocommerce' ); ?>
-								<strong><?php echo $this->order()->get_billing_email(); ?></strong>
-							</li>
+							<div class="omise-billpayment-tesco-print-order-overview-item">
+								<?php _e( 'Email:', 'woocommerce' ); ?>:
+								<br/><strong><?php echo $this->order()->get_billing_email(); ?></strong>
+							</div>
 						<?php endif; ?>
 
-						<li class="woocommerce-order-overview__total total">
-							<?php _e( 'Total:', 'woocommerce' ); ?>
-							<strong><?php echo $this->order()->get_formatted_order_total(); ?></strong>
-						</li>
+						<div class="omise-billpayment-tesco-print-order-overview-item">
+							<?php _e( 'Total:', 'woocommerce' ); ?>:
+							<br/><strong><?php echo $this->order()->get_formatted_order_total(); ?></strong>
+						</div>
+					</div>
 
-						<?php if ( $this->order()->get_payment_method_title() ) : ?>
-							<li class="woocommerce-order-overview__payment-method method">
-								<?php _e( 'Payment method:', 'woocommerce' ); ?>
-								<strong><?php echo wp_kses_post( $this->order()->get_payment_method_title() ); ?></strong>
-							</li>
-						<?php endif; ?>
+					<?php if ( $this->order()->get_payment_method_title() ) : ?>
+						<div class="omise-billpayment-tesco-print-order-payment-method">
+							<?php _e( 'Payment method:', 'woocommerce' ); ?>
+							<br/><strong><?php echo wp_kses_post( $this->order()->get_payment_method_title() ); ?></strong>
+						</div>
+					<?php endif; ?>
 
-					</ul>
+					<p class="omise-billpayment-tesco-print-barcode-message"><?php _e( 'Use this barcode to pay at Tesco Lotus.', 'omise' ); ?></p>
 
-					<p><?php echo __( 'Use this barcode to pay at Tesco Lotus.', 'omise' ); ?></p>
-					<div class="omise-billpayment-tesco-barcode-wrapper">
+					<div class="omise-billpayment-tesco-print-barcode-wrapper">
 						<?php echo $barcode_html; ?>
 					</div>
-					<small class="omise-billpayment-tesco-reference-number">
-						<?php echo $barcode_ref_number; ?>
-					</small>
+
+					<div class="omise-billpayment-tesco-print-reference-number">
+						<small><?php echo $barcode_ref_number; ?></small>
+					</div>
 				</div>
 
 				<script type="text/javascript">
@@ -208,6 +211,8 @@ function register_omise_billpayment_tesco() {
 					let cloned_omise_billpayment_print_detail = omise_billpayment_print_detail[0].cloneNode( true );
 
 					document.body.appendChild( cloned_omise_billpayment_print_detail );
+
+					omise_billpayment_print_detail[0].parentNode.removeChild( omise_billpayment_print_detail[0] );
 				</script>
 
 			<?php endif;

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -146,6 +146,12 @@ function register_omise_billpayment_tesco() {
 					);
 					?>
 				</small>
+
+				<?php if ( 'email' !== $context ) : ?>
+					<div class="omise-billpayment-tesco-print-button">
+						<button onClick="window.print()" class="button button-primary">Print barcode</button>
+					</div>
+				<?php endif; ?>
 			</div>
 			<?php
 		}

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -78,6 +78,8 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	public function omise_checkout_assets() {
 		if ( is_checkout() ) {
 			wp_enqueue_style( 'omise', plugins_url( '../../assets/css/omise-css.css', __FILE__ ), array(), OMISE_WOOCOMMERCE_PLUGIN_VERSION );
+
+			do_action( 'omise_checkout_assets' );
 		}
 	}
 


### PR DESCRIPTION
> ⚠️ THIS PULL REQUEST REQUIRES #122 AND #125 TO BE MERGED FIRST.

#### 1. Objective

Regarding on user behaviour when it comes to a barcode payment.
Either the barcode has to be mobility-supported (which we already provided a solution by sending barcode through email at #125.), or user should be able to print it and carry out.

This pull request is adding a printing button that would help saving our end-users from remembering and finding a `ctrl+p` shortcut on their keyboard.

#### 2. Description of change

Adding a printing button at WooCommerce Thank You page.

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v3.6.5
- **WordPress**: v5.2.2
- **PHP**: v7.2.20

**✏️ Details:**

Make a purchase using `Bill Payment: Tesco` payment method as normal.
At the last step, "Thank You" page, there should be a 'printing barcode' button appear under the barcode reference number.
![printing-btn](https://user-images.githubusercontent.com/2154669/62498130-5e214a80-b808-11e9-8907-49dc07cedb1a.png)

Clicking at the button, a browser printing feature should be triggered, plus, the printing button should be disappeared at the printing page.
![printing-btn-2](https://user-images.githubusercontent.com/2154669/62498166-7729fb80-b808-11e9-8dad-e7f0758edc29.png)

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No