### PR TITLE
Reduce duplicated code from offline payment methods to a dedicated class

### DIFF
--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -1,0 +1,63 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+require_once dirname( __FILE__ ) . '/class-omise-payment.php';
+
+/**
+ * @since 4.0
+ */
+abstract class Omise_Payment_Offline extends Omise_Payment {
+	/**
+	 * A string of Omise Source's type
+	 * (expecting for either 'paynow' or 'bill_payment_tesco_lotus').
+	 *
+	 * @var string
+	 */
+	protected $source_type;
+
+	/**
+	 * @inheritdoc
+	 */
+	public function charge( $order_id, $order ) {
+		$total    = $order->get_total();
+		$currency = $order->get_order_currency();
+		$metadata = array_merge(
+			apply_filters( 'omise_charge_params_metadata', array(), $order ),
+			array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
+		);
+
+		return OmiseCharge::create( array(
+			'amount'      => Omise_Money::to_subunit( $total, $currency ),
+			'currency'    => $currency,
+			'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
+			'source'      => array( 'type' => $this->source_type ),
+			'metadata'    => $metadata
+		) );
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function result( $order_id, $order, $charge ) {
+		if ( self::STATUS_FAILED === $charge['status'] ) {
+			return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
+		}
+
+		if ( self::STATUS_PENDING === $charge['status'] ) {
+			$order->update_status( 'on-hold', sprintf( __( 'Omise: Awaiting %s to be paid.', 'omise' ), $this->title ) );
+
+			return array(
+				'result'   => 'success',
+				'redirect' => $this->get_return_url( $order )
+			);
+		}
+		
+		return $this->payment_failed(
+			sprintf(
+				__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
+				$order_id
+			)
+		);
+	}
+}

--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -10,7 +10,7 @@ require_once dirname( __FILE__ ) . '/class-omise-payment.php';
 abstract class Omise_Payment_Offline extends Omise_Payment {
 	/**
 	 * A string of Omise Source's type
-	 * (expecting for either 'paynow' or 'bill_payment_tesco_lotus').
+	 * (e.g. paynow or bill_payment_tesco_lotus).
 	 *
 	 * @var string
 	 */

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -4,7 +4,7 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 /**
  * @since 3.11
  */
-class Omise_Payment_Paynow extends Omise_Payment {
+class Omise_Payment_Paynow extends Omise_Payment_Offline {
 	public function __construct() {
 		parent::__construct();
 
@@ -22,6 +22,7 @@ class Omise_Payment_Paynow extends Omise_Payment {
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );
 		$this->restricted_countries = array( 'SG' );
+		$this->source_type          = 'paynow';
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_qrcode' ) );
@@ -53,55 +54,6 @@ class Omise_Payment_Paynow extends Omise_Payment {
 				'description' => __( 'This controls the description the user sees during checkout.', 'omise' ),
 				'default'     => __( 'You will not be charged yet. The PayNow QR code will be displayed at the next page.', 'omise' )
 			),
-		);
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public function charge( $order_id, $order ) {
-		$total      = $order->get_total();
-		$currency   = $order->get_order_currency();
-		$return_uri = add_query_arg(
-			array( 'wc-api' => 'omise_paynow_callback', 'order_id' => $order_id ), home_url()
-		);
-		$metadata   = array_merge(
-			apply_filters( 'omise_charge_params_metadata', array(), $order ),
-			array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.
-		);
-
-		return OmiseCharge::create( array(
-			'amount'      => Omise_Money::to_subunit( $total, $currency ),
-			'currency'    => $currency,
-			'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
-			'source'      => array( 'type' => 'paynow' ),
-			'return_uri'  => $return_uri,
-			'metadata'    => $metadata
-		) );
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public function result( $order_id, $order, $charge ) {
-		if ( 'failed' === $charge['status'] ) {
-			return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
-		}
-
-		if ( 'pending' === $charge['status'] ) {
-			$order->update_status( 'on-hold', __( 'Omise: Awaiting PayNow to be paid.', 'omise' ) );
-
-			return array(
-				'result'   => 'success',
-				'redirect' => $this->get_return_url( $order )
-			);
-		}
-
-		return $this->payment_failed(
-			sprintf(
-				__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
-				$order_id
-			)
 		);
 	}
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -121,6 +121,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-capture.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-complete.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-create.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/abstract-omise-payment-offline.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/abstract-omise-payment-offsite.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-alipay.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-billpayment-tesco.php';


### PR DESCRIPTION
## 1. Objective

This pull request is aiming to reduce duplicated code that was discovered during the implementation of API Localization #156 

To reduce a place where we have to apply the L10n for those API response messages.

**Related information**:
Related issue(s): T21114 (internal ticket)

## 2. Description of change

•  Implementing a dedicated class **`Omise_Payment_Offline`** for those offline payment methods to reduce duplicated code.

## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.0.1
- **WordPress**: v5.4.1
- **PHP version**: 7.3.3.

**✏️ Details:**

As we're refactoring the `charge` and `result` methods, we should be making sure that those 2 offline payment methods can be created properly.

1. Making sure that users can place an order using Bill Payment Tesco payment method.
  1.1. Charge can be created properly.
  <img width="1792" alt="bill-successful" src="https://user-images.githubusercontent.com/2154669/81647529-5b1e4f00-9457-11ea-9c1d-ded9ed1fbdff.png">
  1.2. All the params are assigned properly (price, description, metadata)
  <img width="1792" alt="bill-successful-dashboard" src="https://user-images.githubusercontent.com/2154669/81647491-48a41580-9457-11ea-86d8-f822d769bcd3.png">

2. Making sure that users can place an order using **PayNow** payment method.
  2.1. Charge can be created properly.
  <img width="1792" alt="paynow-successful" src="https://user-images.githubusercontent.com/2154669/81648132-62922800-9458-11ea-83ed-4e31db471b7f.png">
  2.2. All the params are assigned properly (price, description, metadata)
  <img width="1792" alt="paynow-successful-dashboard" src="https://user-images.githubusercontent.com/2154669/81648106-573efc80-9458-11ea-9ef1-af51561f0bac.png">

## 4. Impact of the change

No

## 5. Priority of change

Normal

## 6. Additional Notes

This `Omise_Payment_Offline` class may get modified again once we switch back to work on #149  Konbini payment (as Konbini requires more parameters to be passed when creating a new charge)
