### PR TITLE
Fix - When webhook is enabled, order status updated twice and triggered two emails to merchant.

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -81,16 +81,8 @@ class Omise_Callback {
 	 * Resolving a case of charge status: successful.
 	 */
 	protected function payment_successful() {
-		$message = __( 'OMISE: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' );
 
-		$this->order->payment_complete();
-		$this->order->add_order_note(
-			sprintf(
-				wp_kses( $message, array( 'br' => array() ) ),
-				$this->order->get_total(),
-				$this->order->get_order_currency()
-			)
-		);
+		WC()->queue()->add( 'callback_payment_successful', array('order_id' => $this->order->get_id() ), 'omise-payment-complete' );
 
 		WC()->cart->empty_cart();
 		wp_redirect( $this->order->get_checkout_order_received_url() );
@@ -152,3 +144,17 @@ class Omise_Callback {
 		exit;
 	}
 }
+
+function hook_payment_successful( $order_id ) {
+	$message = __( 'OMISE: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' );
+	$order = wc_get_order( $order_id );
+	$order->payment_complete();
+	$order->add_order_note(
+		sprintf(
+			wp_kses( $message, array( 'br' => array() ) ),
+			$order->get_total(),
+			$order->get_order_currency()
+		)
+	);
+}
+add_action( 'callback_payment_successful', 'hook_payment_successful', 10, 2 );

--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -146,7 +146,7 @@ class Omise_Callback {
 }
 
 function hook_payment_successful( $order_id ) {
-	$message = __( 'OMISE: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' );
+	$message = __( 'Omise: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' );
 	$order = wc_get_order( $order_id );
 	$order->payment_complete();
 	$order->add_order_note(

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -81,18 +81,7 @@ class Omise_Event_Charge_Complete {
 
 			case 'successful':
 				if ( $data->authorized && $data->paid ) {
-					$order->add_order_note(
-						sprintf(
-							wp_kses(
-								__( 'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' ),
-								array( 'br' => array() )
-							),
-							$order->get_total(),
-							$order->get_order_currency()
-						)
-					);
-
-					$order->payment_complete( $data->id );
+					WC()->queue()->add( 'callback_payment_successful', array('order_id' => $data->id ), 'omise-payment-complete' );
 				}
 				break;
 			


### PR DESCRIPTION
#### 1. Objective

On WooCommerce plugin, if merchant enables webhook configuration, sometimes they can see the order status updated twice and gets 2 email notification for the same order.

This issue happens as callback action after payment and webhook executes concurrently, updating notes and order status at the same time causing sending email notification twice.

Duplicate notes:
![duplicate_notes](https://user-images.githubusercontent.com/5526195/87423670-e1e0db00-c604-11ea-97c8-479e41ae1546.jpeg)

**Related information**:
Internal Ticket(s): https://phabricator.omise.co/T22125

#### 2. Description of change

- Using worker queue for a function `$order->payment_complete()` which makes sure it to execute one after the other.

#### 3. Quality assurance


**🔧 Environments:**
i.e.
- **WooCommerce**: v4.0.1
- **WordPress**: v5.4.2
- **PHP version**: 7.2.1
- **Omise plugin version**: Omise-WooCommerce 3.11 (optional, in case of submitting a new issue)

**✏️ Details:**
Steps to reproduce:
- Add product to cart.
- Checkout using Card payment.
- Place order and complete the payment process
- Go to customers email account and check email.
- Go to Wordpress backend >> WooCommerce >> Orders >> Check order notes.

Actual behaviour:
After order completion, duplicate(twice) emails gets sent to customer for order comfirmation, Duplicate notes attached to order. This happens intermittently.

Expected behaviour: 
After order completion, no duplicate order email should get sent to customer and no duplicate note should get added to 

#### 4. Impact of the change

Card payment should work normally

#### 5. Priority of change

High.

#### 6. Additional Notes
Using following solution suggested by @guzzilar 
https://gist.github.com/thenbrent/974053a348eb7f3ea4c4cb827a39d2e7