### PR TITLE
Be able to create a refund when placing an order with Alipay or Installment payment method.

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 			$this->has_fields         = false;
 			$this->method_title       = __( 'Omise Alipay', 'omise' );
 			$this->method_description = __( 'Accept payment through Alipay', 'omise' );
+			$this->supports           = array( 'products', 'refunds' );
 
 			$this->init_form_fields();
 			$this->init_settings();

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 				__( 'Accept <strong>installment payments</strong> via Omise payment gateway.', 'omise' ),
 				array( 'strong' => array() )
 			);
+			$this->supports           = array( 'products', 'refunds' );
 
 			$this->init_form_fields();
 			$this->init_settings();


### PR DESCRIPTION
#### 1. Objective

According to Omise documents, those Alipay (online) and Installment payment methods are supporting refund via Omise API. However the plugin is still behind and doesn't provide this feature.

This pull request is to add a refund-feature support to those 2 payment methods.

References:
- https://www.omise.co/alipay#voids-and-refunds
- https://www.omise.co/installment-payments#voids-and-refunds

**Related information**:
Related issue(s): T18953, T19969 (internal ticket)

#### 2. Description of change

Adding refund feature to Alipay (online) and Installment payment methods.

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v3.9.3
- **WordPress**: v5.3.2
- **PHP version**: 7.3.3

**✏️ Details:**

**1. To test refunding a charge using Alipay payment method, you will need to place an order and go through the normal WooCommerce checkout step.**

1.1. At WooCommerce Order page, click **"refund"** button
<img width="1792" alt="alipay-refund-01" src="https://user-images.githubusercontent.com/2154669/78778205-1c632800-79c5-11ea-9403-cc60cc682889.png">

1.2. Enter a refund amount and click **"Refund [amount] via Omise Alipay"**.
<img width="1792" alt="alipay-refund-02" src="https://user-images.githubusercontent.com/2154669/78779330-f8084b00-79c6-11ea-845c-16f2437b3bd7.png">

1.3. Successfully refund will be shown on the **"Order Notes"** section, as well as displaying its refund transaction under the **"items"** section at WooCommerce Order page.
<img width="1792" alt="alipay-refund-03" src="https://user-images.githubusercontent.com/2154669/78778640-cb9fff00-79c5-11ea-96cd-46bcfcea694f.png">

<img width="1792" alt="Screen Shot 2563-04-08 at 19 14 03" src="https://user-images.githubusercontent.com/2154669/78783056-386ac780-79cd-11ea-8685-3cee29a77070.png">

1.4. You may as well, test for a failure case by modifying the code (as WooCommerce provides frontend-validation, the easiest way is to modify Omise code to create a refund with a false amount).
At file: `includes/gateway/class-omise-payment.php` Line: `252`, replace `$amount` with any invalid number, then create another refund via WooCommerce Order page.
<img width="852" alt="Screen Shot 2563-04-08 at 18 24 54" src="https://user-images.githubusercontent.com/2154669/78778922-436e2980-79c6-11ea-8ae7-25d86fc74fda.png">

There will be a alert-dialog showing **"Refund failed: ..."*** with a message (from Omise API)
<img width="1792" alt="alipay-refund-04" src="https://user-images.githubusercontent.com/2154669/78779069-84fed480-79c6-11ea-81ae-73a808351e1e.png">

**2. To test refunding a charge using Installment payment method, you will need to place an order and go through the normal WooCommerce checkout step the same Alipay.**
2.1. At WooCommerce Order page, click **"refund"** button
<img width="1792" alt="installment-refund-01" src="https://user-images.githubusercontent.com/2154669/78782537-626fba00-79cc-11ea-933c-d65fce8eac60.png">

2.2. Enter a refund amount and click **"Refund [amount] via Omise Installment"**.
<img width="1792" alt="installment-refund-02" src="https://user-images.githubusercontent.com/2154669/78782566-6b608b80-79cc-11ea-8cfa-ef3675d8eab6.png">

2.3. Successfully refund will be shown on the **"Order Notes"** section, as well as displaying its refund transaction under the **"items"** section at WooCommerce Order page.
Also for a full-refund, the order status will be updated to `Refunded`.
<img width="1792" alt="installment-refund-03" src="https://user-images.githubusercontent.com/2154669/78782570-6d2a4f00-79cc-11ea-8f2d-558a5d5d2faa.png">

<img width="1792" alt="Screen Shot 2563-04-08 at 19 14 11" src="https://user-images.githubusercontent.com/2154669/78783015-2852e800-79cd-11ea-840b-3133b0dd0d70.png">

2.4. However, Installment payment method does not support for partial-refund.
If you try to create a refund with a partial amount, it will result showing alert-dialog saying: **"Refund failed: charge partial refunds is not permitted for this type of charge."**
<img width="1792" alt="installment-refund-04" src="https://user-images.githubusercontent.com/2154669/78782953-0fe2cd80-79cd-11ea-8de7-57488e1fca45.png">





#### 4. Impact of the change

none

#### 5. Priority of change

Normal

#### 6. Additional Notes

none