### PR TITLE
Localizing Omise API's error messages

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -152,7 +152,7 @@ class Omise_Callback {
 	 */
 	protected function payment_failed() {
 		$message         = __( 'It seems we\'ve been unable to process your payment properly:<br/>%s', 'omise' );
-		$failure_message = $this->charge['failure_message'] . ' (code: ' . $this->charge['failure_code'] . ')';
+		$failure_message = Omise()->translate( $this->charge['failure_message'] ) . ' (code: ' . $this->charge['failure_code'] . ')';
 
 		$this->order->add_order_note( sprintf( wp_kses( __( 'OMISE: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message ) );
 		$this->order->update_status( 'failed' );

--- a/includes/class-omise-localization.php
+++ b/includes/class-omise-localization.php
@@ -20,11 +20,23 @@ class Omise_Localization {
 			'amount must be less than 50000'
 				=> __( 'amount must be less than 50000', 'omise' ),
 
+			'card is stolen or lost'
+				=> __( 'card is stolen or lost', 'omise' ),
+
 			'currency is currently not supported'
 				=> __( 'currency is currently not supported', 'omise' ),
 
 			'email is in invalid format'
 				=> __( 'email is in invalid format', 'omise' ),
+
+			'failed fraud check'
+				=> __( 'failed fraud check', 'omise' ),
+
+			'failed processing'
+				=> __( 'failed processing', 'omise' ),
+
+			'insufficient funds in the account or the card has reached the credit limit'
+				=> __( 'insufficient funds in the account or the card has reached the credit limit', 'omise' ),
 
 			'Metadata should be a JSON hash'
 				=> __( 'Metadata should be a JSON hash', 'omise' ),
@@ -35,11 +47,20 @@ class Omise_Localization {
 			'name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters'
 				=> __( 'name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters', 'omise' ),
 
+			'payment rejected'
+				=> __( 'payment rejected', 'omise' ),
+
 			'phone_number must contain 10-11 digit characters'
 				=> __( 'phone_number must contain 10-11 digit characters', 'omise' ),
 
 			'return uri is invalid'
 				=> __( 'return uri is invalid', 'omise' ),
+
+			'the account number is invalid'
+				=> __( 'the account number is invalid', 'omise' ),
+
+			'the security code is invalid'
+				=> __( 'the security code is invalid', 'omise' ),
 
 			'type is currently not supported'
 				=> __( 'type is currently not supported', 'omise' ),

--- a/includes/class-omise-localization.php
+++ b/includes/class-omise-localization.php
@@ -1,12 +1,12 @@
 <?php
-/**
- * Handles all the API response messages localization.
- *
- * @since 4.0
- */
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Handles all the API response messages localization.
+ *
+ * @since 4.1
+ */
 class Omise_Localization {
 	/**
 	 * @param  string $message

--- a/includes/class-omise-localization.php
+++ b/includes/class-omise-localization.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Handles all the API response messages localization.
+ *
+ * @since 4.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class Omise_Localization {
+	/**
+	 * @param  string $message
+	 * @return string
+	 */
+	public static function translate( $message ) {
+		$known_messages = array(
+			'amount must be at least 200'
+				=> __( 'amount must be at least 200', 'omise' ),
+
+			'amount must be less than 50000'
+				=> __( 'amount must be less than 50000', 'omise' ),
+
+			'currency is currently not supported'
+				=> __( 'currency is currently not supported', 'omise' ),
+
+			'email is in invalid format'
+				=> __( 'email is in invalid format', 'omise' ),
+
+			'Metadata should be a JSON hash'
+				=> __( 'Metadata should be a JSON hash', 'omise' ),
+
+			'name cannot be blank'
+				=> __( 'name cannot be blank', 'omise' ),
+
+			'name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters'
+				=> __( 'name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters', 'omise' ),
+
+			'phone_number must contain 10-11 digit characters'
+				=> __( 'phone_number must contain 10-11 digit characters', 'omise' ),
+
+			'return uri is invalid'
+				=> __( 'return uri is invalid', 'omise' ),
+
+			'type is currently not supported'
+				=> __( 'type is currently not supported', 'omise' ),
+		);
+
+		return isset( $known_messages[ $message ] ) ? $known_messages[ $message ] : $message;
+	}
+}

--- a/includes/classes/class-omise-charge.php
+++ b/includes/classes/class-omise-charge.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'Omise_Charge' ) ) {
 		 */
 		public static function get_error_message( $charge ) {
 			if ( '' !== $charge['failure_code'] ) {
-				return '(' . $charge['failure_code'] . ') ' . $charge['failure_message'];
+				return '(' . $charge['failure_code'] . ') ' . Omise()->translate( $charge['failure_message'] );
 			}
 
 			return '';

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -52,7 +52,7 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 				}
 
 				$message         = __( 'Omise: Payment failed.<br/>%s', 'omise' );
-				$failure_message = $this->data['failure_message'] . ' (code: ' . $this->data['failure_code'] . ')';
+				$failure_message = Omise()->translate( $this->data['failure_message'] ) . ' (code: ' . $this->data['failure_code'] . ')';
 				$this->order->add_order_note(
 					sprintf(
 						wp_kses( $message, array( 'br' => array() ) ),

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -84,7 +84,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 				}
 
 				$message         = __( 'Omise: Payment failed.<br/>%s', 'omise' );
-				$failure_message = $this->data['failure_message'] . ' (code: ' . $this->data['failure_code'] . ')';
+				$failure_message = Omise()->translate( $this->data['failure_message'] ) . ' (code: ' . $this->data['failure_code'] . ')';
 				$this->order->add_order_note(
 					sprintf(
 						wp_kses( $message, array( 'br' => array() ) ),

--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -41,7 +41,7 @@ abstract class Omise_Payment_Offline extends Omise_Payment {
 	 */
 	public function result( $order_id, $order, $charge ) {
 		if ( self::STATUS_FAILED === $charge['status'] ) {
-			return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+			return $this->payment_failed( Omise()->translate( $charge['failure_message'] ) . ' (code: ' . $charge['failure_code'] . ')' );
 		}
 
 		if ( self::STATUS_PENDING === $charge['status'] ) {

--- a/includes/gateway/abstract-omise-payment-offsite.php
+++ b/includes/gateway/abstract-omise-payment-offsite.php
@@ -12,7 +12,7 @@ abstract class Omise_Payment_Offsite extends Omise_Payment {
 	 */
 	public function result( $order_id, $order, $charge ) {
 		if ( self::STATUS_FAILED === $charge['status'] ) {
-			return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+			return $this->payment_failed( Omise()->translate( $charge['failure_message'] ) . ' (code: ' . $charge['failure_code'] . ')' );
 		}
 
 		if ( self::STATUS_PENDING === $charge['status'] ) {

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -363,7 +363,7 @@ class Omise_Payment_Creditcard extends Omise_Payment {
 			$charge->capture();
 
 			if ( ! OmisePluginHelperCharge::isPaid( $charge ) ) {
-				throw new Exception( $charge['failure_message'] );
+				throw new Exception( Omise()->translate( $charge['failure_message'] ) );
 			}
 
 			$this->order()->add_order_note(

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -344,7 +344,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 						__( 'Omise: Payment failed.<br/>%s (code: %s) (manual sync).', 'omise' ),
 						array( 'br' => array() )
 					);
-					$this->order()->add_order_note( sprintf( $message, $charge['failure_message'], $charge['failure_code'] ) );
+					$this->order()->add_order_note( sprintf( $message, Omise()->translate( $charge['failure_message'] ), $charge['failure_code'] ) );
 
 					if ( ! $this->order()->has_status( 'failed' ) ) {
 						$this->order()->update_status( 'failed' );

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -260,7 +260,7 @@ class Omise {
 	/**
 	 * L10n the given string.
 	 *
-	 * @since  4.0
+	 * @since  4.1
 	 *
 	 * @return string
 	 */

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -140,6 +140,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-callback.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-capabilities.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-events.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-localization.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-money.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-payment-factory.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
@@ -254,6 +255,17 @@ class Omise {
 	 */
 	public function payment_methods() {
 		return Omise_Payment_Factory::$payment_methods;
+	}
+
+	/**
+	 * L10n the given string.
+	 *
+	 * @since  4.0
+	 *
+	 * @return string
+	 */
+	public function translate( $message ) {
+		return Omise_Localization::translate( $message );
 	}
 }
 

--- a/tests/unit/class-omise-unit-test.php
+++ b/tests/unit/class-omise-unit-test.php
@@ -11,7 +11,18 @@ class Omise_Unit_Test {
  * Mock WordPress __() function.
  *
  * @see wp-includes/l10n.php
+ * @see https://developer.wordpress.org/reference/functions/__
  */
 function __( $text, $domain = 'default' ) {
+	return $text;
+}
+
+/**
+ * Mock WordPress _x() function.
+ *
+ * @see wp-includes/l10n.php
+ * @see https://developer.wordpress.org/reference/functions/_x
+ */
+function _x( $text, $context, $domain = 'default' ) {
 	return $text;
 }

--- a/tests/unit/includes/class-omise-localization-test.php
+++ b/tests/unit/includes/class-omise-localization-test.php
@@ -1,0 +1,40 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../class-omise-unit-test.php';
+
+class Omise_Localization_Test extends TestCase {
+	public static function setUpBeforeClass(): void {
+        global $l10n;
+        $l10n[] = 'omise';
+
+        require_once __DIR__ . '/../../../includes/class-omise-localization.php';
+	}
+
+	/**
+	 * @test
+     * Note that because the actualy translation is happening 
+	 */
+	public function translate_message() {
+		$message = 'currency is currently not supported';
+
+		$this->assertEquals( $message, Omise_Localization::translate( $message ) );
+    }
+    
+    /**
+	 * @test
+	 */
+	public function translate_multi_sentences_message() {
+		$message = 'name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters';
+
+		$this->assertEquals( $message, Omise_Localization::translate( $message ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function translate_unknown_message() {
+		$message = 'unrecognized message';
+
+		$this->assertEquals( $message, Omise_Localization::translate( $message ) );
+	}
+}

--- a/tests/unit/includes/class-omise-localization-test.php
+++ b/tests/unit/includes/class-omise-localization-test.php
@@ -4,28 +4,26 @@ require_once __DIR__ . '/../class-omise-unit-test.php';
 
 class Omise_Localization_Test extends TestCase {
 	public static function setUpBeforeClass(): void {
-        global $l10n;
-        $l10n[] = 'omise';
+		global $l10n;
+		$l10n[] = 'omise';
 
-        require_once __DIR__ . '/../../../includes/class-omise-localization.php';
+		require_once __DIR__ . '/../../../includes/class-omise-localization.php';
 	}
 
 	/**
 	 * @test
-     * Note that because the actualy translation is happening 
+	 * Note that because the actualy translation is happening.
 	 */
 	public function translate_message() {
 		$message = 'currency is currently not supported';
-
 		$this->assertEquals( $message, Omise_Localization::translate( $message ) );
-    }
-    
-    /**
+	}
+
+	/**
 	 * @test
 	 */
 	public function translate_multi_sentences_message() {
 		$message = 'name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters';
-
 		$this->assertEquals( $message, Omise_Localization::translate( $message ) );
 	}
 
@@ -34,7 +32,6 @@ class Omise_Localization_Test extends TestCase {
 	 */
 	public function translate_unknown_message() {
 		$message = 'unrecognized message';
-
 		$this->assertEquals( $message, Omise_Localization::translate( $message ) );
 	}
 }


### PR DESCRIPTION
## 1. Objective

Omise WooCommerce supports for Japanese and Thai stores, however, some amount of messages haven't been localised properly and still stay as English (especially those from API response messages).

This pull request is to properly addressing all those messages that can't be translated due to the implementation of the code.

**Related information**:
Related issue(s): T2778 (internal ticket)

## 2. Description of change

- Introducing Omise_Localization class to handle Omise API localization (https://github.com/omise/omise-woocommerce/pull/156/commits/1d426abb2d9ec27923160e0c8dfdc2942e4358e1)
- Translating Omise API error messages using Omise_Localization. (https://github.com/omise/omise-woocommerce/pull/156/commits/a832f88e8c4fbed22954e7e7e51f0fe7701261e2)

## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3.3.
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3

**✏️ Details:**

First of all, we can check if the translation covers all the possible part of the code by searching `'failure_message'`.
<img width="1552" alt="Screen Shot 2563-08-18 at 23 33 22" src="https://user-images.githubusercontent.com/2154669/90540305-3f8bb880-e1ab-11ea-8d35-b7b67706ed8b.png">

Try make a payment with an error card to see if Omise_Localization is working properly.
<img width="1552" alt="Screen Shot 2563-08-18 at 23 48 38" src="https://user-images.githubusercontent.com/2154669/90542911-0bb29200-e1af-11ea-9adb-94f51210f62c.png">

## 4. Impact of the change

nothing

## 5. Priority of change

Normal

## 6. Additional Notes

The messages that this PR is implementing with, is not the entire of all the messages that the plugin may receive from Omise API. However, this is to provide a structure and some sample messages first. The improvement could be in the future if there is a specific error message that this PR hasn't covered.