### PR TITLE
Bill Payment, simplifying and updating relevant informations at the thank you page

### DIFF
--- a/assets/css/omise-billpayment-print.css
+++ b/assets/css/omise-billpayment-print.css
@@ -1,64 +1,62 @@
-.omise-billpayment-tesco-print-detail {
+.omise-billpayment-tesco-print-details,
+.omise-billpayment-tesco-print-order-overview {
     display: none;
-    visibility: hidden;
-    width: 100%;
-    height: 0;
-    text-align: center;
 }
 
 @media print {
     body * {
         display: none;
-        visibility: hidden;
     }
 
-    body .omise-billpayment-tesco-print-detail {
+    body .omise-billpayment-tesco-print-details {
         display: block;
-        visibility: visible;
         position: static;
-        left: 0;
         top: 0;
+        left: 0;
         width: 100%;
     }
-    
-    .omise-billpayment-tesco-print-detail * {
+
+    .omise-billpayment-tesco-print-details * {
         display: block;
-        visibility: visible;
         width: auto;
         margin: auto;
-        height: auto;
+    }
+
+    .omise-billpayment-tesco-print-button {
+        display: none;
     }
 
     /**
      * Reset elements for printing screen.
      */
-    .omise-billpayment-tesco-print-detail h1,
-    .omise-billpayment-tesco-print-detail h2,
-    .omise-billpayment-tesco-print-detail h3,
-    .omise-billpayment-tesco-print-detail p {
+    .omise-billpayment-tesco-print-details h1,
+    .omise-billpayment-tesco-print-details h2,
+    .omise-billpayment-tesco-print-details h3,
+    .omise-billpayment-tesco-print-details p {
         width: 100%;
     }
 
-    .omise-billpayment-tesco-print-detail strong,
-    .omise-billpayment-tesco-print-detail small,
-    .omise-billpayment-tesco-print-detail span,
-    .omise-billpayment-tesco-print-detail del,
-    .omise-billpayment-tesco-print-detail ins {
+    .omise-billpayment-tesco-print-details strong,
+    .omise-billpayment-tesco-print-details small,
+    .omise-billpayment-tesco-print-details span,
+    .omise-billpayment-tesco-print-details del,
+    .omise-billpayment-tesco-print-details ins {
         display: inline;
-    }
-
-    .omise-billpayment-tesco-print-detail ul,
-    .omise-billpayment-tesco-print-detail ul li {
-        width: 100%;
     }
     /** END reset elements. **/
 
-    .omise-billpayment-tesco-print-detail ul li {
-        padding: .65 0em;
+    .omise-billpayment-tesco-print-order-overview {
+        margin: 6em 0 2em 0;
     }
 
-    .omise-billpayment-tesco-print-order-overview {
-        padding-top: 6em;
+    .omise-billpayment-tesco-print-order-overview > div {
+        float: left;
+        width: 50%;
+        padding: 1em 0;
+    }
+
+    .omise-billpayment-tesco-print-order-overview strong {
+        font-size: 115%;
     }
 
     .omise-billpayment-tesco-print-order-overview::after {
@@ -69,25 +67,18 @@
         clear: both;
     }
 
-    .omise-billpayment-tesco-print-order-overview-item {
-        float: left;
-        width: 50%;
-        padding: 1em 0;
-    }
-
-    .omise-billpayment-tesco-print-order-payment-method {
-        margin: 3em 0;
-    }
-
-    .omise-billpayment-tesco-print-barcode-message {
-        margin-bottom: 1em;
-    }
-
-    .omise-billpayment-tesco-print-barcode-wrapper {
-        margin-bottom: 1em;
+    .omise-billpayment-tesco-barcode-wrapper {
+        margin: 1em 0;
     }
 
     .omise-billpayment-tesco-barcode {
         display: inline-block;
+    }
+
+    .omise-billpayment-tesco-footnote {
+        width: 90%;
+        margin: 4em auto;
+        text-align: right;
+        font-size: 85%;
     }
 }

--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -61,6 +61,17 @@ fieldset.card-exists {
 .omise-billpayment-tesco-print-button {
 	margin-top: 2em;
 }
+.omise-billpayment-tesco-footnote {
+	margin-top: 4em;
+	padding: 1em;
+	font-size: 85%;
+	text-align: left;
+	background-color: #f8f8f8;
+}
+.omise-billpayment-tesco-footnote p {
+	margin: 0;
+	padding: 0;
+}
 
 /**
  * 2). Components

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -137,84 +137,91 @@ function register_omise_billpayment_tesco() {
 				$charge['source']['references']['reference_number_2'],
 				$charge['amount']
 			);
+			$expires_timestamp  = strtotime( $charge['source']['references']['expires_at'] );
 			?>
 
 			<div class="omise omise-billpayment-tesco-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
-				<p><?php echo __( 'Use this barcode to pay at Tesco Lotus.', 'omise' ); ?></p>
+				<!-- Display for printing only. -->
+				<!-- Hidden by assets/css/omise-billpayment-print.css. -->
+				<?php if ( 'email' !== $context ) : ?>
+					<div class="omise-billpayment-tesco-print-order-overview">
+						<div>
+							<?php _e( 'Order number:', 'woocommerce' ); ?>
+							<br/><strong><?php echo $this->order()->get_order_number(); ?></strong>
+						</div>
+
+						<div>
+							<?php _e( 'Date:', 'woocommerce' ); ?>
+							<br/><strong><?php echo wc_format_datetime( $this->order()->get_date_created() ); ?></strong>
+						</div>
+
+						<div>
+							<?php _e( 'Total:', 'woocommerce' ); ?>
+							<br/><strong><?php echo $this->order()->get_formatted_order_total(); ?></strong>
+						</div>
+
+						<?php if ( $this->order()->get_payment_method_title() ) : ?>
+							<div>
+								<?php _e( 'Payment method:', 'woocommerce' ); ?>
+								<br/><strong><?php echo wp_kses_post( $this->order()->get_payment_method_title() ); ?></strong>
+							</div>
+						<?php endif; ?>
+					</div>
+				<?php endif; ?>
+				<!-- /END .omise-billpayment-tesco-print-detail -->
+
+				<p>
+					<?php
+					echo sprintf(
+						wp_kses(
+							__( 'Please bring this barcode to pay at Tesco Lotus within:<br/><strong>%1$s</strong> at <strong>%2$s</strong>.', 'omise' ),
+							array( 'br' => array(), 'strong' => array() )
+						),
+						date_i18n( wc_date_format(), $expires_timestamp ),
+						date_i18n( wc_time_format(), $expires_timestamp )
+					);
+					?>
+				</p>
+
 				<div class="omise-billpayment-tesco-barcode-wrapper">
 					<?php echo $barcode_html; ?>
 				</div>
-				<small class="omise-billpayment-tesco-reference-number">
-					<?php echo $barcode_ref_number; ?>
-				</small>
+
+				<div class="omise-billpayment-tesco-barcode-reference-number">
+					<small><?php echo $barcode_ref_number; ?></small>
+				</div>
 
 				<?php if ( 'email' !== $context ) : ?>
 					<div class="omise-billpayment-tesco-print-button">
 						<button onClick="window.print()" class="button button-primary">Print barcode</button>
 					</div>
 				<?php endif; ?>
+
+				<div class="omise-billpayment-tesco-footnote">
+					<p>
+						<?php
+						echo wp_kses(
+							__(
+								'
+								Tesco Lotus may charge a small fee for the transaction.<br/>
+								Failing to make payment within the mentioned date and time, your order will be automatically canceled.
+								', 'omise'
+							),
+							array( 'br' => array() )
+						);
+						?>
+					</p>
+				</div>
 			</div>
 
-			<!-- Display for printing only. -->
-			<!-- Hidden by assets/css/omise-billpayment-print.css. -->
 			<?php if ( 'email' !== $context ) : ?>
-
-				<div class="omise-billpayment-tesco-print-detail">
-					<div>
-						<h2><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ), $order ); ?></h2>
-					</div>
-
-					<div class="omise-billpayment-tesco-print-order-overview">
-						<div class="omise-billpayment-tesco-print-order-overview-item">
-							<?php _e( 'Order number:', 'woocommerce' ); ?>
-							<br/><strong><?php echo $this->order()->get_order_number(); ?></strong>
-						</div>
-
-						<div class="omise-billpayment-tesco-print-order-overview-item">
-							<?php _e( 'Date:', 'woocommerce' ); ?>:
-							<br/><strong><?php echo wc_format_datetime( $this->order()->get_date_created() ); ?></strong>
-						</div>
-
-						<?php if ( is_user_logged_in() && $this->order()->get_user_id() === get_current_user_id() && $this->order()->get_billing_email() ) : ?>
-							<div class="omise-billpayment-tesco-print-order-overview-item">
-								<?php _e( 'Email:', 'woocommerce' ); ?>:
-								<br/><strong><?php echo $this->order()->get_billing_email(); ?></strong>
-							</div>
-						<?php endif; ?>
-
-						<div class="omise-billpayment-tesco-print-order-overview-item">
-							<?php _e( 'Total:', 'woocommerce' ); ?>:
-							<br/><strong><?php echo $this->order()->get_formatted_order_total(); ?></strong>
-						</div>
-					</div>
-
-					<?php if ( $this->order()->get_payment_method_title() ) : ?>
-						<div class="omise-billpayment-tesco-print-order-payment-method">
-							<?php _e( 'Payment method:', 'woocommerce' ); ?>
-							<br/><strong><?php echo wp_kses_post( $this->order()->get_payment_method_title() ); ?></strong>
-						</div>
-					<?php endif; ?>
-
-					<p class="omise-billpayment-tesco-print-barcode-message"><?php _e( 'Use this barcode to pay at Tesco Lotus.', 'omise' ); ?></p>
-
-					<div class="omise-billpayment-tesco-print-barcode-wrapper">
-						<?php echo $barcode_html; ?>
-					</div>
-
-					<div class="omise-billpayment-tesco-print-reference-number">
-						<small><?php echo $barcode_ref_number; ?></small>
-					</div>
-				</div>
-
 				<script type="text/javascript">
-					let omise_billpayment_print_detail        = document.getElementsByClassName( 'omise-billpayment-tesco-print-detail' );
-					let cloned_omise_billpayment_print_detail = omise_billpayment_print_detail[0].cloneNode( true );
+					let omise_billpayment_detail        = document.getElementsByClassName( 'omise-billpayment-tesco-details' );
+					let cloned_omise_billpayment_detail = omise_billpayment_detail[0].cloneNode( true );
+					    cloned_omise_billpayment_detail.classList.add( 'omise-billpayment-tesco-print-details' );
 
-					document.body.appendChild( cloned_omise_billpayment_print_detail );
-
-					omise_billpayment_print_detail[0].parentNode.removeChild( omise_billpayment_print_detail[0] );
+					document.body.appendChild( cloned_omise_billpayment_detail );
 				</script>
-
 			<?php endif;
 		}
 

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -175,7 +175,7 @@ function register_omise_billpayment_tesco() {
 					<?php
 					echo sprintf(
 						wp_kses(
-							__( 'Please bring this barcode to pay at Tesco Lotus within:<br/><strong>%1$s</strong> at <strong>%2$s</strong>.', 'omise' ),
+							__( 'Please bring this barcode to pay at Tesco Lotus by:<br/><strong>%1$s %2$s</strong>.', 'omise' ),
 							array( 'br' => array(), 'strong' => array() )
 						),
 						wc_format_datetime( $expires_datetime, wc_date_format() ),
@@ -194,7 +194,7 @@ function register_omise_billpayment_tesco() {
 
 				<?php if ( 'email' !== $context ) : ?>
 					<div class="omise-billpayment-tesco-print-button">
-						<button onClick="window.print()" class="button button-primary">Print barcode</button>
+						<button onClick="window.print()" class="button button-primary"><?php echo __( 'Print barcode', 'omise' ); ?></button>
 					</div>
 				<?php endif; ?>
 
@@ -205,7 +205,7 @@ function register_omise_billpayment_tesco() {
 							__(
 								'
 								Tesco Lotus may charge a small fee for the transaction.<br/>
-								Failing to make payment within the mentioned date and time, your order will be automatically canceled.
+								If you fail to make payment by the stated time, your order will be automatically canceled.
 								', 'omise'
 							),
 							array( 'br' => array() )

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -184,7 +184,7 @@ function register_omise_billpayment_tesco() {
 					?>
 				</p>
 
-				<div class="omise-billpayment-tesco-barcode-wrapper">
+				<div class="omise-billpayment-tesco-barcode-wrapper" <?php echo 'email' === $context ? 'style="margin: 1em 0;"' : ''; ?>>
 					<?php echo $barcode_html; ?>
 				</div>
 
@@ -198,8 +198,8 @@ function register_omise_billpayment_tesco() {
 					</div>
 				<?php endif; ?>
 
-				<div class="omise-billpayment-tesco-footnote">
-					<p>
+				<div class="omise-billpayment-tesco-footnote" <?php echo 'email' === $context ? 'style="margin-top: 4em; padding: 1em; font-size: 85%; text-align: right; background-color: #f8f8f8;"' : ''; ?>>
+					<p <?php echo 'email' === $context ? 'style="margin: 0; padding: 0;"' : ''; ?>>
 						<?php
 						echo wp_kses(
 							__(

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -137,7 +137,8 @@ function register_omise_billpayment_tesco() {
 				$charge['source']['references']['reference_number_2'],
 				$charge['amount']
 			);
-			$expires_timestamp  = strtotime( $charge['source']['references']['expires_at'] );
+			$expires_datetime   = new WC_DateTime( $charge['source']['references']['expires_at'], new DateTimeZone( 'UTC' ) );
+			$expires_datetime->set_utc_offset( wc_timezone_offset() );
 			?>
 
 			<div class="omise omise-billpayment-tesco-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
@@ -177,8 +178,8 @@ function register_omise_billpayment_tesco() {
 							__( 'Please bring this barcode to pay at Tesco Lotus within:<br/><strong>%1$s</strong> at <strong>%2$s</strong>.', 'omise' ),
 							array( 'br' => array(), 'strong' => array() )
 						),
-						date_i18n( wc_date_format(), $expires_timestamp ),
-						date_i18n( wc_time_format(), $expires_timestamp )
+						wc_format_datetime( $expires_datetime, wc_date_format() ),
+						wc_format_datetime( $expires_datetime, wc_time_format() )
 					);
 					?>
 				</p>


### PR DESCRIPTION
#### 1. Objective

There are some missing informations on our Bill Payment barcode detail (on both printing, and on a screen).

This pull request is aiming to add all those details (as well as adjusting its UI)
– suggested by @jacstn, thanks :D 

#### 2. Description of change

- Simplifying stylesheet and reconstruct HTML element to reduce duplicated code and unnecessary css-classes
- Removing buyer's `Email` column from the printing detail.
- Adding more information about expiring date and Tesco Lotus transaction fee.

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v3.6.5
- **WordPress**: v5.2.2
- **PHP**: v7.2.21

**✏️ Details:**

Make a new purchase using Bill Payment payment method as normal.
At the thank you page, you should be able to see this new information at the page.
![Screen Shot 2562-08-14 at 08 38 17](https://user-images.githubusercontent.com/2154669/62989364-d70c4c00-be71-11e9-8a5e-7b36806dbed0.png)

We may want to make sure that an expiration date can be formatted properly based on a store's time-zone by updating TimeZone option at WordPress General Setting page.
![wordpress-setting-tz](https://user-images.githubusercontent.com/2154669/62989455-366a5c00-be72-11e9-951e-989674d993fc.jpg)

Then, refresh the thank you page to make sure that an expiration date is formatted accordingly.
![billpayment-tz-adjusted](https://user-images.githubusercontent.com/2154669/62989520-8f39f480-be72-11e9-9da6-7b0f8a8745be.jpg)

Click "Print barcode" button, check its output.
![Screen Shot 2562-08-14 at 08 40 07](https://user-images.githubusercontent.com/2154669/62989566-b7295800-be72-11e9-9157-108b4ca5c43b.png)

Also, check its output for the email format.
![Screen Shot 2562-08-14 at 08 48 15](https://user-images.githubusercontent.com/2154669/62989575-c90afb00-be72-11e9-8d59-ccfc72c6dfe2.png)

#### 4. Impact of the change

Nothing

#### 5. Priority of change

Normal

#### 6. Additional Notes

Just want to note that I think this code is relying too much on WooCommerce Helper class and method. Would be nice to somehow, organize it within Omise class, and provide an alternative in case if those WC helper methods get removed.

However, it would be way too big for this scope of its objective and concern.
Probably better to split it to another PR if we are really going to refactor it.

Also, this button and message at the thank you page may mislead users that they have only one option to print the barcode out without realizing that the barcode is also sent to their email. (again, I think it is out of scope for this objective)
