### PR TITLE
Bill Payment, correcting order status after a new order is placed (on-hold instead of pending-payment)

### DIFF
--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -104,6 +104,8 @@ function register_omise_billpayment_tesco() {
 			}
 
 			if ( 'pending' == $charge['status'] ) {
+				$order->update_status( 'on-hold', __( 'Omise: Awaiting Bill Payment to be paid.', 'omise' ) );
+
 				return array(
 					'result'   => 'success',
 					'redirect' => $this->get_return_url( $order )


### PR DESCRIPTION
#### 1. Objective

As described at WooCommerce official document (https://docs.woocommerce.com/document/managing-orders). 
- **"Pending payment"** – Order received, no payment initiated. Awaiting payment (unpaid).
- **"On-Hold"** – Awaiting payment – stock is reduced, but you need to confirm payment."

These 2 statuses are being used to describe the "Awaiting Payment" state of WooCommerce order flow.
However, the difference between these 2 are that there is no **"payment initiated"** for "Pending Payment" order status. Also there is no reducing product stock on a particular item that has been chosen at "Pending Payment" state (and no confirmation email is being sent).

This is to correct the order status after an order is placed using Omise Bill Payment payment method, from `pending-payment` to `on-hold`.

**Related information**:
Related issue(s): T17477 (internal ticket)

#### 2. Description of change

- Updating an order status to `on-hold` right after a new order is placed.

![Screen Shot 2562-10-31 at 04 51 28](https://user-images.githubusercontent.com/2154669/67901754-2709cd80-fb9a-11e9-9db5-916f72a244b5.png)

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v3.7.1
- **WordPress**: v5.3.2
- **PHP version**: 7.3.3

**✏️ Details:**

Placing an order using Omise Bill Payment payment method as normal until you are being redirected to the **order received** page. As buyer's perspective, everything will be just the same.
![Screen Shot 2562-10-31 at 06 17 07](https://user-images.githubusercontent.com/2154669/67906150-4c9cd400-fba6-11e9-8b04-030885994677.png)

As a merchant, after buyers placed their order. Now that particular order will be set to `on-hold` status. Also, a particular item will be reserved (stock gets reduced) and wait until the payment is completed.
![Screen Shot 2562-10-31 at 06 17 34 copy](https://user-images.githubusercontent.com/2154669/67906492-4e1acc00-fba7-11e9-984e-0e5e33897189.png)

Bonus point.
As we set an order status to `on-hold`. An order confirmation email will be sent out with a message
> Thanks for your order. It’s on-hold until we confirm that payment has been received. In the meantime, here’s a reminder of what you ordered:

Previously with `pending-payment` status, it does not send an email out after buyer placed an order.
![Screen Shot 2562-10-31 at 06 16 51](https://user-images.githubusercontent.com/2154669/67906554-891cff80-fba7-11e9-9c3e-8df819c34967.png)


#### 4. Impact of the change

Order status will now be set to `on-hold` instead of `pending-payment`.
This may affect to merchant's order flow as a business point of view. As they might have in mind that after placed an order with Bill Payment, an order status will be set to `pending-payment`.

Now It is set to `on-hold` instead.

#### 5. Priority of change

Normal

#### 6. Additional Notes

nothing.