### PR TITLE
PayNow: adding default payment instruction at the checkout page

### DIFF
--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -50,7 +50,8 @@ class Omise_Payment_Paynow extends Omise_Payment {
 			'description' => array(
 				'title'       => __( 'Description', 'omise' ),
 				'type'        => 'textarea',
-				'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
+				'description' => __( 'This controls the description the user sees during checkout.', 'omise' ),
+				'default'     => __( 'You will not be charged yet. The PayNow QR code will be displayed at the next page.', 'omise' )
 			),
 		);
 	}


### PR DESCRIPTION
## 1. Objective

There are some confusions about how to use PayNow or when will buyers be charged.
This pull request is to add a default payment instruction (editable) to guide buyers that they will have to scan a QR code to pay at the next page after checkout.

## 2. Description of change

Adding one sentence for the PayNow payment instruction.

## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v3.9.3.
- **WordPress**: v5.4.1.
- **PHP version**: 7.3.3.

**✏️ Details:**

With a fresh installed Omise WooCommerce, you should be able to see a sentence filled by default at Omise PayNow payment setting page (editable).
<img width="1552" alt="Screen Shot 2563-05-28 at 17 41 08" src="https://user-images.githubusercontent.com/2154669/83131709-78674480-a10a-11ea-8b64-f2e7231a8986.png">

As well, it will be shown at the checkout page.
<img width="1552" alt="Screen Shot 2563-05-28 at 17 43 11" src="https://user-images.githubusercontent.com/2154669/83131999-ef9cd880-a10a-11ea-8029-ac402b357426.png">


## 4. Impact of the change

This change does not apply for those merchants who already enabled PayNow payment method. As at a time merchant enabled the payment method, the database will save its configuration as `description: ""` (empty string)

#### 5. Priority of change

Normal

#### 6. Additional Notes

None
