### PR TITLE
✨ Releasing Omise-WooCommerce v3.8 (HOTFIX)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,9 +23,10 @@ Specify where and how you tested this and what further testing it might need.
 Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.
 
 i.e.
-- **Platform version**: WooCommerce 3.1.1.
-- **Omise plugin version**: Omise-WooCommerce 3.7.
-- **PHP version**: 7.0.16.
+- **WooCommerce**: v3.7.0
+- **WordPress**: v5.3.2
+- **PHP version**: 7.0.16
+- **Omise plugin version**: Omise-WooCommerce 3.8 (optional, in case of submitting a new issue)
 
 **✏️ Details:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### [v3.8 _(Sep 17, 2019)_](https://github.com/omise/omise-woocommerce/releases/tag/v3.8)
+
+#### 👾 Bug Fixes
+
+- Billpayment - check if an order is made by Bill Payment before display a barcode. (PR [#137](https://github.com/omise/omise-woocommerce/pull/137))
+
+---
+
 ### [v3.7 _(Sep 13, 2019)_](https://github.com/omise/omise-woocommerce/releases/tag/v3.7)
 
 #### ✨ Highlights

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
                     potHeaders: {
                         poedit: false,                  // Includes common Poedit headers.
                         'x-poedit-keywordslist': true,  // Include a list of all possible gettext functions.
-                        'Project-Id-Version': 'Omise Payment Gateway v3.7',
+                        'Project-Id-Version': 'Omise Payment Gateway v3.8',
                         'Report-Msgid-Bugs-To': 'https://github.com/omise/omise-woocommerce/issues'
                     },                                  // Headers to add to the generated POT file.
                     processPot: null,                   // A callback function for manipulating the POT file.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Supported Versions
 
-WooCommerce version 3.3.4 and above (tested to version 3.6.5).
+WooCommerce version 3.3.4 and above (tested to version 3.7.0).
 
 **The extension doesn't work on your version?**  
 Our aim is to support as many versions of WooCommerce as we can.  
@@ -26,12 +26,12 @@ In order to install Omise-WooCommerce plugin, you can either manually download t
 
 #### Manually
 
-1. Download and extract the zip file from [Omise-WooCommerce](https://github.com/omise/omise-woocommerce/archive/v3.7.zip) to your local machine.
+1. Download and extract the zip file from [Omise-WooCommerce](https://github.com/omise/omise-woocommerce/archive/v3.8.zip) to your local machine.
   ![screen shot 2560-07-26 at 12 36 43 pm](https://user-images.githubusercontent.com/2154669/38302382-ac3b1cf8-382c-11e8-80d4-61e935b7a567.png)
 
-2. Copy all files from the step 1 to WordPress plugin folder, `your-wordpress-dir/wp-content/plugins/omise-woocommerce-3.7`.
+2. Copy all files from the step 1 to WordPress plugin folder, `your-wordpress-dir/wp-content/plugins/omise-woocommerce-3.8`.
 
-3. Rename `omise-woocommerce-3.7` folder to `omise`
+3. Rename `omise-woocommerce-3.8` folder to `omise`
   ![screen shot 2560-07-26 at 12 36 43 pm](https://user-images.githubusercontent.com/2154669/28606035-2b9387dc-71ff-11e7-887d-dc90ce774a39.png)
 
 4. Once done, `Omise Payment Gateway` plugin will be shown at the **Installed Plugins** page. Click `activate` to activate the plugin.

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     3.7
+ * Version:     3.8
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -18,7 +18,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '3.7';
+	public $version = '3.8';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay
 Requires at least: 4.3.1
-Tested up to: 5.2.2
-Stable tag: 3.7
+Tested up to: 5.2.3
+Stable tag: 3.8
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,12 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 3.8 =
+
+#### 👾 Bug Fixes
+
+- Billpayment - check if an order is made by Bill Payment before display a barcode. (PR [#137](https://github.com/omise/omise-woocommerce/pull/137))
 
 = 3.7 =
 


### PR DESCRIPTION
Bumping version number up to v3.8.

### This release contains 1 PR as below:

#### 👾 Bug Fixes

- **PR #137**: Billpayment - check if an order is made by Bill Payment before display a barcode.