### PR TITLE
Introducing Konbini payment method

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -57,6 +57,7 @@ fieldset.card-exists {
  * Omise Bill Payment Tesco
  * CSS for the 'Thank You' (order-received) page.
  */
+.omise-konbini-details,
 .omise-billpayment-tesco-details {
 	margin-bottom: 4em;
 	text-align: center;
@@ -67,6 +68,7 @@ fieldset.card-exists {
 .omise-billpayment-tesco-print-button {
 	margin-top: 2em;
 }
+.omise-konbini-footnote,
 .omise-billpayment-tesco-footnote {
 	margin-top: 4em;
 	padding: 1em;

--- a/includes/class-omise-localization.php
+++ b/includes/class-omise-localization.php
@@ -20,6 +20,12 @@ class Omise_Localization {
 			'amount must be less than 50000'
 				=> __( 'amount must be less than 50000', 'omise' ),
 
+			'amount must be greater than or equal to 200'
+				=> __( 'amount must be greater than or equal to 200', 'omise' ),
+
+			'amount must be greater than or equal to 200 and phone_number must contain 10-11 digit characters'
+				=> __( 'amount must be greater than or equal to 200 and phone_number must contain 10-11 digit characters', 'omise' ),
+
 			'card is stolen or lost'
 				=> __( 'card is stolen or lost', 'omise' ),
 

--- a/includes/class-omise-payment-factory.php
+++ b/includes/class-omise-payment-factory.php
@@ -18,6 +18,7 @@ class Omise_Payment_Factory {
 		'Omise_Payment_Creditcard',
 		'Omise_Payment_Installment',
 		'Omise_Payment_Internetbanking',
+		'Omise_Payment_Konbini',
 		'Omise_Payment_Paynow',
 		'Omise_Payment_Promptpay',
 		'Omise_Payment_Truemoney'

--- a/includes/gateway/class-omise-payment-konbini.php
+++ b/includes/gateway/class-omise-payment-konbini.php
@@ -1,0 +1,148 @@
+<?php
+
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+/**
+ * @since 4.1
+ */
+class Omise_Payment_Konbini extends Omise_Payment_Offline {
+	public function __construct() {
+		parent::__construct();
+
+		$this->id                 = 'omise_konbini';
+		$this->has_fields         = true;
+		$this->method_title       = __( 'Convenience Store / Pay-easy / Online Banking', 'omise' );
+		$this->method_description = wp_kses(
+			__( 'Accept payments through <strong>Convenience Store</strong> / <strong>Pay-easy</strong> / <strong>Online Banking</strong> via Omise payment gateway.', 'omise' ),
+			array( 'strong' => array() )
+		);
+
+		$this->init_form_fields();
+		$this->init_settings();
+
+		$this->title                = $this->get_option( 'title' );
+		$this->description          = $this->get_option( 'description' );
+		$this->restricted_countries = array( 'JP' );
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
+		add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_link' ) );
+		add_action( 'woocommerce_email_after_order_table', array( $this, 'email_link' ) );
+	}
+
+	/**
+	 * @see WC_Settings_API::init_form_fields()
+		* @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
+		*/
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled' => array(
+				'title'   => __( 'Enable/Disable', 'omise' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Enable Omise Convenience Store / Pay-easy / Online Banking Payment', 'omise' ),
+				'default' => 'no'
+			),
+
+			'title' => array(
+				'title'       => __( 'Title', 'omise' ),
+				'type'        => 'text',
+				'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
+				'default'     => __( 'Convenience Store / Pay-easy / Online Banking', 'omise' ),
+			),
+
+			'description' => array(
+				'title'       => __( 'Description', 'omise' ),
+				'type'        => 'textarea',
+				'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
+			),
+		);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function payment_fields() {
+		Omise_Util::render_view( 'templates/payment/form-konbini.php', array() );
+	}
+
+	/**
+	 * @inheritdoc
+		*/
+	public function charge( $order_id, $order ) {
+		$konbini_name  = isset( $_POST['omise_konbini_name'] ) ? sanitize_text_field( $_POST['omise_konbini_name'] ) : '';
+		$konbini_email = isset( $_POST['omise_konbini_email'] ) ? sanitize_text_field( $_POST['omise_konbini_email'] ) : '';
+		$konbini_phone = isset( $_POST['omise_konbini_phone'] ) ? sanitize_text_field( $_POST['omise_konbini_phone'] ) : '';
+
+		$total         = $order->get_total();
+		$currency      = $order->get_order_currency();
+		$metadata      = array_merge(
+			apply_filters( 'omise_charge_params_metadata', array(), $order ),
+			array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
+		);
+
+		return OmiseCharge::create( array(
+			'amount'      => Omise_Money::to_subunit( $total, $currency ),
+			'currency'    => $currency,
+			'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
+			'source'      => array( 'type' => 'econtext', 'name' => $konbini_name, 'email' => $konbini_email, 'phone_number' => $konbini_phone ),
+			'metadata'    => $metadata
+		) );
+	}
+
+	/**
+	 * @param int|WC_Order $order
+	 * @param string       $context  pass 'email' value through this argument only for 'sending out an email' case.
+	 */
+	public function display_link( $order, $context = 'view' ) {
+		if ( ! $this->load_order( $order ) ) {
+			return;
+		}
+
+		$charge_id          = $this->get_charge_id_from_order();
+		$charge             = OmiseCharge::retrieve( $charge_id );
+		$payment_link       = $charge['authorize_uri'];
+		$expires_datetime   = new WC_DateTime( $charge['source']['references']['expires_at'], new DateTimeZone( 'UTC' ) );
+		$expires_datetime->set_utc_offset( wc_timezone_offset() );
+		?>
+
+		<div class="omise omise-konbini-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
+			<p>
+				<?php echo __( 'Your payment code has been sent to your email ', 'omise' ); ?>
+				<br/>
+				<?php
+				echo sprintf(
+					wp_kses(
+						__( 'Please find the payment instruction there or click on the link below and complete the payment by:<br/><strong>%1$s %2$s</strong>.', 'omise' ),
+						array( 'br' => array(), 'strong' => array() )
+					),
+					wc_format_datetime( $expires_datetime, wc_date_format() ),
+					wc_format_datetime( $expires_datetime, wc_time_format() )
+				);
+				?>
+				<br/>
+				<?php
+				echo sprintf(
+					wp_kses(
+						__( '<a href="%s" target="_blank">Payment Link</a>', 'omise' ),
+						array( 'a' => array( 'href' => array(), 'target' => array() ) )
+					),
+					$payment_link
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * @param WC_Order $order
+	 *
+	 * @see   woocommerce/templates/emails/email-order-details.php
+	 * @see   woocommerce/templates/emails/plain/email-order-details.php
+	 */
+	public function email_link( $order ) {
+		if ( $this->id == $order->get_payment_method() ) {
+			$this->display_link( $order, 'email' );
+		}
+	}
+}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -133,6 +133,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-creditcard.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-installment.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-internetbanking.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-konbini.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-paynow.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-promptpay.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-truemoney.php';

--- a/templates/payment/form-konbini.php
+++ b/templates/payment/form-konbini.php
@@ -1,0 +1,16 @@
+<fieldset id="omise-form-konbini">
+    <p class="form-row form-row-wide omise-required-field">
+	    <label for="omise_konbini_name"><?php _e( 'Name', 'omise' ); ?></label>
+	    <input id="omise_konbini_name" class="input-text" name="omise_konbini_name" type="text" maxlength="10" autocomplete="off">
+    </p>
+
+    <p class="form-row form-row-wide omise-required-field">
+	    <label for="omise_konbini_email"><?php _e( 'Email', 'omise' ); ?></label>
+	    <input id="omise_konbini_email" class="input-text" name="omise_konbini_email" type="text" maxlength="50" autocomplete="off">
+    </p>
+
+    <p class="form-row form-row-wide omise-required-field">
+	    <label for="omise_konbini_phone"><?php _e( 'Phone', 'omise' ); ?></label>
+	    <input id="omise_konbini_phone" class="input-text" name="omise_konbini_phone" type="text" maxlength="11" autocomplete="off">
+    </p>
+</fieldset>


### PR DESCRIPTION
## 1. Objective

Omise has been providing a payment service (credit card) for Japan for a couple years. And now, we have also delivered a brand-new payment method, "Konbini" recently that would enable more opportunities for merchants and buyers that are living in Japan to have more choice of payments and to make the payment experience even better.

Now it's time to bring this new payment feature to Omise-WooCommerce plugin

**Related information**:
Related issue(s): T17761 (internal ticket)

## 2. Description of change

- Displaying **"Konbini"** payment method on both Admin and checkout page.
- Merchant will be able to enable **"Konbini"** payment start accepting payment through Konbini.
- Buyers will be able to select **"Konbini"** as a payment method when checking out an order. 

## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3.3
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3

**✏️ Details:**

<img width="1552" alt="Screen Shot 2563-08-19 at 00 23 58" src="https://user-images.githubusercontent.com/2154669/90545103-5386e880-e1b2-11ea-93db-f445cd051d24.png">

<img width="1552" alt="Screen Shot 2563-08-19 at 00 25 26" src="https://user-images.githubusercontent.com/2154669/90545220-8204c380-e1b2-11ea-9c9a-c92ea27989a2.png">

<img width="1552" alt="Screen Shot 2563-08-19 at 00 41 22" src="https://user-images.githubusercontent.com/2154669/90546776-be392380-e1b4-11ea-9e35-ae6498a2a462.png">

## 4. Impact of the change

none

## 5. Priority of change

Normal

## 6. Additional Notes

As this payment method is aiming for Japanese market, this plugin should be translated in Japanese language before release.