### PR TITLE
Introducing PromptPay payment method (Thailand)

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -118,6 +118,11 @@ fieldset.card-exists {
 	font-size: 80%;
 }
 
+.omise-additional-payment-details-box {
+	margin-bottom: 4em;
+	text-align: center;
+}
+
 /**
  * 2.3). Form, bank list components
  */

--- a/includes/class-omise-ajax-actions.php
+++ b/includes/class-omise-ajax-actions.php
@@ -1,0 +1,23 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 4.1
+ */
+class Omise_Ajax_Actions {
+    /**
+     * An extra action using to fetch an order status
+     * from a given order_id.
+     *
+     * @action wp_ajax_nopriv_fetch_order_status
+     * @action wp_ajax_fetch_order_status
+     *
+     * @see    omise-woocommerce.php
+     * @see    Omise::register_ajax_actions()
+     */
+    public static function fetch_order_status() {
+        $order = wc_get_order( $_POST['order_id'] );
+        wp_send_json_success( array( 'order_status' => $order->get_status() ) );
+    }
+}

--- a/includes/class-omise-payment-factory.php
+++ b/includes/class-omise-payment-factory.php
@@ -19,6 +19,7 @@ class Omise_Payment_Factory {
 		'Omise_Payment_Installment',
 		'Omise_Payment_Internetbanking',
 		'Omise_Payment_Paynow',
+		'Omise_Payment_Promptpay',
 		'Omise_Payment_Truemoney'
 	);
 

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -81,6 +81,10 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 		}
 
 		$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
