### PR TITLE
Introducing TrueMoney payment (only available in Thailand) 

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -1,3 +1,9 @@
+.form-row.omise-label-inline label,
+.omise-label-inline label,
+label.omise-label-inline {
+	display: inline-block;
+}
+
 .omise-remember-card input,
 .omise-remember-card label {
 	display: inline-block;

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -137,7 +137,8 @@
 									new Omise_Payment_Billpayment_Tesco,
 									new Omise_Payment_Creditcard,
 									new Omise_Payment_Installment,
-									new Omise_Payment_Internetbanking
+									new Omise_Payment_Internetbanking,
+									new Omise_Payment_Truemoney
 								);
 								foreach ( $available_gateways as $gateway ) :
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -28,6 +28,8 @@ function register_omise_truemoney() {
 
 			$this->title       = $this->get_option( 'title' );
 			$this->description = $this->get_option( 'description' );
+
+			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		}
 
 		/**

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -71,12 +71,13 @@ function register_omise_truemoney() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
-			$total      = $order->get_total();
-			$currency   = $order->get_order_currency();
-			$return_uri = add_query_arg(
+			$phone_number = isset( $_POST['omise_phone_number_default'] ) && 1 == $_POST['omise_phone_number_default'] ? $order->get_billing_phone() : '000';
+			$total        = $order->get_total();
+			$currency     = $order->get_order_currency();
+			$return_uri   = add_query_arg(
 				array( 'wc-api' => 'omise_truemoney_callback', 'order_id' => $order_id ), home_url()
 			);
-			$metadata   = array_merge(
+			$metadata     = array_merge(
 				apply_filters( 'omise_charge_params_metadata', array(), $order ),
 				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
 			);
@@ -85,7 +86,7 @@ function register_omise_truemoney() {
 				'amount'      => Omise_Money::to_subunit( $total, $currency ),
 				'currency'    => $currency,
 				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
-				'source'      => array( 'type' => 'truemoney', 'phone_number' => '' ),
+				'source'      => array( 'type' => 'truemoney', 'phone_number' => $phone_number ),
 				'return_uri'  => $return_uri,
 				'metadata'    => $metadata
 			) );

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -23,6 +23,8 @@ function register_omise_truemoney() {
 				array( 'strong' => array() )
 			);
 
+			$this->supports           = array( 'products', 'refunds' );
+
 			$this->init_form_fields();
 			$this->init_settings();
 
@@ -209,6 +211,84 @@ function register_omise_truemoney() {
 
 			wp_die( 'Access denied', 'Access Denied', array( 'response' => 401 ) );
 			die();
+		}
+
+		/**
+		 * Process refund.
+		 *
+		 * @param  int    $order_id
+		 * @param  float  $amount
+		 * @param  string $reason
+		 *
+		 * @return boolean True|False based on success, or a WP_Error object.
+		 *
+		 * @see    WC_Payment_Gateway::process_refund( $order_id, $amount = null, $reason = '' )
+		 */
+		public function process_refund( $order_id, $amount = null, $reason = '' ) {
+			if ( ! isset( $order_id ) || ! $order = $this->load_order( $order_id ) ) {
+				return new WP_Error(
+					'error',
+					sprintf(
+						wp_kses(
+							__( 'We cannot process your refund.<br/>Note that nothing wrong by you, this might be from the store issue.<br/><br/>Please feel try to create a refund again or report our support team that you have found this problem', 'omise' ),
+							array(
+								'br' => array()
+							)
+						),
+						$order_id
+					)
+				);
+			}
+
+			$currency = $order->get_order_currency();
+
+			$order->add_order_note(
+				sprintf( __( 'Omise: Refunding a payment with an amount %1$s %2$s', 'omise' ), $amount, $currency )
+			);
+
+			try {
+				$charge = OmiseCharge::retrieve( $order->get_transaction_id() );
+				$refund = $charge->refunds()->create( array(
+					'amount' => Omise_Money::to_subunit( $amount, $currency )
+				) );
+
+				$order->add_order_note(
+					sprintf(
+						wp_kses(
+							__( 'Omise: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
+							array( 'br' => array() )
+						),
+						$amount,
+						$currency,
+						$refund['id']
+					)
+				);
+
+				return true;
+			} catch (Exception $e) {
+				$order->add_order_note(
+					sprintf(
+						wp_kses(
+							__( 'Omise: Refund failed.<br/>%s', 'omise' ),
+							array( 'br' => array() )
+						),
+						$e->getMessage()
+					)
+				);
+
+				return new WP_Error(
+					'error',
+					sprintf(
+						wp_kses(
+							__( 'Omise: Refund failed.<br/>%s', 'omise' ),
+							array( 'br' => array() )
+						),
+						$e->getMessage()
+					)
+				);
+			}
+
+			return false;
 		}
 	}
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -1,0 +1,87 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+function register_omise_truemoney() {
+	require_once dirname( __FILE__ ) . '/class-omise-payment.php';
+
+	if ( ! class_exists( 'WC_Payment_Gateway' ) || class_exists( 'Omise_Payment_Truemoney' ) ) {
+		return;
+	}
+
+	/**
+	 * @since 3.9
+	 */
+	class Omise_Payment_Truemoney extends Omise_Payment {
+		public function __construct() {
+			parent::__construct();
+
+			$this->id                 = 'omise_truemoney';
+			$this->has_fields         = true;
+			$this->method_title       = __( 'Omise TrueMoney Wallet', 'omise' );
+			$this->method_description = wp_kses(
+				__( 'Accept payments through <strong>TrueMoney Wallet</strong> via Omise payment gateway (only available in Thailand).', 'omise' ),
+				array( 'strong' => array() )
+			);
+
+			$this->init_form_fields();
+			$this->init_settings();
+
+			$this->title       = $this->get_option( 'title' );
+			$this->description = $this->get_option( 'description' );
+		}
+
+		/**
+		 * @see WC_Settings_API::init_form_fields()
+		 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled' => array(
+					'title'   => __( 'Enable/Disable', 'omise' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable Omise TrueMoney Wallet Payment', 'omise' ),
+					'default' => 'no'
+				),
+
+				'title' => array(
+					'title'       => __( 'Title', 'omise' ),
+					'type'        => 'text',
+					'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
+					'default'     => __( 'TrueMoney Wallet', 'omise' ),
+				),
+
+				'description' => array(
+					'title'       => __( 'Description', 'omise' ),
+					'type'        => 'textarea',
+					'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
+				),
+			);
+		}
+
+		/**
+		 * @inheritdoc
+		 */
+		public function charge( $order_id, $order ) {
+		}
+
+		/**
+		 * @inheritdoc
+		 */
+		public function result( $order_id, $order, $charge ) {
+		}
+	}
+
+	if ( ! function_exists( 'add_omise_truemoney' ) ) {
+		/**
+		 * @param  array $methods
+		 *
+		 * @return array
+		 */
+		function add_omise_truemoney( $methods ) {
+			$methods[] = 'Omise_Payment_Truemoney';
+			return $methods;
+		}
+
+		add_filter( 'woocommerce_payment_gateways', 'add_omise_truemoney' );
+	}
+}

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -64,12 +64,49 @@ function register_omise_truemoney() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
+			$total      = $order->get_total();
+			$currency   = $order->get_order_currency();
+			$return_uri = add_query_arg(
+				array( 'wc-api' => 'omise_truemoney_callback', 'order_id' => $order_id ), home_url()
+			);
+			$metadata   = array_merge(
+				apply_filters( 'omise_charge_params_metadata', array(), $order ),
+				array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
+			);
+
+			return OmiseCharge::create( array(
+				'amount'      => Omise_Money::to_subunit( $total, $currency ),
+				'currency'    => $currency,
+				'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
+				'source'      => array( 'type' => 'truemoney', 'phone_number' => '' ),
+				'return_uri'  => $return_uri,
+				'metadata'    => $metadata
+			) );
 		}
 
 		/**
 		 * @inheritdoc
 		 */
 		public function result( $order_id, $order, $charge ) {
+			if ( self::STATUS_FAILED == $charge['status'] ) {
+				return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+			}
+
+			if ( self::STATUS_PENDING == $charge['status'] ) {
+				$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );
+
+				return array (
+					'result'   => 'success',
+					'redirect' => $charge['authorize_uri'],
+				);
+			}
+
+			return $this->payment_failed(
+				sprintf(
+					__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
+					$order_id
+				)
+			);
 		}
 	}
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -72,7 +72,7 @@ function register_omise_truemoney() {
 		 * @inheritdoc
 		 */
 		public function charge( $order_id, $order ) {
-			$phone_number = isset( $_POST['omise_phone_number_default'] ) && 1 == $_POST['omise_phone_number_default'] ? $order->get_billing_phone() : '000';
+			$phone_number = isset( $_POST['omise_phone_number_default'] ) && 1 == $_POST['omise_phone_number_default'] ? $order->get_billing_phone() : sanitize_text_field( $_POST['omise_phone_number'] );
 			$total        = $order->get_total();
 			$currency     = $order->get_order_currency();
 			$return_uri   = add_query_arg(

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -63,6 +63,13 @@ function register_omise_truemoney() {
 		/**
 		 * @inheritdoc
 		 */
+		public function payment_fields() {
+			Omise_Util::render_view( 'templates/payment/form-truemoney.php', array() );
+		}
+
+		/**
+		 * @inheritdoc
+		 */
 		public function charge( $order_id, $order ) {
 			$total      = $order->get_total();
 			$currency   = $order->get_order_currency();

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -81,6 +81,7 @@ class Omise {
 		register_omise_creditcard();
 		register_omise_installment();
 		register_omise_internetbanking();
+		register_omise_truemoney();
 		prepare_omise_myaccount_panel();
 	}
 
@@ -130,6 +131,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-creditcard.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-installment.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-internetbanking.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-truemoney.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-php/lib/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-plugin/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-capabilities.php';

--- a/templates/payment/form-truemoney.php
+++ b/templates/payment/form-truemoney.php
@@ -1,8 +1,27 @@
 <fieldset id="omise-form-truemoney">
 	<?php _e( 'TrueMoney phone number', 'omise' ); ?><br/>
-	<input id="omise_phone_number_default" type="checkbox" name="omise_phone_number_default" value="1" checked="checked" />
-	<label for="omise_phone_number_default"><?php _e( 'Same as Billing Detail', 'omise' ); ?></label>
+
+	<p id="omise_phone_number_default_field" class="form-row form-row-wide omise-label-inline">
+		<input id="omise_phone_number_default" type="checkbox" name="omise_phone_number_default" value="1" checked="checked" />
+		<label for="omise_phone_number_default"><?php _e( 'Same as Billing Detail', 'omise' ); ?></label>
+	</p>
+
+	<p id="omise_phone_number_field" class="form-row form-row-wide" style="display: none;">
+		<span class="woocommerce-input-wrapper">
+			<input id="omise_phone_number" class="input-text" name="omise_phone_number" type="tel" autocomplete="off">
+		</span>
+	</p>
+
 	<p class="omise-secondary-text">
 		<?php _e( 'One-Time Password (OTP) will be sent to the phone number above', 'omise' ); ?>
 	</p>
 </fieldset>
+
+<script type="text/javascript">
+	let phone_number_field   = document.getElementById( 'omise_phone_number_field' );
+	let phone_number_default = document.getElementById( 'omise_phone_number_default' );
+
+	phone_number_default.addEventListener( 'change', ( e ) => {
+		phone_number_field.style.display = e.target.checked ? "none" : "block";
+	} );
+</script>

--- a/templates/payment/form-truemoney.php
+++ b/templates/payment/form-truemoney.php
@@ -1,0 +1,8 @@
+<fieldset id="omise-form-truemoney">
+	<?php _e( 'TrueMoney phone number', 'omise' ); ?><br/>
+	<input id="omise_phone_number_default" type="checkbox" name="omise_phone_number_default" value="1" checked="checked" />
+	<label for="omise_phone_number_default"><?php _e( 'Same as Billing Detail', 'omise' ); ?></label>
+	<p class="omise-secondary-text">
+		<?php _e( 'One-Time Password (OTP) will be sent to the phone number above', 'omise' ); ?>
+	</p>
+</fieldset>


### PR DESCRIPTION
#### 1. Objective

Explain in non-technical terms **WHY this PR is required**.
E.g.: What feature it adds, what problem it solves...

This section will be used in the release notes. 

#### 2. Description of change

Adding functionalities that support for Omise, TrueMoney payment.
- Implementing all the necessary foundation code.
- Displaying TrueMoney payment method on both WordPress's Omise setting page and WooCommerce's checkout page.
- Handle TrueMoney payment result.

All the necessary details are listed in each commit. You may refer it from these 8 commits in this pull request.
- TrueMoney: implementing a foundation code to list the payment at the WC payment setting page.
- TrueMoney: listing TrueMoey Wallet payment method at the admin Omise Setting Page.
- TrueMoney: Be able to save the payment settings to WC configuration db.
- TrueMoney: Be able to create a new charge.
- TrueMoney: Displaying form field.
- TrueMoney: Be able to create a charge using Billing Details' phone number.
- TrueMoney: Implementing callback function.
- TrueMoney: Be able to use different phone number from Billing Details to receive OTP, at the checkout form.

#### 3. Quality assurance

**🔧 Environments:**

- **PHP version**: 7.3.3
- **WordPress**: v5.2.3
- **WooCommerce**: v3.7.0

**✏️ Details:**

drafting...

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

This payment is available only in Thailand.
For more information, please check the official document: https://www.omise.co/truemoney