### PR TITLE
Billpayment - check if an order is made by Bill Payment before display a barcode.

### DIFF
--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -233,7 +233,9 @@ function register_omise_billpayment_tesco() {
 		 * @see   woocommerce/templates/emails/plain/email-order-details.php
 		 */
 		public function email_barcode( $order ) {
-			$this->display_barcode( $order, 'email' );
+			if ( $this->id == $order->get_payment_method() ) {
+				$this->display_barcode( $order, 'email' );
+			}
 		}
 
 		/**


### PR DESCRIPTION
#### 1. Objective

Omise-WooCommerce v3.7 Bill Payment barcode causes the issue that a confirmation email can't be sent out.

As from investigation, it is because `Omise_Payment_Billpayment_Tesco` class hooks `woocommerce_email_after_order_table` action to display an extra information, Bill Payment Barcode. 

```php
class Omise_Payment_Billpayment_Tesco extends Omise_Payment {
    public function __construct() {
        ...
        add_action( 'woocommerce_email_after_order_table', array( $this, 'email_barcode' ) );
        ...
    }
    ...
}
```

However, this hook action is being loaded in every payment method – causing that all payment methods that is available will be sharing and executing `email_barcode` method, which would raise an error and makes WooCommerce confirmation email can't be sent out.

**Related information**:
Related issue(s): #136 and all related tickets that have been reported internally.

#### 2. Description of change

Add a condition to check if an order is placed by Bill Payment payment method before display a barcode.

> Note, this approach has been implemented by one of WooCommerce default-built-in payment methods, `WC_Gateway_BACS`

```php
class WC_Gateway_BACS extends WC_Payment_Gateway {
    ...
    public function __construct() {
        ...
        // Customer Emails.
        add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 3 );
    }
    ...
    /**
     * Add content to the WC emails.
     *
     * @param WC_Order $order Order object.
     * @param bool     $sent_to_admin Sent to admin.
     * @param bool     $plain_text Email format: plain text or HTML.
     */
    public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
        if ( ! $sent_to_admin && 'bacs' === $order->get_payment_method() && $order->has_status( 'on-hold' ) ) {
            if ( $this->instructions ) {
                echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
            }
            $this->bank_details( $order->get_id() );
        }
    }

}
```

#### 3. Quality assurance

**🔧 Environments:**

- **PHP**: v7.2.22
- **WordPress**: v5.2.3
- **WooCommerce**: v3.7.0

**✏️ Details:**

As from reports, a confirmation email can't be sent out if Omise plugin is enabled.
After this fix, all email should be sent out properly.

Testing by,
1. Make an order
2. Place an order with any payment method (Cash on Delivery, Omise: Credit Card, Omise: Tesco Bill Payment). All should work properly

![Screen Shot 2562-09-17 at 17 37 05](https://user-images.githubusercontent.com/2154669/65034717-cc157180-d971-11e9-952e-3022bf76144a.png)

> Please note, that I have discovered one another unrelated issue about Tesco Bill Payment which makes no email is being sent when you place an order with Tesco Bill Payment.
> Because of order-status, placing order with Tesco Bill Payment will set its order status to `pending payment`, which does not trigger a confirmation email.
>
> As I checked, `pending payment` is used as a state where buyer orders but does not complete a payment (not go through the whole order-payment process).
> In a case of Tesco Bill Payment, we should rather set an order to `on-hold` status, which will be fixed in the next coming PR.

#### 4. Impact of the change

None

#### 5. Priority of change

Immediate.

#### 6. Additional Notes

None