### PR TITLE
Adding ability to sync payment status to Bill Payment and TrueMoney Payment.

### DIFF
--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -32,6 +32,7 @@ function register_omise_billpayment_tesco() {
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_barcode' ) );
 			add_action( 'woocommerce_email_after_order_table', array( $this, 'email_barcode' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 			add_action( 'omise_checkout_assets', array( $this, 'omise_billpayment_checkout_assets' ) );
 		}
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -33,6 +33,7 @@ function register_omise_truemoney() {
 
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
+			add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 		}
 
 		/**


### PR DESCRIPTION
### 1. Objective

In a case of `offsite` payment, there is a chance that a payment transaction will not be resolved immediately after users have completed their payment at the 3rd-party payment page (i.e. Internet Banking). Omise Charge status will stay as `pending` and as so, WooCommerce order status.

With the above case, unless the Webhook feature is properly set. Merchant will need to go to Omise Dashboard to check a final status later on, then manually update his/her order status accordingly.

This pull request is to add a functionality where merchants can pull a latest status of a particular Omise Charge transaction and automatically update WooCommerce Order's status accordingly right at the WooCommerce Order page.

**Related information**:
Related issue(s): T17007 (internal ticket)

### 2. Description of change

This feature has been implemented to the rest payment methods.
However, there are 2 missing payment methods, which are, `Bill Payment`, and `TrueMoney Wallet`.

### 3. Quality assurance

 **🔧 Environments:**

 **WooCommerce**: v3.7.0
- **WordPress**: v5.2.3
- **PHP**: 7.3.3

**✏️ Details:**

As we cannot test the `pending` case with Omise test account. This test requires a little modification on Omise-WooCommerce's code.

**Preparation**
1. At directory `includes/gateway`, you will see bunch of classes that are representing of each payment method. Open `includes/gateway/class-omise-payment-truemoney.php` file with your text editor.

2. Find the method `callback()` and search for the following line
```php
$charge = OmiseCharge::retrieve( $order->get_transaction_id() );
```

Then add this code after. 
```php
$charge['paid']   = false;
$charge['status'] = 'pending';
```

**Output**
```php
/**
 * @return void
 */
public function callback() {

    ...

    try {
        $charge = OmiseCharge::retrieve( $order->get_transaction_id() );
        $charge['paid']   = false; // add the code right here
        $charge['status'] = 'pending'; // add the code right here

        ...
}
```

3. Save the file, then back to WooCommerce store. Place an order with Omise TrueMoney Wallet payment method. WooCommerce Order will be created with TrueMoney Wallet payment, with `on-hold` status.

![Screen Shot 2562-10-25 at 14 18 47](https://user-images.githubusercontent.com/2154669/67551169-7a12f900-f732-11e9-9357-a921684b1dae.png)

> Note, there will be 2 double notes and that is a normal-expected behaviour.

**Test for TrueMoney Wallet payment**

1. At the right-top of WooCommerce **Order page**, Order actions section. Choose: **Omise: Manual sync payment status**.
  ![2Screen_Shot_2562-10-07_at_15 32 25_copy](https://user-images.githubusercontent.com/2154669/67556789-01199e80-f73e-11e9-9f32-1cb545c6250f.png)

2. Click **"Update"** button.
![Screen_Shot_2562-10-07_at_16 18 22_copy](https://user-images.githubusercontent.com/2154669/67557815-feb84400-f73f-11e9-9399-0c23a98b1c8e.png)

3. In case of **"successful"** payment (`charge.status = successful`)
- An order status will be changed to `processing`.
- A note will be added with the following message
```
Omise: Payment successful.
An amount {amount} {currency} has been paid (manual sync).
```
![Screen Shot 2562-10-25 at 15 56 57 copy](https://user-images.githubusercontent.com/2154669/67559353-fa415a80-f742-11e9-8665-385e80adb1e8.png)

4. In case of **"failed"** payment (`charge.status = failed`)
- An order status will be changed to `failed`.
- A note will be added with the following message
```
Omise: Payment failed.
{failure_message} (code: {failure_code}) (manual sync).
```
<img width="1552" alt="Screen Shot 2562-10-25 at 16 52 52 copy" src="https://user-images.githubusercontent.com/2154669/67562081-417e1a00-f748-11e9-8af4-3cab90536027.png">

5. In case of **"pending"** payment (`charge.status = pending`)
There may be a chance where a particular charge has not yet been processed even after a while.
- An order status stays as `on-hold`
- A note will be added with the following message
```
Omise: Payment is still in progress.
You might wait for a moment before click sync the status again or contact Omise support team at support@omise.co if you have any questions (manual sync).
```
<img width="1552" alt="Screen Shot 2562-10-25 at 16 57 38 copy" src="https://user-images.githubusercontent.com/2154669/67563712-72ac1980-f74b-11e9-9ef0-4f773de550d8.png">

**Test for Bill Payment**

Bill Payment case is similar to TrueMoney Wallet payment, except that you don't need to alter the plugin code at `callback` method (because Bill Payment payment method is an offline method, there is no redirection after finished the purchase).

1. Place an order with Bill Payment method, then go to Omise Dashboard to mark a charge to be either **"successful"** or **"failed"**
<img width="1552" alt="Screen Shot 2562-10-25 at 17 33 51 copy" src="https://user-images.githubusercontent.com/2154669/67565485-c0c31c00-f74f-11e9-852e-f2d8ef8b2ae2.png">

2. In a case of either **"successful"** or **"failed"**, the result will be identically the same as TrueMoney Wallet payment (and the same as the rest of other payment methods).

`Pending > Successful`
<img width="1552" alt="Screen Shot 2562-10-25 at 17 25 27 copy" src="https://user-images.githubusercontent.com/2154669/67565612-041d8a80-f750-11e9-8187-0e40c03485ef.png">

`Failed`
<img width="1552" alt="Screen Shot 2562-10-25 at 17 51 36 copy" src="https://user-images.githubusercontent.com/2154669/67565669-2e6f4800-f750-11e9-94d1-6c48ef8d3b52.png">

### 4. Impact of the change

None

### 5. Priority of change

Normal

### 6. Additional Notes

Please note that at the moment, a pending status of Bill Payment is shown as `pending payment` which will be corrected in the coming Pull Request. (it should be set to `on-hold` instead)
