### PR TITLE
Fixing calling Omise_Money's non-static method statically.

### DIFF
--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -37,7 +37,7 @@ class Omise_Money {
 	 *                    This is to prevent any miscalculation for those fractional subunits
 	 *                    between the amount that is charged, and the actual amount from the store.
 	 */
-	public function to_subunit( $amount, $currency ) {
+	public static function to_subunit( $amount, $currency ) {
 		$amount   = static::purify_amount( $amount );
 		$currency = strtoupper( $currency );
 

--- a/includes/class-omise-money.php
+++ b/includes/class-omise-money.php
@@ -38,14 +38,14 @@ class Omise_Money {
 	 *                    between the amount that is charged, and the actual amount from the store.
 	 */
 	public static function to_subunit( $amount, $currency ) {
-		$amount   = static::purify_amount( $amount );
+		$amount   = self::purify_amount( $amount );
 		$currency = strtoupper( $currency );
 
-		if ( ! isset( static::$subunit_multiplier[ $currency ] ) ) {
+		if ( ! isset( self::$subunit_multiplier[ $currency ] ) ) {
 			throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
 		}
 
-		return $amount * static::$subunit_multiplier[ $currency ];
+		return $amount * self::$subunit_multiplier[ $currency ];
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

We've got a report of an error on PHP 5.6 when using `Omise_Money` class.

```php
PHP Fatal error:  Call to undefined method Omise_Payment_Creditcard::purify_amount() in /var/www/html/wp-content/plugins/omise/includes/class-omise-money.php on line 41
```

This pull request is to address the issue.

More context:
Originally `Omise_Money` class was designed to be initiated (`$money = new Omise_Money`) before use, then got modified during the code review process.

However the `Omise_Money::to_subunit()` method hasn't been modified accordingly.
So if we are trying to call a non-static method statically while this method is calling another static method inside itself (with `static` keyword instead of `self`), the late static binding will get confused and result as "Fatal error".


**Related information**:
Related issue(s): Internal Ticket: **T14441**

#### 2. Description of change

There are 2 possibilities to solve this problem.
One is to make `Omise_Money::to_subunit()` method static
```php
class Omise_Money {
    public function to_subunit() { ... }
}
```
👇 
```php
class Omise_Money {
    public static function to_subunit() { ... }
}
```

And,
Another is to replace all `static` keywords to `self`.

```php
public function to_subunit( $amount, $currency ) {
    $amount   = static::purify_amount( $amount );
    $currency = strtoupper( $currency );

    if ( ! isset( static::$subunit_multiplier[ $currency ] ) ) {
        throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
    }

    return $amount * static::$subunit_multiplier[ $currency ];
}
```
👇 
```php
public function to_subunit( $amount, $currency ) {
    $amount   = self::purify_amount( $amount );
    $currency = strtoupper( $currency );

    if ( ! isset( self::$subunit_multiplier[ $currency ] ) ) {
        throw new Exception( __( 'We do not support the currency you are using.', 'omise' ) );
    }

    return $amount * self::$subunit_multiplier[ $currency ];
}
```

However, I choose to modify these 2 places together as for the following reasons:
1. Technically, calling non-static method statically is a wrong-doing and got deprecated by PHP 7.x already (In PHP 5, calling non-static methods statically generates an `E_STRICT` level warning).
  So we have to fix this right away.
  ref: https://www.php.net/manual/en/language.oop5.static.php

2. `static` keyword is designed for the late static binding feature, which, we don't really need that ability in this method. Replacing `static` is to reduce any misbehaviour potential that we don't design it for.

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: `v3.7.0`.
- **WordPress**: `v5.2.2`.
- **PHP**: `v5.6.40`, `v7.3.3`.

**✏️ Details:**

Go through the checkout process as normal and place an order.
You should be able to make a new charge properly
**PHP v5.6.40**
![Screen Shot 2562-08-19 at 07 14 34](https://user-images.githubusercontent.com/2154669/63232349-48247880-c251-11e9-8b06-f54bd7c25774.png)

![Screen Shot 2562-08-19 at 07 14 14](https://user-images.githubusercontent.com/2154669/63232348-48247880-c251-11e9-934d-d07038c391eb.png)

**PHP v7.3.3**
![Screen Shot 2562-08-19 at 07 47 13](https://user-images.githubusercontent.com/2154669/63232814-ad7a6880-c255-11e9-94a8-7659fa6673e8.png)

![Screen Shot 2562-08-19 at 07 47 40](https://user-images.githubusercontent.com/2154669/63232816-ae12ff00-c255-11e9-980a-4d69635cb25d.png)

And,
Making sure that all tests are green.
![Screen Shot 2562-08-19 at 08 01 18](https://user-images.githubusercontent.com/2154669/63233041-950b4d80-c257-11e9-8278-fb8cc8a3ec25.png)

#### 4. Impact of the change

No

#### 5. Priority of change

High

#### 6. Additional Notes

Thanks @keeratita for helping me debug this issue