### PR TITLE
Revise order statuses (Part 1, failing payment should result as order failed)

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -144,14 +144,8 @@ class Omise_Callback {
 		$message         = __( 'It seems we\'ve been unable to process your payment properly:<br/>%s', 'omise' );
 		$failure_message = $this->charge['failure_message'] . ' (code: ' . $this->charge['failure_code'] . ')';
 
-		$this->order->add_order_note(
-			sprintf( wp_kses( __( 'OMISE: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message )
-		);
-
-		// Offsite case.
-		if ( ! is_null( $this->charge['source'] ) && 'redirect' === $this->charge['source']['flow'] ) {
-			$this->order->update_status( 'failed' );
-		}
+		$this->order->add_order_note( sprintf( wp_kses( __( 'OMISE: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message ) );
+		$this->order->update_status( 'failed' );
 
 		wc_add_notice( sprintf( wp_kses( $message, array( 'br' => array() ) ), $failure_message ), 'error' );
 		wp_redirect( wc_get_checkout_url() );

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -379,13 +379,11 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 			} catch ( Exception $e ) {
 				$this->order()->add_order_note(
 					sprintf(
-						wp_kses(
-							__( 'Omise: Payment failed (manual capture).<br/>%s', 'omise' ),
-							array( 'br' => array() )
-						),
+						wp_kses( __( 'Omise: Payment failed (manual capture).<br/>%s', 'omise' ), array( 'br' => array() ) ),
 						$e->getMessage()
 					)
 				);
+				$this->order()->update_status( 'failed' );
 			}
 		}
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -418,9 +418,8 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		);
 
 		if ( $this->order() ) {
-			$this->order()->add_order_note(
-				sprintf( __( 'Omise: Payment failed, %s', 'omise' ), $message )
-			);
+			$this->order()->add_order_note( sprintf( __( 'Omise: Payment failed, %s', 'omise' ), $message ) );
+			$this->order()->update_status( 'failed' );
 		}
 	}
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -183,7 +183,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 */
 	public function process_payment( $order_id ) {
 		if ( ! $order = $this->load_order( $order_id ) ) {
-			return $this->payment_failed_no_order( $order_id );
+			return $this->invalid_order( $order_id );
 		}
 
 		$order->add_order_note( sprintf( __( 'Omise: Processing a payment with %s', 'omise' ), $this->method_title ) );
@@ -387,7 +387,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	/**
 	 * @param int|mixed $order_id
 	 */
-	protected function payment_failed_no_order( $order_id ) {
+	protected function invalid_order( $order_id ) {
 		wc_add_notice(
 			sprintf(
 				wp_kses(


### PR DESCRIPTION
## 1. Objective

There is a query has been raised of the confusion regarding on how the Omise payment status maps with WooCommerce order status for the failure payment cases.

This pull request is aiming to revise the order status for the failure payment cases.

## 2. Description of change

- **Renaming 'Omise_Payment::payment_failed_no_order' method to 'invalid_order'**
As for the conclusion of the internal team about the confusion of order status when payment is failed. The first step first this commit is aiming is to differentiate between what method should count as 'payment failed' and whats not.

  Therefore the current 'Omise_Payment::payment_failed_no_order' giving an impression that the payment result is failed while it actually hasn't been started at this point.

> Note, there are 2 places that using `payment_failed_no_order`.
> Renaming here should be safe to go.
> <img width="1020" alt="Screen Shot 2563-06-23 at 14 23 20" src="https://user-images.githubusercontent.com/2154669/85384137-09dfa000-b56b-11ea-81dc-d644d9983ba6.png">


- **Updating order status to 'failed' when the payment result is failed in any circumstances)**
All the `pending-payment` order status will now be updated to `failed` if a particular payment transaction is resulted in `failed` status for all the payment methods.

> Note, beside `class-omise-callback`, there are 4 files that are executing `payment_failed` method. The execution can be separated into 2 main use-cases.
> - When a particular Omise charge transaction gets `failed` status, the plugin triggers `payment_failed()`. 👈 This pull request is making this case to also update WC Order status to `failed`.
> - A fallback case when the plugin cannot validate a particular charge status. (see [6. Additional Notes])
<img width="1552" alt="Screen Shot 2563-06-23 at 14 24 18" src="https://user-images.githubusercontent.com/2154669/85384285-31cf0380-b56b-11ea-870d-49a8eea07670.png">


## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v3.9.3.
- **WordPress**: v5.4.2.
- **PHP version**: 7.3.3.

**✏️ Details:**

3.1 **Making sure that the `Omise_Payment::invalid_order()` method is working properly.**
To test this case, you will need to update the plugin code to make the plugin not be able to retrieve an order object properly:
At file: `includes/gateway/class-omise-payment.php`, line `185`. Replacing `$order_id` with any string to make a false-id.
<img width="1183" alt="Screen Shot 2563-06-23 at 15 17 35" src="https://user-images.githubusercontent.com/2154669/85378511-d863d600-b564-11ea-81f6-832da8589f20.png">

Then, try to place an order as normal.
The plugin will display a warning message on the checkout page screen saying that the payment cannot be processed.
<img width="1552" alt="Screen Shot 2563-06-23 at 15 16 12" src="https://user-images.githubusercontent.com/2154669/85378724-224cbc00-b565-11ea-80bb-ec3898ee439f.png">

As the plugin cannot retrieve a proper Order object, so the plugin will not be able to alter any of order status, however, there will be new order transaction created at Admin, WooCommerce Order  page.
<img width="1552" alt="Screen Shot 2563-06-23 at 15 16 49" src="https://user-images.githubusercontent.com/2154669/85378837-414b4e00-b565-11ea-8d10-ff93150c0b0c.png">

> This is an edge case that normally won't happen unless there is an unexpected bug from WooCommerce itself or database went down right at this moment and the plugin cannot retrieve WooCommerce Order object properly. (as the `$order_id` variable is coming from WooCommerce itself).

3.2 **Testing placing an order using Credit Card payment method. The result of failed-charge should update that particular Order status to `failed`.**
To test the failure payment case, you must use any of those testing cards that make the charge failed. https://www.omise.co/api-testing#creating-failed-charges
<img width="1552" alt="Screen Shot 2563-06-23 at 15 31 33" src="https://user-images.githubusercontent.com/2154669/85380908-aacc5c00-b567-11ea-9964-c70a1806d3bd.png">

Then, go through the checkout step as normal, placing an order using Credit Card payment method. There should be an error message displayed on your checkout page saying that the payment is failed.
<img width="1552" alt="Screen Shot 2563-06-23 at 15 32 30" src="https://user-images.githubusercontent.com/2154669/85381505-3c3bce00-b568-11ea-800d-7568199c2c3b.png">

A particular order status should be updated to `failed` accordingly.
<img width="1552" alt="Screen Shot 2563-06-23 at 15 38 47" src="https://user-images.githubusercontent.com/2154669/85381163-e7985300-b567-11ea-9d8c-7fa701bcec13.png">

3.3 **Testing placing the same order using a proper test card to make the charge successful should result in order status changes from `failed` to `processing`.**
Continuing from [3.2.], you may try to place an order again with a proper successful test card.
The order will be placed and redirect buyer to the order confirmation (thank-you page) properly.
<img width="1552" alt="Screen Shot 2563-06-23 at 15 43 18" src="https://user-images.githubusercontent.com/2154669/85381953-b0767180-b568-11ea-9858-da482ba207bd.png">

Order status will be updated from `failed` to `processing`.
<img width="1552" alt="Screen Shot 2563-06-23 at 15 45 17" src="https://user-images.githubusercontent.com/2154669/85381985-b704e900-b568-11ea-8003-48ac89616005.png">

3.4 **We may as well test for a manual capture case. Failing to capture an authorized charge should result in order status = failed**.

To test this case, you must set the Credit Card payment `Payment Action` to `Manual Capture`.
<img width="1552" alt="Screen Shot 2563-06-23 at 16 11 28" src="https://user-images.githubusercontent.com/2154669/85432814-b5a9df80-b5ad-11ea-9464-ce338bfd18cc.png">

As well, you must update the plugin code to simulate the capture-failure case.
At the file: `includes/gateway/class-omise-payment-creditcard.php`, line: `365`. Commenting out line `364` and `366` to make sure that the program will go through the `throw new Exception` case.
<img width="1223" alt="Screen Shot 2563-06-24 at 00 08 51" src="https://user-images.githubusercontent.com/2154669/85433753-1ab20500-b5af-11ea-8ce6-3541c57f3d42.png">

You now then, may place a new order using Credit Card payment method.
Once done ordering, you may check your order at the Admiin order detail page. Then make a manual capture action.
<img width="1440" alt="Screen Shot 2563-06-24 at 00 15 45" src="https://user-images.githubusercontent.com/2154669/85434276-fd316b00-b5af-11ea-92e0-31e8e9b41a73.png">

The order status will be updated to `Failed` as the capture will be failed at this point.
<img width="1552" alt="Screen Shot 2563-06-24 at 00 16 14" src="https://user-images.githubusercontent.com/2154669/85434294-04587900-b5b0-11ea-8dd6-b3f4c803489e.png"> 



 
## 4. Impact of the change

Order status flow changed, this may result in a confusion of the current merchants that are currently using, or adapting their way of order-management to the previous flow (mostly for credit card payment method).

## 5. Priority of change

Normal

## 6. Additional Notes

At the moment, the plugin is handling the "unknown" case as `payment failed`.
In fact, I think it would be better to update order status to `on-hold` for those unknown payment result cases (those fallback cases).

```php
public function result( $order_id, $order, $charge ) {
	if ( self::STATUS_FAILED === $charge['status'] ) {
		return $this->payment_failed( $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')' );
	}

	if ( self::STATUS_PENDING === $charge['status'] ) {
		$order->add_order_note( sprintf( __( 'Omise: Redirecting buyer to %s', 'omise' ), esc_url( $charge['authorize_uri'] ) ) );

		return array (
			'result'   => 'success',
			'redirect' => $charge['authorize_uri'],
		);
	}

	// This fallback case should be treat as "cannot validate the payment result"
	// The order status should be set as `on-hold` instead of treating it as `payment-failed`.
	return $this->payment_failed(
		sprintf(
			__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),
			$order_id
		)
	);
}
```