### PR TITLE
Integrating WooCommerce refund's reason parameter to Omise Refund object.

### DIFF
--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -249,7 +249,8 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		try {
 			$charge = OmiseCharge::retrieve( $order->get_transaction_id() );
 			$refund = $charge->refunds()->create( array(
-				'amount' => Omise_Money::to_subunit( $amount, $order->get_order_currency() )
+				'amount'   => Omise_Money::to_subunit( $amount, $order->get_order_currency() ),
+				'metadata' => array( 'reason' => sanitize_text_field( $reason ) )
 			) );
 
 			if ( $refund['voided'] ) {


### PR DESCRIPTION
#### 1. Objective

WooCommerce has provided a "reason" field for merchant to add a comment on the refund transaction. However, it hasn't been integrated to Omise Refund object.

Since Omise Refund API accepts for metadata parameter, it would be best to integrate it now.

**Related information**:
Internal ticket (T20652)

#### 2. Description of change

There is nothing change in the term of UI. However, merchant now, can check for their refund's reason at Omise Dashboard as well.

#### 3. Quality assurance
**🔧 Environments:**
- **WooCommerce**: v4.0.1 (latest, at the time)
- **WordPress**: v5.4 (latest, at the time)
- **PHP version**: 7.3.3

**✏️ Details:**

Making sure that merchant can create a refund with a reason-adding.
1. At the WooCommerce Order Detail page (admin), click at the refund button.
<img width="1792" alt="refund-reason-01" src="https://user-images.githubusercontent.com/2154669/79742120-8b793e80-832c-11ea-93d3-32b091e6cdbd.png">

2. There will be 2 fields show up, **Refund Amount**, and **Reason for refund (optional)**.
Entering any message to the **Reason for refund (optional)** field.
<img width="1792" alt="refund-reason-02" src="https://user-images.githubusercontent.com/2154669/79742148-992ec400-832c-11ea-9a4e-8820fa2c178d.png">

3. If successful, a refund transaction will be displayed on WooCommerce Order page, as well as in Omise Dashboard, refund page.
<img width="1792" alt="refund-reason-03" src="https://user-images.githubusercontent.com/2154669/79742157-9c29b480-832c-11ea-989d-d38263527d4d.png">
<img width="1792" alt="refund-reason-04" src="https://user-images.githubusercontent.com/2154669/79742163-9df37800-832c-11ea-8e20-aa44dc7a55f1.png">

4. We would also make sure that, without adding any message to the **Reason for refund (optional)** field, there should not be any problem.
<img width="1792" alt="refund-reason-05" src="https://user-images.githubusercontent.com/2154669/79742166-9f24a500-832c-11ea-85be-35cdba203486.png">
At Omise `metadata.reason`, it will show as empty string.
<img width="1792" alt="refund-reason-06" src="https://user-images.githubusercontent.com/2154669/79742171-a0ee6880-832c-11ea-9c06-9251ac1c74c2.png">

5. Also making sure that the HTML (and script) tags will be sanitized before submitting to the Omise Refund API.
<img width="1792" alt="refund-reason-07" src="https://user-images.githubusercontent.com/2154669/79742645-5caf9800-832d-11ea-9f8e-e439f188dd96.png">

<img width="1792" alt="refund-reason-08" src="https://user-images.githubusercontent.com/2154669/79742661-620ce280-832d-11ea-8860-fecbe096e20e.png">

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

I think it would be nice if the coming metadata name is broadly used in another of Omise plugins as well, so please feel free to discuss about the naming there. (This PR is introducing `$refund['metadata']['reason']`).
