### PR TITLE
✨ Releasing Omise-WooCommerce v3.11

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ i.e.
 - **WooCommerce**: v3.7.1
 - **WordPress**: v5.3.2
 - **PHP version**: 7.0.16
-- **Omise plugin version**: Omise-WooCommerce 3.10 (optional, in case of submitting a new issue)
+- **Omise plugin version**: Omise-WooCommerce 3.11 (optional, in case of submitting a new issue)
 
 **✏️ Details:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+### [v3.11 _(Mar 18, 2020)_](https://github.com/omise/omise-woocommerce/releases/tag/v3.11)
+
+#### ✨ Highlights
+
+- Introducing PayNow payment method (only available in Singapore) (PR [#152](https://github.com/omise/omise-woocommerce/pull/152))
+
+#### 🚀 Enhancements
+
+- (proposal) Code cleaning for payment method classes. (PR [#153](https://github.com/omise/omise-woocommerce/pull/153))
+- Payment Setting: properly display payment methods based on a given Omise Account (for admin) (PR [#151](https://github.com/omise/omise-woocommerce/pull/151))
+
+---
+
 ### [v3.10 _(Jan 16, 2020)_](https://github.com/omise/omise-woocommerce/releases/tag/v3.10)
 
 #### ✨ Highlights

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
                     potHeaders: {
                         poedit: false,                  // Includes common Poedit headers.
                         'x-poedit-keywordslist': true,  // Include a list of all possible gettext functions.
-                        'Project-Id-Version': 'Omise Payment Gateway v3.10',
+                        'Project-Id-Version': 'Omise Payment Gateway v3.11',
                         'Report-Msgid-Bugs-To': 'https://github.com/omise/omise-woocommerce/issues'
                     },                                  // Headers to add to the generated POT file.
                     processPot: null,                   // A callback function for manipulating the POT file.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Supported Versions
 
-WooCommerce version 3.3.4 and above (tested to version 3.7.1).
+WooCommerce version 3.3.4 and above (tested to version 3.9.2).
 
 **The extension doesn't work on your version?**  
 Our aim is to support as many versions of WooCommerce as we can.  
@@ -42,12 +42,12 @@ Install Omise WooCommerce plugin via WordPress Plugin Directory by following the
 
 #### Manually
 
-1. Download and extract the zip file from [Omise-WooCommerce](https://github.com/omise/omise-woocommerce/archive/v3.10.zip) to your local machine.
+1. Download and extract the zip file from [Omise-WooCommerce](https://github.com/omise/omise-woocommerce/archive/v3.11.zip) to your local machine.
   ![Manually download and extract the zip file](https://user-images.githubusercontent.com/2154669/68250447-8876e400-0053-11ea-9c8f-209474b2ec7c.png)
 
-2. Copy all files from the step 1 to WordPress plugin folder, `your-wordpress-dir/wp-content/plugins/omise-woocommerce-3.10`.
+2. Copy all files from the step 1 to WordPress plugin folder, `your-wordpress-dir/wp-content/plugins/omise-woocommerce-3.11`.
 
-3. Rename `omise-woocommerce-3.10` folder to `omise`
+3. Rename `omise-woocommerce-3.11` folder to `omise`
   ![Renaming its foldername to omise](https://user-images.githubusercontent.com/2154669/68250537-b1977480-0053-11ea-8778-3e9697506630.png)
 
 4. Once done, `Omise Payment Gateway` plugin will be shown at the **Installed Plugins** page. Click **"Activate"** to activate the plugin.

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     3.10
+ * Version:     3.11
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -18,7 +18,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '3.10';
+	public $version = '3.11';
 
 	/**
 	 * @since 3.11

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Omise WooCommerce ===
 Contributors: Omise
-Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay
+Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
-Tested up to: 5.2.4
-Stable tag: 3.10
+Tested up to: 5.3.2
+Stable tag: 3.11
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,17 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 3.11 =
+
+#### ✨ Highlights
+
+- Introducing PayNow payment method (only available in Singapore) (PR [#152](https://github.com/omise/omise-woocommerce/pull/152))
+
+#### 🚀 Enhancements
+
+- (proposal) Code cleaning for payment method classes. (PR [#153](https://github.com/omise/omise-woocommerce/pull/153))
+- Payment Setting: properly display payment methods based on a given Omise Account (for admin) (PR [#151](https://github.com/omise/omise-woocommerce/pull/151))
 
 = 3.10 =
 


### PR DESCRIPTION
Bumping version number up to v3.11.

### This release contains 3 PR as below:

#### ✨ Highlights

- **PR #152**: Introducing PayNow payment method (only available in Singapore).

#### 🚀 Enhancements

- **PR #153**: (proposal) Code cleaning for payment method classes.
- **PR #151**: Payment Setting: properly display payment methods based on a given Omise Account (for admin).
