### PR TITLE
Bill Payment: adding white-background to a displayed barcode (both we…

### DIFF
--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -261,6 +261,7 @@ function register_omise_billpayment_tesco() {
 
 			$div_wrapper = $xhtml->createElement( 'div' );
 			$div_wrapper->setAttribute( 'class', 'omise-billpayment-tesco-barcode' );
+			$div_wrapper->setAttribute( 'style', 'background-color: #ffffff;' );
 
 			// Read data from all <rect> nodes.
 			foreach ( $xml->g->g->children() as $rect ) {
@@ -277,13 +278,12 @@ function register_omise_billpayment_tesco() {
 				$prevWidth = $attributes['width'];
 			}
 
-			$xhtml->appendChild( $div_wrapper );
-
 			// Add an empty <div></div> element to clear those floating elements.
 			$div = $xhtml->createElement( 'div' );
 			$div->setAttribute( 'style', 'clear:both' );
-			$xhtml->appendChild( $div );
+			$div_wrapper->appendChild( $div );
 
+			$xhtml->appendChild( $div_wrapper );
 			return $xhtml->saveXML( null, LIBXML_NOEMPTYTAG );
 		}
 	}


### PR DESCRIPTION
#### 1. Objective

To prevent a situation where Bill Payment barcode might be displayed at a website or an email client that is themed in a black background or in a dark theme.

#### 2. Description of change

- Adding a white background to a barcode's parent div element.
- Also rearrange a div element (moving `<div style="clear:both"></div>` into `<div class="omise-billpayment-tesco-barcode`">...</div>`.

Before:
```html
<div class="omise-billpayment-tesco-barcode">
    <div>... bar code ...</div>
    <div>... bar code ...</div>
    <div>... bar code ...</div>
</div>
<div style="clear:both"></div>
```

After:
```html
<div class="omise-billpayment-tesco-barcode" style="background-color: #ffffff;">
    <div>... bar code ...</div>
    <div>... bar code ...</div>
    <div>... bar code ...</div>
    <div style="clear:both"></div>
</div>
```

The reason is those barcode elements are set to `float: left` and without clearing its floating position properly, we can't set a white background to `.omise-billpayment-tesco-barcode` element.

#### 3. Quality assurance

**✏️ Details:**

Just test setting content's background to be black or using dark color then purchase an item with Bill Payment payment method while you are still at the dark-color theme.
Then, using any free barcode scanner application (mobile) to test scan barcode if it worked.

![Screen Shot 2562-08-13 at 21 45 52](https://user-images.githubusercontent.com/2154669/62953216-499c0e00-be17-11e9-816e-c75264e2347b.png)

![Screen Shot 2562-08-13 at 22 06 19](https://user-images.githubusercontent.com/2154669/62953243-53be0c80-be17-11e9-8dcc-546a21d906de.png)

I did test scan the above barcodes on both website and email. It works properly.

#### 4. Impact of the change

Nothing

#### 5. Priority of change

Normal

#### 6. Additional Notes

Suggested by @jonrandy 