### PR TITLE
Preventing async requests from Omise Webhook and Callback URI from updating WC Order status twice.

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -38,7 +38,7 @@ class Omise_Callback {
 	}
 
 	public function validate() {
-		$this->order->add_order_note( __( 'Omise: user is redirected back from the payment page.', 'omise' ) );
+		$this->order->add_order_note( __( 'Omise: User has been redirected back from the payment page.', 'omise' ) );
 
 		try {
 			$this->charge = OmiseCharge::retrieve( $this->order->get_transaction_id() );

--- a/includes/class-omise-payment-result.php
+++ b/includes/class-omise-payment-result.php
@@ -1,0 +1,113 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 4.0
+ */
+class Omise_Payment_Result {
+	/**
+	 * @var \WC_Abstract_Order
+	 */
+	protected $order;
+
+	/**
+	 * @var \OmiseCharge
+	 */
+	protected $charge;
+
+	/**
+	 * @var string
+	 */
+	protected $context;
+
+	public function __construct( $order, $charge, $context ) {
+		$this->order   = $order;
+		$this->charge  = $charge;
+		$this->context = $context;
+	}
+
+	public static function callback( $order_id, $charge, $context ) {
+		$result = new self( wc_get_order( $order_id ), unserialize( $charge ), $context );
+		$result->resolve();
+	}
+
+	public function resolve() {
+		switch ( strtolower( $this->charge['status'] ) ) {
+			case 'successful':
+				$this->payment_successful();
+				break;
+
+			case 'failed':
+				$this->payment_failed();
+				break;
+
+			case 'pending':
+				$this->payment_pending();
+				break;
+
+			default:
+				throw new Exception( __( 'Unrecognized Omise Charge status.', 'omise' ) );
+				break;
+		}
+	}
+
+	/**
+	 * Resolving a case of charge status: successful.
+	 */
+	public function payment_successful() {
+		$message = __( 'OMISE: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' );
+
+		$this->order->payment_complete();
+		$this->order->add_order_note(
+			sprintf(
+				wp_kses( $message, array( 'br' => array() ) ),
+				$this->order->get_total(),
+				$this->order->get_order_currency()
+			)
+		);
+	}
+
+	/**
+	 * Resolving a case of charge status: successful.
+	 */
+	public function payment_failed() {
+		$failure_message = $this->charge['failure_message'] . ' (code: ' . $this->charge['failure_code'] . ')';
+
+		$this->order->add_order_note( sprintf( wp_kses( __( 'OMISE: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message ) );
+		$this->order->update_status( 'failed' );
+	}
+
+	/**
+	 * Resolving a case of charge status: successful.
+	 */
+	public function payment_pending() {
+		if ( ! $this->charge['capture'] && $this->charge['authorized'] ) {
+			// Card authorized case.
+			$message = __(
+				'Omise: The payment is being processed.<br/>
+				 An amount %1$s %2$s has been authorized.',
+				'omise'
+			);
+
+			$this->order->add_order_note(
+				sprintf(
+					wp_kses( $message, array( 'br' => array() ) ),
+					$this->order->get_total(),
+					$this->order->get_order_currency()
+				)
+			);
+		} else {
+			// Offsite case.
+			$message = __(
+				'Omise: The payment is being processed.<br/>
+				Depending on the payment provider, this may take some time to process.<br/>
+				Please do a manual \'Sync Payment Status\' action from the <strong>Order Actions</strong> panel, or check the payment status directly at the Omise Dashboard later.',
+				'omise'
+			);
+
+			$this->order->add_order_note( wp_kses( $message, array( 'br' => array(), 'strong' => array() ) ) );
+			$this->order->update_status( 'on-hold' );
+		}
+	}
+}

--- a/includes/class-omise-payment-result.php
+++ b/includes/class-omise-payment-result.php
@@ -80,7 +80,7 @@ class Omise_Payment_Result {
 			return;
 		}
 
-		$message = wp_kses( __( 'OMISE: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ), array( 'br' => array() ) );
+		$message = wp_kses( __( 'Omise: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ), array( 'br' => array() ) );
 		$this->order->add_order_note( sprintf( $message, $this->order->get_total(), $this->order->get_currency() ) );
 		$this->order->payment_complete();
 	}

--- a/includes/class-omise-payment-result.php
+++ b/includes/class-omise-payment-result.php
@@ -94,7 +94,7 @@ class Omise_Payment_Result {
 		}
 
 		$failure_message = $this->charge['failure_message'] . ' (code: ' . $this->charge['failure_code'] . ')';
-		$this->order->add_order_note( sprintf( wp_kses( __( 'OMISE: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message ) );
+		$this->order->add_order_note( sprintf( wp_kses( __( 'Omise: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message ) );
 		$this->order->update_status( 'failed' );
 	}
 

--- a/includes/class-omise-payment-result.php
+++ b/includes/class-omise-payment-result.php
@@ -102,6 +102,10 @@ class Omise_Payment_Result {
 	 * Resolving a case of charge status: pending.
 	 */
 	public function payment_pending() {
+		if ( $this->order->has_status( 'on-hold' ) ) {
+			return;
+		}
+
 		$message = wp_kses( __(
 			'Omise: The payment is being processed.<br/>
 			Depending on the payment provider, this may take some time to process.<br/>
@@ -117,6 +121,10 @@ class Omise_Payment_Result {
 	 * Resolving a case of an authorized charge.
 	 */
 	public function payment_authorized() {
+		if ( $this->order->has_status( 'processing' ) ) {
+			return;
+		}
+
 		$message = wp_kses( __(
 			'Omise: The payment is being processed.<br/>
 			 An amount %1$s %2$s has been authorized.',

--- a/includes/class-omise-payment-result.php
+++ b/includes/class-omise-payment-result.php
@@ -46,7 +46,7 @@ class Omise_Payment_Result {
 
 	/**
 	 * Resolving order status based on
-	 * the result of a particulalr payment.
+	 * the result of a particular payment.
 	 */
 	public function resolve() {
 		switch ( strtolower( $this->charge['status'] ) ) {

--- a/includes/class-omise-rest-webhooks-controller.php
+++ b/includes/class-omise-rest-webhooks-controller.php
@@ -42,14 +42,14 @@ class Omise_Rest_Webhooks_Controller {
 			return new WP_Error( 'omise_rest_wrong_header', __( 'Wrong header type.', 'omise' ), array( 'status' => 400 ) );
 		}
 
-		$body = json_decode( $request->get_body() );
+		$body = json_decode( $request->get_body(), true );
 
-		if ( 'event' !== $body->object ) {
+		if ( 'event' !== $body['object'] ) {
 			return new WP_Error( 'omise_rest_wrong_object', __( 'Wrong object type.', 'omise' ), array( 'status' => 400 ) );
 		}
 
 		$event = new Omise_Events;
-		$event = $event->handle( $body->key, $body->data );
+		$event = $event->handle( $body['key'], $body['data'] );
 
 		return rest_ensure_response( $event );
 	}

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -24,11 +24,11 @@ class Omise_Event_Charge_Capture {
 	 * @return void
 	 */
 	public function handle( $data ) {
-		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
-		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
@@ -39,9 +39,9 @@ class Omise_Event_Charge_Capture {
 			)
 		);
 
-		switch ($data->status) {
+		switch ($data['status']) {
 			case 'successful':
-				if ( $data->authorized && $data->paid ) {
+				if ( $data['authorized'] && $data['paid'] ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(
@@ -49,11 +49,11 @@ class Omise_Event_Charge_Capture {
 								array( 'br' => array() )
 							),
 							$order->get_total(),
-							$order->get_order_currency()
+							$order->get_currency()
 						)
 					);
 
-					$order->payment_complete( $data->id );
+					$order->payment_complete( $data['id'] );
 				}
 
 				break;

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -57,7 +57,7 @@ class Omise_Event_Charge_Complete {
 			return;
 		}
 
-		$order->add_order_note( __( 'Omise: Receiving charge.complete webhook event.', 'omise' ) );
+		$order->add_order_note( __( 'Omise: Received charge.complete webhook event.', 'omise' ) );
 
 		WC()->queue()->add(
 			'omise_async_payment_result',

--- a/includes/events/class-omise-event-charge-create.php
+++ b/includes/events/class-omise-event-charge-create.php
@@ -54,11 +54,11 @@ class Omise_Event_Charge_Create {
 	 * @return void
 	 */
 	public function handle( $data ) {
-		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
-		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -76,6 +76,7 @@ class Omise {
 		$this->init_admin();
 		$this->init_route();
 		$this->register_payment_methods();
+		$this->register_hooks();
 
 		prepare_omise_myaccount_panel();
 	}
@@ -138,6 +139,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-events.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-money.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-payment-factory.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-payment-result.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-setting.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
@@ -178,6 +180,13 @@ class Omise {
 		add_filter( 'woocommerce_payment_gateways', function( $methods ) {
 			return array_merge( $methods, $this->payment_methods() );
 		} );
+	}
+
+	/**
+	 * @since  4.0
+	 */
+	public function register_hooks() {
+		add_action( 'omise_async_payment_result', 'Omise_Payment_Result::callback', 10, 3 );
 	}
 
 	/**


### PR DESCRIPTION
## 1. Objective

In a race-condition where Omise Webhook is fired at the same time as buyer returns to the Callback URI (`return_uri`). A particular WooCommerce Order object will get updated its status twice which creates a consequence of a confirmation email is being sent to the recipient twice causing a confusion in a business flow that rely on this particular email.

<img width="1552" alt="Screen Shot 2563-07-15 at 01 52 59 copy" src="https://user-images.githubusercontent.com/2154669/87465191-6dc32900-c63e-11ea-86c1-d7d6d9218c2c.png">

This happens because at the moment where Omise Webhook and Callback URI are triggered asynchronously at the same time, they both retrieve WC Order object with the `pending` status and update it to `processing` using `WC_Order::payment_complete()`, which triggers an email function to be executed twice. 

This pull request is providing a solution to prevent the async request from creating a race-condition, by integrating with WC_Queue feature to handle those async request by executing it by order.

**Related information**:
Related issue(s): T22125 (internal ticket)

## 2. Description of change


## 3. Quality assurance


**🔧 Environments:**

- **WooCommerce**: v4.2.2.
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3.

**✏️ Details:**

> ⚠️ At the moment, I have no other approach to test the race-condition but to try create and place an order again and again until the Webhook event is finally arrived to the store first before user get redirected back to the Callback URI.

> ⚠️ Also, to test this pull request, you may use `ngrok` to create HTTPS public url for Omise Webhook.

> ⚠️ To check if the Webhook is finally arrived first, you may query database with the following command:
> `SELECT * from wp_actionscheduler_actions;`
> Or `SELECT action_id, hook, status, extended_args from wp_actionscheduler_actions ORDER BY action_id DESC LIMIT 5;`
> <img width="1550" alt="Screen Shot 2563-07-15 at 04 58 52 copy" src="https://user-images.githubusercontent.com/2154669/87481160-fe0e6780-c658-11ea-9769-f47928d1049f.png">
> In a typical case, you will get the action `omise_async_payment_result` with `context: callback` come first following by `context: webhook`. This means the Callback URI is being executed first (buyer arrives first).
> And another way around, if Webhook arrived first or at the same time as buyer.

Once everything is in placed and you have set Webhook properly, you may try to place an order again until the Webhook is finally arrived to the store first before the Callback URI being executed.

<img width="1552" alt="Screen Shot 2563-07-15 at 04 56 38" src="https://user-images.githubusercontent.com/2154669/87480480-9a376f00-c657-11ea-8fcc-33700363ce62.png">

If you check at the Admin Order Detail page, there will no longer be a double customer note (meaning that the request does not reach to the `WC_Order::payment_complete()` function).
<img width="1552" alt="Screen Shot 2563-07-15 at 05 38 40 copy" src="https://user-images.githubusercontent.com/2154669/87483474-0026f500-c65e-11ea-903b-381402cea731.png">


## 4. Impact of the change

There is a limitation of concurrent that `Action Scheduler` library can handle.
Please check the following document as reference: https://actionscheduler.org/perf

> **Action Scheduler will only process actions in a request until:**
> • 90% of available memory is used
> • processing another 3 actions would exceed 30 seconds of total request time, based on the average processing time for the current batch
> • in a single concurrent queue

Also

> By default, Action Scheduler will only process actions for a maximum of 30 seconds in each request. This time limit minimises the risk of a script timeout on unknown hosting environments, some of which enforce 30 second timeouts.

> By default, Action Scheduler will claim a batch of 25 actions. This small batch size is because the default time limit is only 30 seconds; however, if you know your actions are processing very quickly, e.g. taking microseconds not seconds, or that you have more than 30 second available to process each batch, increasing the batch size can slightly improve performance.

> By default, Action Scheduler will run only one concurrent batches of actions. This is to prevent consuming a lot of available connections or processes on your webserver.

However, it shall not effect to its capability to handle the queue. Just for some high-volume transaction per minute website, it may take some seconds or minutes until all the queue get executed. 

As stated in WP-Cron: https://developer.wordpress.org/plugins/cron/#what-is-wp-cron

## 5. Priority of change

Immediate.

## 6. Additional Notes

Just to clarify the relationship between 3 names.
- **WooCommerce** integrated **Action Scheduler** library in the project
- **Action Scheduler** is designed to work with **WP-Cron**
- **WP-Cron** is a default built-in Cron worker that WordPress provided.

However, there is one point that we should understand of WP-Cron behaviour, to understand how the WC_Queue work.
As stated in WP-Cron document: https://developer.wordpress.org/plugins/cron/#what-is-wp-cron
> **WP-Cron** works by checking, on every page load, a list of scheduled tasks to see what needs to be run. Any tasks due to run will be called during that page load.

> **WP-Cron** does not run constantly as the system cron does; it is only triggered on page load.

> With the system scheduler, if the time passes and the task did not run, it will not be re-attempted. With WP-Cron, all scheduled tasks are put into a queue and will run at the next opportunity (meaning the next page load). So while you can’t be 100% sure when your task will run, you can be 100% sure that it will run eventually.

The WP-Cron is only working when "any" of page get loaded. It's not time-based as a typical system scheduler.
Meaning that, even though we set some schedule to be executed after "5" mins, but if there is no one open "any" page of the WordPress website, then that schedule won't be triggered. 
