### PR TITLE
Payment Setting: properly display payment methods based on a given Omise Account (for admin)

### DIFF
--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -69,6 +69,17 @@ class Omise_Page_Settings {
 
 		$settings = $page->get_settings();
 
+		/**
+		 * Added later at Omise-WooCommerce v3.11.
+		 * To migrate all the users that haven been using Omise-WooCommerce
+		 * below the version v3.11.
+		 */
+		if ( ! $settings['account_country'] && ( $settings['test_private_key'] || $settings['live_private_key'] ) ) {
+			$settings['omise_setting_page_nonce'] = wp_create_nonce( 'omise-setting' );
+			$page->save( $settings );
+			$settings = $page->get_settings();
+		}
+
 		include_once __DIR__ . '/views/omise-page-settings.php';
 	}
 }

--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -38,7 +38,20 @@ class Omise_Page_Settings {
 			wp_die( __( 'You are not allowed to modify the settings from a suspicious source.', 'omise' ) );
 		}
 
-		$this->settings->update_settings( $data );
+		$public_key = $data['sandbox'] ? $data['test_public_key'] : $data['live_public_key'];
+		$secret_key = $data['sandbox'] ? $data['test_private_key'] : $data['live_private_key'];
+
+		try {
+			$account = OmiseAccount::retrieve( $public_key, $secret_key );
+
+			$data['account_id']      = $account['id'];
+			$data['account_email']   = $account['email'];
+			$data['account_country'] = $account['country'];
+
+			$this->settings->update_settings( $data );
+		} catch (Exception $e) {
+			// Do nothing.
+		}
 	}
 
 	/**

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -98,85 +98,89 @@
 		<hr />
 
 		<h3><?php _e( 'Payment Methods', 'omise' ); ?></h3>
-		<p><?php _e( 'The table below is a list of available payment methods that you can enable in your WooCommerce store.', 'omise' ); ?></p>
-		<table class="form-table">
-			<tbody>
-				<tr>
-					<th scope="row"><label for="sandbox"><?php _e( 'Available Payment Methods', 'omise' ); ?></label></th>
-					<td>
-						<table class="widefat fixed striped" cellspacing="0">
-							<thead>
-								<tr>
-									<?php
-										$columns = array(
-											'name'    => __( 'Payment Method', 'omise' ),
-											'status'  => __( 'Enabled', 'omise' ),
-											'setting' => ''
-										);
+		<?php if ($settings['account_country']) : ?>
+			<p><?php _e( 'The table below is a list of available payment methods that you can enable in your WooCommerce store.', 'omise' ); ?></p>
+			<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row"><label for="sandbox"><?php _e( 'Available Payment Methods', 'omise' ); ?></label></th>
+						<td>
+							<table class="widefat fixed striped" cellspacing="0">
+								<thead>
+									<tr>
+										<?php
+											$columns = array(
+												'name'    => __( 'Payment Method', 'omise' ),
+												'status'  => __( 'Enabled', 'omise' ),
+												'setting' => ''
+											);
 
-										foreach ( $columns as $key => $column ) {
+											foreach ( $columns as $key => $column ) {
+												switch ( $key ) {
+													case 'status' :
+													case 'setting' :
+														echo '<th style="text-align: center; padding: 10px;" class="' . esc_attr( $key ) . '">' . esc_html( $column ) . '</th>';
+														break;
+
+													default:
+														echo '<th style="padding: 10px;" class="' . esc_attr( $key ) . '">' . esc_html( $column ) . '</th>';
+														break;
+												}
+
+											}
+										?>
+									</tr>
+								</thead>
+								<tbody>
+									<?php
+									$available_gateways = array(
+										new Omise_Payment_Alipay,
+										new Omise_Payment_Billpayment_Tesco,
+										new Omise_Payment_Creditcard,
+										new Omise_Payment_Installment,
+										new Omise_Payment_Internetbanking,
+										new Omise_Payment_Truemoney
+									);
+									foreach ( $available_gateways as $gateway ) :
+
+										echo '<tr>';
+
+										foreach ( $columns as $key => $column ) :
 											switch ( $key ) {
-												case 'status' :
-												case 'setting' :
-													echo '<th style="text-align: center; padding: 10px;" class="' . esc_attr( $key ) . '">' . esc_html( $column ) . '</th>';
+												case 'name' :
+													$method_title = $gateway->get_title() ? $gateway->get_title() : __( '(no title)', 'omise' );
+													echo '<td class="name">
+														<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . esc_html( $method_title ) . '</a>
+													</td>';
 													break;
 
-												default:
-													echo '<th style="padding: 10px;" class="' . esc_attr( $key ) . '">' . esc_html( $column ) . '</th>';
+												case 'status' :
+													echo '<td class="status" style="text-align: center;">';
+													echo ( 'yes' === $gateway->enabled ) ? '<span>' . __( 'Yes', 'omise' ) . '</span>' : '-';
+													echo '</td>';
+													break;
+
+												case 'setting' :
+													echo '<td class="setting" style="text-align: center;">
+														<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . __( 'config', 'omise' ) . '</a>
+													</td>';
 													break;
 											}
+										endforeach;
 
-										}
-									?>
-								</tr>
-							</thead>
-							<tbody>
-								<?php
-								$available_gateways = array(
-									new Omise_Payment_Alipay,
-									new Omise_Payment_Billpayment_Tesco,
-									new Omise_Payment_Creditcard,
-									new Omise_Payment_Installment,
-									new Omise_Payment_Internetbanking,
-									new Omise_Payment_Truemoney
-								);
-								foreach ( $available_gateways as $gateway ) :
+										echo '</tr>';
 
-									echo '<tr>';
-
-									foreach ( $columns as $key => $column ) :
-										switch ( $key ) {
-											case 'name' :
-												$method_title = $gateway->get_title() ? $gateway->get_title() : __( '(no title)', 'omise' );
-												echo '<td class="name">
-													<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . esc_html( $method_title ) . '</a>
-												</td>';
-												break;
-
-											case 'status' :
-												echo '<td class="status" style="text-align: center;">';
-												echo ( 'yes' === $gateway->enabled ) ? '<span>' . __( 'Yes', 'omise' ) . '</span>' : '-';
-												echo '</td>';
-												break;
-
-											case 'setting' :
-												echo '<td class="setting" style="text-align: center;">
-													<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . __( 'config', 'omise' ) . '</a>
-												</td>';
-												break;
-										}
 									endforeach;
-
-									echo '</tr>';
-
-								endforeach;
-								?>
-							</tbody>
-						</table>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+									?>
+								</tbody>
+							</table>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		<?php else: ?>
+			<p><?php _e( 'Please set up your Omise account to see all the available payment methods.', 'omise' ); ?></p>
+		<?php endif; ?>
 
 		<input type="hidden" name="omise_setting_page_nonce" value="<?= wp_create_nonce( 'omise-setting' ); ?>" />
 		<?php submit_button( __( 'Save Settings', 'omise' ) ); ?>

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -142,34 +142,36 @@
 										new Omise_Payment_Truemoney
 									);
 									foreach ( $available_gateways as $gateway ) :
+										if ( $gateway->is_country_support( $settings['account_country'] ) ) :
 
-										echo '<tr>';
+											echo '<tr>';
 
-										foreach ( $columns as $key => $column ) :
-											switch ( $key ) {
-												case 'name' :
-													$method_title = $gateway->get_title() ? $gateway->get_title() : __( '(no title)', 'omise' );
-													echo '<td class="name">
-														<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . esc_html( $method_title ) . '</a>
-													</td>';
-													break;
+											foreach ( $columns as $key => $column ) :
+												switch ( $key ) {
+													case 'name' :
+														$method_title = $gateway->get_title() ? $gateway->get_title() : __( '(no title)', 'omise' );
+														echo '<td class="name">
+															<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . esc_html( $method_title ) . '</a>
+														</td>';
+														break;
 
-												case 'status' :
-													echo '<td class="status" style="text-align: center;">';
-													echo ( 'yes' === $gateway->enabled ) ? '<span>' . __( 'Yes', 'omise' ) . '</span>' : '-';
-													echo '</td>';
-													break;
+													case 'status' :
+														echo '<td class="status" style="text-align: center;">';
+														echo ( 'yes' === $gateway->enabled ) ? '<span>' . __( 'Yes', 'omise' ) . '</span>' : '-';
+														echo '</td>';
+														break;
 
-												case 'setting' :
-													echo '<td class="setting" style="text-align: center;">
-														<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . __( 'config', 'omise' ) . '</a>
-													</td>';
-													break;
-											}
-										endforeach;
+													case 'setting' :
+														echo '<td class="setting" style="text-align: center;">
+															<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) ) . '">' . __( 'config', 'omise' ) . '</a>
+														</td>';
+														break;
+												}
+											endforeach;
 
-										echo '</tr>';
+											echo '</tr>';
 
+										endif;
 									endforeach;
 									?>
 								</tbody>

--- a/includes/class-omise-setting.php
+++ b/includes/class-omise-setting.php
@@ -52,6 +52,9 @@ class Omise_Setting {
 	 */
 	protected function get_default_settings() {
 		return array(
+			'account_id'       => '',
+			'account_email'    => '',
+			'account_country'  => '',
 			'sandbox'          => 'yes',
 			'test_public_key'  => '',
 			'test_private_key' => '',

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -16,8 +16,9 @@ function register_omise_alipay() {
 			$this->init_form_fields();
 			$this->init_settings();
 
-			$this->title       = $this->get_option( 'title' );
-			$this->description = $this->get_option( 'description' );
+			$this->title                = $this->get_option( 'title' );
+			$this->description          = $this->get_option( 'description' );
+			$this->restricted_countries = array( 'TH' );
 
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -26,8 +26,9 @@ function register_omise_billpayment_tesco() {
 			$this->init_form_fields();
 			$this->init_settings();
 
-			$this->title       = $this->get_option( 'title' );
-			$this->description = $this->get_option( 'description' );
+			$this->title                = $this->get_option( 'title' );
+			$this->description          = $this->get_option( 'description' );
+			$this->restricted_countries = array( 'TH' );
 
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_barcode' ) );

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -33,9 +33,10 @@ function register_omise_creditcard() {
 			$this->init_form_fields();
 			$this->init_settings();
 
-			$this->title          = $this->get_option( 'title' );
-			$this->description    = $this->get_option( 'description' );
-			$this->payment_action = $this->get_option( 'payment_action' );
+			$this->title                = $this->get_option( 'title' );
+			$this->description          = $this->get_option( 'description' );
+			$this->payment_action       = $this->get_option( 'payment_action' );
+			$this->restricted_countries = array( 'TH', 'JP', 'SG' );
 
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -22,8 +22,9 @@ function register_omise_installment() {
 			$this->init_form_fields();
 			$this->init_settings();
 
-			$this->title       = $this->get_option( 'title' );
-			$this->description = $this->get_option( 'description' );
+			$this->title                = $this->get_option( 'title' );
+			$this->description          = $this->get_option( 'description' );
+			$this->restricted_countries = array( 'TH' );
 
 			$this->backend     = new Omise_Backend_Installment;
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -21,8 +21,9 @@ function register_omise_internetbanking() {
 			$this->init_form_fields();
 			$this->init_settings();
 
-			$this->title       = $this->get_option( 'title' );
-			$this->description = $this->get_option( 'description' );
+			$this->title                = $this->get_option( 'title' );
+			$this->description          = $this->get_option( 'description' );
+			$this->restricted_countries = array( 'TH' );
 
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -24,8 +24,9 @@ function register_omise_truemoney() {
 			$this->init_form_fields();
 			$this->init_settings();
 
-			$this->title       = $this->get_option( 'title' );
-			$this->description = $this->get_option( 'description' );
+			$this->title                = $this->get_option( 'title' );
+			$this->description          = $this->get_option( 'description' );
+			$this->restricted_countries = array( 'TH' );
 
 			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 			add_action( 'woocommerce_api_' . $this->id . '_callback', array( $this, 'callback' ) );

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -49,6 +49,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	public $payment_settings = array();
 
 	/**
+	 * A list of countries the payment method can be operated with.
+	 *
+	 * @var array
+	 */
+	public $restricted_countries = array();
+
+	/**
 	 * @var array
 	 */
 	private $currency_subunits = array(
@@ -143,6 +150,21 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 */
 	protected function is_currency_support( $currency ) {
 		if ( isset( $this->currency_subunits[ strtoupper( $currency ) ] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param  string $country_code
+	 *
+	 * @return bool
+	 */
+	public function is_country_support( $country_code ) {
+		array_map( 'strtoupper', $this->restricted_countries );
+
+		if ( in_array( strtoupper( $country_code ), $this->restricted_countries ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
### 1. Objective

Previously all the payment methods that have been implemented to the plugin will be shown at WooCommerce Payment Setting page, regardless on a given Omise account.

For instance, using Omise Japan account at Omise-WooCommerce plugin, you will see all the payment methods, including those that can be used only for Omise Thailand.

This, is believed to cause a bad user-experience and a confusion for all the merchants outside Thailand.

**Related information**:
Related issue(s): T18705

### 2. Description of change

1. Before saving given credential keys to WooCommerce's DB, the plugin will be making a request to Omise API to retrieve Omise Account detail, then pack and save it to WooCommerce's DB along with those credentials.

At WordPress's `wp_options` table, option_name: `woocommerce_omise_settings`, there will be 3 new parameters: `account_id`, `account_email`, and `account_country`.

**Before**
```
a:5:{s:7:"sandbox";s:3:"yes";s:15:"test_public_key";s:29:"pkey_test_***";s:16:"test_private_key";s:29:"skey_test_***";s:15:"live_public_key";s:0:"";s:16:"live_private_key";s:0:"";}
```

**After**
```
a:8:{s:10:"account_id";s:24:"acct_***";s:13:"account_email";s:22:"***@***";s:15:"account_country";s:2:"JP";s:7:"sandbox";s:3:"yes";s:15:"test_public_key";s:29:"pkey_test_***";s:16:"test_private_key";s:29:"skey_test_***";s:15:"live_public_key";s:0:"";s:16:"live_private_key";s:0:"";}
```

.
2. At the Admin Payment Setting page, add a condition to display only payment methods that are available for that specific Omise account's country.

**Before**
_The below screenshot: all the payment methods are listed at the payment setting page regardless on a given Omise account._
![Screen Shot 2563-01-20 at 06 35 45](https://user-images.githubusercontent.com/2154669/72690450-1e98b180-3b4f-11ea-9e85-853b6bbe6538.png)

**After**
_The below screenshot: hide all the payment methods if Omise account's credential hasn't been set._
![Screen Shot 2563-01-20 at 06 34 32](https://user-images.githubusercontent.com/2154669/72690432-fa3cd500-3b4e-11ea-8dde-1a8c06804926.png)

_The below screenshot: Once the Omise account has been set, the payment methods will be shown accordingly to the given account (in this case, Thailand account)._
![Screen Shot 2563-01-20 at 06 39 55](https://user-images.githubusercontent.com/2154669/72690522-c0b89980-3b4f-11ea-94d0-76910f615772.png)

_The below screenshot: Once the Omise account has been set, the payment methods will be shown accordingly to the given account (in this case, Japan account)._
![Screen Shot 2563-01-20 at 06 40 45](https://user-images.githubusercontent.com/2154669/72690530-d037e280-3b4f-11ea-9449-a046c12c985c.png)

3. Also make sure that it won't affect to the current merchants.

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v3.8.1
- **WordPress**: v5.3.2
- **PHP version**: 7.3.3

**✏️ Details:**

There are 2 possible cases.
1. Current users upgrading from the previous plugin version to this one.
The following code should detect and auto-update its database to meet with the condition of displaying payment methods by a given Omise account.
https://github.com/omise/omise-woocommerce/pull/151/files#diff-9849043e36d1d7b568f325534b722341R77

As for user perspective, they wouldn't need to do any extra step.

2. New users that download the plugin for the first time.
This group should be no problem as described at the section **2. Description of change**, [2].

#### 4. Impact of the change

As described at the section **2. Description of change**, [1]. There will be 3 new parameters saved at WordPress's `wp_options` table, option_name: `woocommerce_omise_settings`.

#### 5. Priority of change

Normal

#### 6. Additional Notes

No