+		if ( self::STATUS_PENDING !== $charge['status'] ) {
+			return;
+		}
+
 		$qrcode = $charge['source']['scannable_code']['image']['download_uri'];
 
 		$expires_datetime = new WC_DateTime( $charge['expires_at'], new DateTimeZone( 'UTC' ) );

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -1,0 +1,207 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 4.1
+ */
+class Omise_Payment_Promptpay extends Omise_Payment_Offline {
+	public function __construct() {
+		parent::__construct();
+
+		$this->id                 = 'omise_promptpay';
+		$this->has_fields         = false;
+		$this->method_title       = __( 'Omise PromptPay', 'omise' );
+		$this->method_description = wp_kses(
+			__( 'Accept payments through <strong>PromptPay</strong> via Omise payment gateway.', 'omise' ),
+			array( 'strong' => array() )
+		);
+
+		$this->init_form_fields();
+		$this->init_settings();
+
+		$this->title                = $this->get_option( 'title' );
+		$this->description          = $this->get_option( 'description' );
+		$this->restricted_countries = array( 'TH' );
+		$this->source_type          = 'promptpay';
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
+		add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_qrcode' ) );
+		add_action( 'woocommerce_email_after_order_table', array( $this, 'email_qrcode' ) );
+	}
+
+	/**
+	 * @see WC_Settings_API::init_form_fields()
+	 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled' => array(
+				'title'   => __( 'Enable/Disable', 'omise' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Enable Omise PromptPay Payment', 'omise' ),
+				'default' => 'no'
+			),
+
+			'title' => array(
+				'title'       => __( 'Title', 'omise' ),
+				'type'        => 'text',
+				'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
+				'default'     => __( 'PromptPay', 'omise' ),
+			),
+
+			'description' => array(
+				'title'       => __( 'Description', 'omise' ),
+				'type'        => 'textarea',
+				'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
+			),
+		);
+	}
+
+	/**
+	 * @param WC_Order $order
+	 *
+	 * @see   woocommerce/templates/emails/email-order-details.php
+	 * @see   woocommerce/templates/emails/plain/email-order-details.php
+	 */
+	public function email_qrcode( $order ) {
+		if ( $this->id == $order->get_payment_method() ) {
+			$this->display_qrcode( $order, 'email' );
+		}
+	}
+
+	/**
+	 * @param int|WC_Order $order
+	 * @param string       $context  pass 'email' value through this argument only for 'sending out an email' case.
+	 */
+	public function display_qrcode( $order, $context = 'view' ) {
+		if ( ! $this->load_order( $order ) ) {
+			return;
+		}
+
+		$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
+		$qrcode = $charge['source']['scannable_code']['image']['download_uri'];
+
+		$expires_datetime = new WC_DateTime( $charge['expires_at'], new DateTimeZone( 'UTC' ) );
+		$expires_datetime->set_utc_offset( wc_timezone_offset() );
+
+		if ( 'view' === $context ) : ?>
+			<div id="omise-offline-additional-details" class="omise omise-additional-payment-details-box omise-promptpay-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
+				<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
+				<div class="omise omise-promptpay-qrcode">
+					<img style="margin: 0 auto;" src="<?php echo $qrcode; ?>" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
+				</div>
+				<div>
+					<?php echo __( 'Payment expires in: ', 'omise' ); ?>
+					<?php echo wc_format_datetime( $expires_datetime, wc_date_format() ); ?>
+					<?php echo wc_format_datetime( $expires_datetime, wc_time_format() ); ?>
+				</div>
+
+				<div id="omise-offline-payment-timeout" style="margin-top: 2em; display: none;">
+					<p><button id="omise-offline-payment-refresh-status">refresh status</button></p>
+				</div>
+			</div>
+
+			<div id="omise-offline-payment-result" class="omise-additional-payment-details-box" style="display: none;"></div>
+
+			<script>
+				( function( $ ) {
+					let initializeTimer = function() {
+						console.log('cc');
+						validatePaymentResultTimerId = setInterval( validatePaymentResult, intervalTime );
+						setTimeout( function() { clearInterval( validatePaymentResultTimerId ); }, maxIntervalTime );
+
+						// 10 minutes
+						watch( 60, $( '#omise-timer' ) );
+						return validatePaymentResultTimerId;
+					}
+
+					let watch = function( duration, display ) {
+						let timer = duration, minutes, seconds;
+							timeInterval = setInterval( function () {
+								minutes = parseInt( timer / 60, 10 )
+								seconds = parseInt( timer % 60, 10 );
+
+								minutes = minutes < 10 ? "0" + minutes : minutes;
+								seconds = seconds < 10 ? "0" + seconds : seconds;
+
+								display.text( minutes + ":" + seconds );
+
+								if ( --timer < 0 ) { clearInterval(timeInterval); }
+							}, 1000);
+					}
+
+					let elementRefreshButton         = $( '#omise-offline-payment-refresh-status' ),
+					    elementOmiseOfflineDetails   = $( '#omise-offline-additional-details' ),
+					    elementTimeoutMessage        = $( '#omise-offline-payment-timeout' ),
+					    elementPaymentResult         = $( '#omise-offline-payment-result' ),
+					    validatePaymentResultCount   = 0;
+					    validatePaymentResultTimerId = null,
+					    intervalTime                 = 10000; // 10 seconds
+					    maxIntervalTime              = 600000; // 10 minutes
+					    validatePaymentResult        = function() {
+							validatePaymentResultCount++;
+
+							$.ajax({
+								type: 'POST',
+								url: '<?php echo admin_url( 'admin-ajax.php' ); ?>',
+								dataType: 'json',
+								data: {
+									'action': 'fetch_order_status',
+									'order_id': '<?php echo $order; ?>'
+								},
+								success: function( response ) {
+									if ( 'processing' === response.data.order_status ) {
+										elementOmiseOfflineDetails.fadeOut();
+										elementPaymentResult.html('<h4><?php echo __( "Payment successful", "omise" ); ?></h4><p><?php echo __( "Thank you. Your order has been paid.", "omise" ); ?></p>').fadeIn();
+										clearInterval( validatePaymentResultTimerId );
+										return;
+									} else if ( 'failed' === response.data.order_status ) {
+										elementOmiseOfflineDetails.fadeOut();
+										elementPaymentResult.html('<h4><?php echo __( "Payment failed", "omise" ); ?></h4><p><?php echo __( "Please try placing an order with a different payment method.", "omise" ); ?></p>').fadeIn();
+										clearInterval( validatePaymentResultTimerId );
+										return;
+									}
+								},
+								error: function( response ) { console.log(response); },
+								complete: function (response ) {
+									if ( validatePaymentResultCount * intervalTime >= maxIntervalTime ) {
+										elementTimeoutMessage.fadeIn();
+										console.log('stop');
+										return;
+									}
+								}
+							});
+						};
+
+					elementRefreshButton.click( function() {
+						validatePaymentResultCount   = 0;
+						validatePaymentResultTimerId = initializeTimer();
+
+						elementTimeoutMessage.fadeOut();
+					} );
+
+					$( document ).ready( function() {
+						validatePaymentResultCount   = 0;
+						validatePaymentResultTimerId = initializeTimer();
+					});
+				})(jQuery);
+			</script>
+		<?php elseif ( 'email' === $context ) : ?>
+			<div>
+				<?php
+				echo sprintf(
+					wp_kses(
+						__( 'Please scan the QR code and pay before: <strong>%1$s %2$s</strong>', 'omise' ),
+						array( 'strong' => array() )
+					),
+					wc_format_datetime( $expires_datetime, wc_date_format() ),
+					wc_format_datetime( $expires_datetime, wc_time_format() )
+				);
+				?>
+			</div>
+			<p><a href="<?php echo $qrcode; ?>"><?php echo __( 'Click this link to display the QR code', 'omise' ); ?></a></p>
+		<?php endif;
+	}
+}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -77,6 +77,7 @@ class Omise {
 		$this->init_route();
 		$this->register_payment_methods();
 		$this->register_hooks();
+		$this->register_ajax_actions();
 
 		prepare_omise_myaccount_panel();
 	}
