### PR TITLE
Revising Omise Settings

### DIFF
--- a/includes/admin/class-omise-admin-page.php
+++ b/includes/admin/class-omise-admin-page.php
@@ -4,7 +4,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * @since 4.0
  */
-class Omise_Admin_Page {
+class Omise_Admin_Page extends Omise_Setting {
 	/**
 	 * @var array  a set of system messages.
 	 */

--- a/includes/admin/class-omise-admin-page.php
+++ b/includes/admin/class-omise-admin-page.php
@@ -7,12 +7,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Omise_Admin_Page extends Omise_Setting {
 	/**
-	 * @var array  a set of system messages.
+	 * @var array  of system messages.
 	 */
 	protected $messages = array();
 
 	/**
-	 * @var array  a set of error messages.
+	 * @var array  of error messages.
 	 */
 	protected $errors = array();
 

--- a/includes/admin/class-omise-admin-page.php
+++ b/includes/admin/class-omise-admin-page.php
@@ -1,4 +1,5 @@
 <?php
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -31,6 +32,9 @@ class Omise_Admin_Page extends Omise_Setting {
 		}
 	}
 
+	/**
+	 * @return HTML
+	 */
 	public function display_messages() {
 		if ( count( $this->errors ) > 0 ) {
 			foreach ( $this->errors as $error ) {

--- a/includes/admin/class-omise-admin-page.php
+++ b/includes/admin/class-omise-admin-page.php
@@ -1,0 +1,47 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 4.0
+ */
+class Omise_Admin_Page {
+	/**
+	 * @var array  a set of system messages.
+	 */
+	protected $messages = array();
+
+	/**
+	 * @var array  a set of error messages.
+	 */
+	protected $errors = array();
+
+	/**
+	 * @param string $type     Whether 'error' or 'message'
+	 * @param string $message  A message to display
+	 */
+	public function add_message( $type, $message ) {
+		switch ( $type ) {
+			case 'error':
+				$this->errors[] = $message;
+				break;
+
+			case 'message':
+				$this->messages[] = $message;
+				break;
+		}
+	}
+
+	public function display_messages() {
+		if ( count( $this->errors ) > 0 ) {
+			foreach ( $this->errors as $error ) {
+				echo '<div class="error"><p>' . esc_html( $error ) . '</p></div>';
+			}
+		}
+
+		if ( count( $this->messages ) > 0 ) {
+			foreach ( $this->messages as $message ) {
+				echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';
+			}
+		}
+	}
+}

--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -6,7 +6,7 @@ if ( class_exists( 'Omise_Page_Settings' ) ) {
 	return;
 }
 
-class Omise_Page_Settings {
+class Omise_Page_Settings extends Omise_Admin_Page {
 	/**
 	 * @var Omise_Setting
 	 */
@@ -49,8 +49,12 @@ class Omise_Page_Settings {
 			$data['account_country'] = $account['country'];
 
 			$this->settings->update_settings( $data );
+			$this->add_message(
+				'message',
+				sprintf( __( 'The settings have been saved, an account: %s has been connected.', 'omise' ), $account['email'] )
+			);
 		} catch (Exception $e) {
-			// Do nothing.
+			$this->add_message( 'error', $e->getMessage() );
 		}
 	}
 

--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -17,8 +17,8 @@ class Omise_Page_Settings extends Omise_Admin_Page {
 			wp_die( __( 'You are not allowed to modify the settings from a suspicious source.', 'omise' ) );
 		}
 
-		$public_key = $data['sandbox'] ? $data['test_public_key'] : $data['live_public_key'];
-		$secret_key = $data['sandbox'] ? $data['test_private_key'] : $data['live_private_key'];
+		$public_key = isset( $data['sandbox'] ) ? $data['test_public_key'] : $data['live_public_key'];
+		$secret_key = isset( $data['sandbox'] ) ? $data['test_private_key'] : $data['live_private_key'];
 
 		try {
 			$account = OmiseAccount::retrieve( $public_key, $secret_key );

--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -8,27 +8,6 @@ if ( class_exists( 'Omise_Page_Settings' ) ) {
 
 class Omise_Page_Settings extends Omise_Admin_Page {
 	/**
-	 * @var Omise_Setting
-	 */
-	protected $settings;
-
-	/**
-	 * @since 3.1
-	 */
-	public function __construct() {
-		$this->settings = Omise()->settings();
-	}
-
-	/**
-	 * @return array
-	 *
-	 * @since  3.1
-	 */
-	protected function get_settings() {
-		return $this->settings->get_settings();
-	}
-
-	/**
 	 * @param array $data
 	 *
 	 * @since  3.1
@@ -48,7 +27,7 @@ class Omise_Page_Settings extends Omise_Admin_Page {
 			$data['account_email']   = $account['email'];
 			$data['account_country'] = $account['country'];
 
-			$this->settings->update_settings( $data );
+			$this->update_settings( $data );
 			$this->add_message(
 				'message',
 				sprintf( __( 'The settings have been saved, an account: %s has been connected.', 'omise' ), $account['email'] )

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -1,7 +1,21 @@
 <div class="wrap omise">
+	<style>
+		.omise-notice-testmode {
+			background: #ffce00;
+			color: #575D66;
+			border: 1px solid #efc200;
+			border-left-width: 4px;
+		}
+	</style>
 	<h1><?php echo $title; ?></h1>
 
 	<?php $page->display_messages(); ?>
+
+	<?php if ( 'yes' === $settings['sandbox'] && $settings['account_email'] ) : ?>
+		<div class="notice omise-notice-testmode">
+			<p><?php echo _e( 'You are in test mode. No actual payment is made in this mode', 'omise' ); ?></p>
+		</div>
+	<?php endif; ?>
 
 	<h2><?php echo _e( 'Payment Settings', 'omise' ); ?></h2>
 
@@ -20,7 +34,26 @@
 		);
 		?>
 	</p>
+
 	<form method="POST">
+		<!-- Section: account information -->
+		<?php if ( $settings['account_email'] ) : ?>
+			<hr />
+			<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row"><label><?php _e( 'Account status', 'omise' ); ?></label></th>
+						<td>
+							<fieldset>
+								Connected: <em><?php echo $settings['account_email']; ?> (<?php echo $settings['account_country']; ?>)</em>
+							</fieldset>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+			<hr />
+		<?php endif; ?>
+
 		<table class="form-table">
 			<tbody>
 				<tr>

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -1,6 +1,10 @@
 <div class="wrap omise">
 	<h1><?php echo $title; ?></h1>
+
+	<?php $page->display_messages(); ?>
+
 	<h2><?php echo _e( 'Payment Settings', 'omise' ); ?></h2>
+
 	<p>
 		<?php
 		echo sprintf(

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -11,7 +11,7 @@
 
 	<?php $page->display_messages(); ?>
 
-	<?php if ( 'yes' === $settings['sandbox'] && $settings['account_email'] ) : ?>
+	<?php if ( 'yes' === $settings['sandbox'] ) : ?>
 		<div class="notice omise-notice-testmode">
 			<p><?php echo _e( 'You are in test mode. No actual payment is made in this mode', 'omise' ); ?></p>
 		</div>

--- a/includes/class-omise-admin.php
+++ b/includes/class-omise-admin.php
@@ -25,6 +25,7 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		 * @since 3.3
 		 */
 		public function init() {
+			require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/admin/class-omise-admin-page.php';
 			require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/admin/class-omise-page-settings.php';
 
 			$this->register_admin_menu();


### PR DESCRIPTION
### 1. Objective

There are still some more of UI that could enhance **Omise Setting** page.
This pull request is aiming to give an enhancement to it. On both UI and the code itself.

### 2. Description of change

2.1. Adding a **test-mode indicator** bar on top of the page.
<img width="1242" alt="Screen Shot 2563-07-02 at 17 19 40" src="https://user-images.githubusercontent.com/2154669/86475949-c9083800-bd6f-11ea-8cd3-dffab14b5aa4.png">

2.2. Also, displaying an Omise account's email that is currently linked to a store.

2.3. Displaying notification messages when the setting form is submitted.

2.4. Fixing issue that Omise-WooCommerce test mode can't be disabled on WooCommerce version 4.

--
However, as for the beginning of the plugin (right after installed), everything will be the same.
<img width="1552" alt="Screen Shot 2563-07-02 at 17 38 10" src="https://user-images.githubusercontent.com/2154669/86475921-c0176680-bd6f-11ea-952e-d13f91cc7ece.png">

### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.2.2.
- **WordPress**: v5.4.2.
- **PHP version**: 7.3.3.

**✏️ Details:**

In order to test all the cases, you may need a fresh-installed Omise-WooCommerce plugin.
3.1. Making sure that a fresh-installed Omise-WooCommerce plugin would function as the same.

<img width="1552" alt="Screen Shot 2563-07-04 at 15 59 40" src="https://user-images.githubusercontent.com/2154669/86509070-6f574a80-be0f-11ea-9582-aeab94f17b98.png">

3.2. Test input a wrong credential, Omise plugin should response as `authentication failed`
<img width="1552" alt="Screen Shot 2563-07-04 at 16 01 53" src="https://user-images.githubusercontent.com/2154669/86509184-41263a80-be10-11ea-8d87-7ae6bbc3605d.png">

<img width="1552" alt="Screen Shot 2563-07-04 at 16 02 05" src="https://user-images.githubusercontent.com/2154669/86509179-39669600-be10-11ea-954f-f9cf16374986.png">

3.3. Test input test keys, the plugin should display a test-mode indicator at the top of the page.

<img width="1552" alt="Screen Shot 2563-07-04 at 16 09 07" src="https://user-images.githubusercontent.com/2154669/86509262-c7428100-be10-11ea-8615-13acbe1a4c54.png">

3.4. Test enable live mode, the test-mode iindicator should be disappeared

<img width="1552" alt="Screen Shot 2563-07-04 at 16 11 16" src="https://user-images.githubusercontent.com/2154669/86509298-0d97e000-be11-11ea-9ec0-f59eb9449533.png">


#### 4. Impact of the change

none

#### 5. Priority of change

Normal

#### 6. Additional Notes

Nothing
