### PR TITLE
README, adding 'Install via WordPress Plugin Manager' at the Installation Instruction section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,35 @@ If the version you are currently using has not been listed, you can try installi
 
 ### Installation Instructions
 
-In order to install Omise-WooCommerce plugin, you can either manually download the plugin from this repository and install it or download it via WordPress Plugin Store.  
+In order to install Omise-WooCommerce plugin, you can either download it via WordPress Plugin Store or manually download the plugin from this repository.
+
+#### WordPress Plugin Manager (recommended)
+
+You can simply install Omise WooCommerce plugin via WordPress Plugin Manager by the following 4 steps
+1. From the left sidebar at your WordPress Admin page, under **"Plugin"** section. Click **"Add New"**.
+
+2. At the **"Add Plugins"** page, search for Omise WooCommerce plugin using keyword: `Omise`.
+
+3. Click **"Install Now"** to download and install Omise WooCommerce plugin into your WordPress website.
+
+![Screen_Shot_2562-10-01_at_08 28 27_copy](https://user-images.githubusercontent.com/2154669/68250269-274f1080-0053-11ea-8db1-bab9cc32ea46.png)
+
+4. After the plugin has been downloaded and installed. The **"Install Now"** button will now be changed to `Activate`. Make sure to click **"Activate"**
+
+![Screen_Shot_2562-10-01_at_08 38 42_copy](https://user-images.githubusercontent.com/2154669/68250334-477ecf80-0053-11ea-9817-6a9da5b53335.png)
 
 #### Manually
 
 1. Download and extract the zip file from [Omise-WooCommerce](https://github.com/omise/omise-woocommerce/archive/v3.9.zip) to your local machine.
-  ![screen shot 2560-07-26 at 12 36 43 pm](https://user-images.githubusercontent.com/2154669/38302382-ac3b1cf8-382c-11e8-80d4-61e935b7a567.png)
+  ![Screen_Shot_2562-10-01_at_08 10 13](https://user-images.githubusercontent.com/2154669/68250447-8876e400-0053-11ea-9c8f-209474b2ec7c.png)
 
 2. Copy all files from the step 1 to WordPress plugin folder, `your-wordpress-dir/wp-content/plugins/omise-woocommerce-3.9`.
 
 3. Rename `omise-woocommerce-3.9` folder to `omise`
-  ![screen shot 2560-07-26 at 12 36 43 pm](https://user-images.githubusercontent.com/2154669/28606035-2b9387dc-71ff-11e7-887d-dc90ce774a39.png)
+  ![Screen_Shot_2562-10-01_at_08 17 12](https://user-images.githubusercontent.com/2154669/68250537-b1977480-0053-11ea-8778-3e9697506630.png)
 
 4. Once done, `Omise Payment Gateway` plugin will be shown at the **Installed Plugins** page. Click `activate` to activate the plugin.
-  ![omise-woocommerce-plugin-activate](https://user-images.githubusercontent.com/2154669/38302722-dd2404c8-382d-11e8-9f21-09cbe9829dbe.png)
+  ![Screen_Shot_2562-10-01_at_08 21 34_copy](https://user-images.githubusercontent.com/2154669/68250581-c7a53500-0053-11ea-8db8-c710c6cd9a3d.png)
 
 Now you've done installing Omise-WooCommerce plugin.  
 Next, check **[First Time Setup](#first-time-setup)** to continue setting up your Omise account with your WooCommerce store.


### PR DESCRIPTION
#### 1. Objective

Omise-WooCommerce can be installed with in a super simple way as any other WordPress plugin. However, It hasn't been mentioned in our README.md file yet.