### PR TITLE
Event "charge.complete", making sure that event's charge id is identical with order transaction id.

### DIFF
--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -52,6 +52,11 @@ class Omise_Event_Charge_Complete {
 			return;
 		}
 
+		// Making sure that an event's charge id is identical with an order transaction id.
+		if ( $order->get_transaction_id() !== $data->id ) {
+			return;
+		}
+
 		$order->add_order_note(
 			__(
 				'Omise: an event charge.complete has been caught (webhook).',


### PR DESCRIPTION
#### 1. Objective

[drafting]

**Related information**:
Related issue(s): #100, #103 

#### 2. Description of change

Check if order's transaction id is the same as charge object in the event's payload.

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: `v3.7.0`.
- **WordPress**: `v5.2.2`.
- **PHP**: `v5.6.40`, `v7.3.3`.

**✏️ Details:**

[drafting]

#### 4. Impact of the change

No

#### 5. Priority of change

High

#### 6. Additional Notes

No