@@ -133,10 +134,12 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-installment.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-internetbanking.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-paynow.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-promptpay.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-truemoney.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-php/lib/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-plugin/Omise.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-ajax-actions.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-callback.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-capabilities.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-events.php';
@@ -189,6 +192,14 @@ class Omise {
 	 */
 	public function register_hooks() {
 		add_action( 'omise_async_webhook_event_handler', 'Omise_Queue_Runner::execute_webhook_event_handler', 10, 3 );
+	}
+
+	/**
+	 * @since  4.1
+	 */
+	public function register_ajax_actions() {
+		add_action('wp_ajax_nopriv_fetch_order_status', 'Omise_Ajax_Actions::fetch_order_status' );
+		add_action('wp_ajax_fetch_order_status', 'Omise_Ajax_Actions::fetch_order_status' );
 	}
 
 	/**


### PR DESCRIPTION
## 1. Objective

This pull request is introducing PromptPay payment method to Omise-WooCommerce plugin.

**Related information**:
Related issue(s): T22500 (internal ticket)

## 2. Description of change

- **Displaying PromptPay payment method at the checkout page.**
<img width="1552" alt="promptpay-04" src="https://user-images.githubusercontent.com/2154669/89579732-7afabe80-d85e-11ea-85c8-1d6aa3f66725.png">

- **Displaying PromptPay QR code at the Thank-you page.**
Alongs with the QR code expiry date.

<img width="1552" alt="Screen Shot 2563-08-17 at 13 23 20" src="https://user-images.githubusercontent.com/2154669/90363382-d6158800-e08c-11ea-8be0-60e33b2a1a0c.png">

- **Displaying successful payment message if the payment has been successfully paid.**
<img width="1552" alt="promptpay-01" src="https://user-images.githubusercontent.com/2154669/89579183-88637900-d85d-11ea-918d-cf949df4daeb.png">

- **Displaying failed payment message if the payment has failed.**
<img width="1552" alt="promptpay-02" src="https://user-images.githubusercontent.com/2154669/89579196-8c8f9680-d85d-11ea-948d-fd5c4124188c.png">

- **After 10 minutes, if a particular order status still stay as `on-hold` then the plugin will stop Ajax-polling request to save the computer resource and display a 'refresh' button to allow buyer to fetch a payment status manually instead.**
<img width="1552" alt="Screen Shot 2563-08-17 at 12 20 04" src="https://user-images.githubusercontent.com/2154669/90363636-399fb580-e08d-11ea-93b7-651a7d048df1.png">

- **Displaying a link to PromptPay QR code at the `order-confirmation` email.**

<img width="1020" alt="Screen Shot 2563-08-17 at 12 53 51" src="https://user-images.githubusercontent.com/2154669/90363818-84213200-e08d-11ea-8ad0-0e36920e2180.png">



## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3.

**✏️ Details:**

There are 2 aspects that we want to test for this pull request, "merchant's perspective" and "buyer's perspective".
All the tests in this section will be separated into 2 situations as mentioned.

### Setting up:

1. Once installed this PR, at the admin page, from sidebar menu `Omise > Settings`. You will see the **PromptPay** payment method is listed at the **Available Payment Methods** table. Click **config**
<img width="1552" alt="Screen Shot 2563-08-17 at 13 49 04" src="https://user-images.githubusercontent.com/2154669/90365723-74571d00-e090-11ea-9b72-15f536a7486f.png">

2. You may rename or add a payment description at the payment configuration page. Then, check the `Enable Omise PromptPay Payment` and click **Save changes**
<img width="1552" alt="Screen Shot 2563-08-17 at 13 49 11" src="https://user-images.githubusercontent.com/2154669/90365732-79b46780-e090-11ea-9ec9-2038b630fe74.png">

3. To be able to use the full feature of plugin, you may set the Webhook endpoint to your Omise Account as well.
> Note: As Webhook endpoint requires for HTTPS server. For localhost test, you can use https://ngrok.com tool to simulate for `https` protocol.
<img width="1552" alt="Screen Shot 2563-08-17 at 13 49 04" src="https://user-images.githubusercontent.com/2154669/90369223-956e3c80-e095-11ea-9c15-8d6dda9fe324.png">

4. Once done, the PromptPay payment method will be listed at the checkout page.
<img width="1552" alt="Screen Shot 2563-08-17 at 14 07 44" src="https://user-images.githubusercontent.com/2154669/90367442-10822380-e093-11ea-82b0-15b4c0225d08.png">

### Placing Order:

#### As a buyer:

Once the payment method has been set and enabled. Buyers will be able to placing order using PromptPay payment method at the checkout page.
<img width="1552" alt="Screen Shot 2563-08-17 at 14 07 44" src="https://user-images.githubusercontent.com/2154669/90367442-10822380-e093-11ea-82b0-15b4c0225d08.png">

After selecting PromptPay as a payment method, PromptPay QR code will be displayed at the WooCommerce Order-Confirmation page (thank-you page), along with the QR code expiry date.
<img width="1552" alt="Screen Shot 2563-08-17 at 14 31 28" src="https://user-images.githubusercontent.com/2154669/90369687-66a49600-e096-11ea-9fd2-8ca507c5e17a.png">

> Important: at this step, there will be AJAX polling request running behind to keep fetch order status every 10 seconds for 10 minutes to check if the payment has been paid (to update the screen accordingly). After 10 minutes, the AJAX  will be terminated and displaying "refresh status" on the screen instead.

As well, there will be an email sent to buyer's billing email.
<img width="1026" alt="Screen Shot 2563-08-17 at 14 53 52" src="https://user-images.githubusercontent.com/2154669/90371709-9012f100-e099-11ea-91b2-0be8e51556e6.png">

At this point, user may scan the QR code to pay.

#### As a merchant:

Once buyers make placed an order using PromptPay payment method, a new order with `on-hold` status will be created on WooCommerce. 

<img width="1552" alt="Screen Shot 2563-08-17 at 14 47 38" src="https://user-images.githubusercontent.com/2154669/90371075-9eacd880-e098-11ea-912e-4b3d8eea659f.png">

### Complete the payment

#### As a buyer:

Once the buyer paid for the payment, if payment is successful, there will be a successful payment message appear on the screen.
<img width="1552" alt="Screen Shot 2563-08-17 at 15 04 23" src="https://user-images.githubusercontent.com/2154669/90372697-f9473400-e09a-11ea-9997-bccb8115c83f.png">

Once the buyer paid for the payment, if payment is failed, there will be a failure payment message appear on the screen.
<img width="1552" alt="Screen Shot 2563-08-17 at 15 06 08" src="https://user-images.githubusercontent.com/2154669/90372818-33b0d100-e09b-11ea-9d87-0e7820bfb989.png">

In case if buyer didn't complete the transaction within 10 minutes, there will be a button **refresh status** appeared on the screen (this means that the AJAX polling has been terminated. Buyer can click this button to reactivate the AJAX script).
<img width="1552" alt="Screen Shot 2563-08-17 at 15 03 11" src="https://user-images.githubusercontent.com/2154669/90372576-cd2bb300-e09a-11ea-82bc-522c4178a030.png">

#### As a merchant:

In case of payment successful, the order status will be updated to `processing`.

<img width="1552" alt="Screen Shot 2563-08-17 at 15 09 42" src="https://user-images.githubusercontent.com/2154669/90373195-ba65ae00-e09b-11ea-837a-963e95ffc7ec.png">

In case of payment successful, the order status will be updated to `failed`.

<img width="1552" alt="Screen Shot 2563-08-17 at 15 09 48" src="https://user-images.githubusercontent.com/2154669/90373206-bd609e80-e09b-11ea-87a1-d3b02f246189.png">

## 4. Impact of the change

None

## 5. Priority of change

Normal

## 6. Additional Notes

Nothing.