### PR TITLE
Refactoring Event Handlers, make the code support for asynchronous request to prevent race-condition from Webhook 

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -93,6 +93,9 @@ class Omise_Callback {
 		);
 
 		WC()->cart->empty_cart();
+		$this->order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
+		$this->order->save();
+
 		wp_redirect( $this->order->get_checkout_order_received_url() );
 		exit;
 	}
@@ -120,6 +123,9 @@ class Omise_Callback {
 
 			// Remove cart
 			WC()->cart->empty_cart();
+			$this->order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
+			$this->order->save();
+
 			wp_redirect( $this->order->get_checkout_order_received_url() );
 			exit;
 		}
@@ -134,6 +140,9 @@ class Omise_Callback {
 
 		$this->order->add_order_note( wp_kses( $message, array( 'br' => array(), 'strong' => array() ) ) );
 		$this->order->update_status( 'on-hold' );
+		$this->order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
+		$this->order->save();
+
 		wp_redirect( $this->order->get_checkout_order_received_url() );
 		exit;
 	}
@@ -147,6 +156,8 @@ class Omise_Callback {
 
 		$this->order->add_order_note( sprintf( wp_kses( __( 'OMISE: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message ) );
 		$this->order->update_status( 'failed' );
+		$this->order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
+		$this->order->save();
 
 		wc_add_notice( sprintf( wp_kses( $message, array( 'br' => array() ) ), $failure_message ), 'error' );
 		wp_redirect( wc_get_checkout_url() );

--- a/includes/class-omise-events.php
+++ b/includes/class-omise-events.php
@@ -11,14 +11,20 @@ class Omise_Events {
 	 */
 	protected $events = array();
 
-	public function __construct() {
-		$events = array(
-			'Omise_Event_Charge_Capture',
-			'Omise_Event_Charge_Complete',
-			'Omise_Event_Charge_Create'
-		);
+	/**
+	 * All the available event handler classes
+	 * that Omise WooCommerce supported.
+	 *
+	 * @var array
+	 */
+	public static $event_classes = array(
+		'Omise_Event_Charge_Capture',
+		'Omise_Event_Charge_Complete',
+		'Omise_Event_Charge_Create'
+	);
 
-		foreach ( $events as $event ) {
+	public function __construct() {
+		foreach ( self::$event_classes as $event ) {
 			$this->events[ $event::EVENT_NAME ] = $event;
 		}
 	}

--- a/includes/class-omise-queue-runner.php
+++ b/includes/class-omise-queue-runner.php
@@ -1,0 +1,22 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 4.0
+ */
+class Omise_Queue_Runner {
+	public static function execute_webhook_event_handler( $event_key, $data, $attempt ) {
+		$events = array();
+		foreach ( Omise_Events::$event_classes as $event ) {
+			$events[ $event::EVENT_NAME ] = $event;
+		}
+
+		$event          = new $events[ $event_key ]( unserialize( $data ) );
+		$event->attempt = $attempt;
+
+		if ( $event->validate() ) {
+			$event->resolve();
+		}
+	}
+}

--- a/includes/class-omise-queueable.php
+++ b/includes/class-omise-queueable.php
@@ -1,0 +1,33 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 4.0
+ */
+class Omise_Queueable {
+    /**
+     * @var int
+     */
+    public $attempt = 0;
+
+    /**
+     * @var int
+     */
+    public $attempt_limit = 3;
+
+    /**
+     * @var int
+     */
+    public $adding_time = 5;
+
+    public function schedule_single( $schedule_action, $data, $schedule_group ) {
+        $schedule_time   = time() + $this->adding_time;
+        $data['attempt'] = ++$this->attempt;
+        WC()->queue()->schedule_single( $schedule_time, $schedule_action, $data, $schedule_group );
+    }
+
+    public function is_attempt_limit_exceeded() {
+        return $this->attempt > $this->attempt_limit;
+    }
+}

--- a/includes/class-omise-rest-webhooks-controller.php
+++ b/includes/class-omise-rest-webhooks-controller.php
@@ -42,14 +42,14 @@ class Omise_Rest_Webhooks_Controller {
 			return new WP_Error( 'omise_rest_wrong_header', __( 'Wrong header type.', 'omise' ), array( 'status' => 400 ) );
 		}
 
-		$body = json_decode( $request->get_body() );
+		$body = json_decode( $request->get_body(), true );
 
-		if ( 'event' !== $body->object ) {
+		if ( 'event' !== $body['object'] ) {
 			return new WP_Error( 'omise_rest_wrong_object', __( 'Wrong object type.', 'omise' ), array( 'status' => 400 ) );
 		}
 
 		$event = new Omise_Events;
-		$event = $event->handle( $body->key, $body->data );
+		$event = $event->handle( $body['key'], $body['data'] );
 
 		return rest_ensure_response( $event );
 	}

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -1,82 +1,39 @@
 <?php
-defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 
-if ( class_exists( 'Omise_Event_Charge_Capture' ) ) {
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 
-class Omise_Event_Charge_Capture {
+/**
+ * There are several cases that can trigger the 'charge.capture' event.
+ *
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * Credit Card
+ * charge data in payload will be:
+ *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+ *
+ */
+class Omise_Event_Charge_Capture extends Omise_Event {
 	/**
 	 * @var string  of an event name.
 	 */
-	public $event = 'charge.capture';
+	const EVENT_NAME = 'charge.capture';
 
 	/**
-	 * There are several cases that can trigger the 'charge.capture' event.
-	 *
-	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-	 * Credit Card
-	 * charge data in payload will be:
-	 *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
-	 *
-	 * @param  mixed $data
-	 *
-	 * @return void
+	 * @inheritdoc
 	 */
-	public function handle( $data ) {
-		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
-			return;
+	public function validate() {
+		if ( 'charge' !== $this->data['object'] || ! isset( $this->data['metadata']['order_id'] ) ) {
+			return false;
 		}
 
-		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
-			return;
+		if ( ! $this->order = wc_get_order( $this->data['metadata']['order_id'] ) ) {
+			return false;
 		}
 
-		$order->add_order_note(
-			__(
-				'Omise: an event charge.capture has been caught (webhook).',
-				'omise'
-			)
-		);
-
-		switch ($data['status']) {
-			case 'successful':
-				if ( $data['authorized'] && $data['paid'] ) {
-					$order->add_order_note(
-						sprintf(
-							wp_kses(
-								__( 'Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid', 'omise' ),
-								array( 'br' => array() )
-							),
-							$order->get_total(),
-							$order->get_order_currency()
-						)
-					);
-
-					$order->payment_complete( $data['id'] );
-				}
-
-				break;
-			
-			default:
-				$order->add_order_note(
-					wp_kses(
-						__( 'Omise: Payment invalid.<br/>There was something wrong in the Webhook payload. Please contact Omise support team to investigate further.', 'omise' ),
-						array( 'br' => array() )
-					)
-				);
-
-				break;
+		// Making sure that an event's charge id is identical with an order transaction id.
+		if ( $this->order->get_transaction_id() !== $this->data['id'] ) {
+			return false;
 		}
 
-		/**
-		 * Hook after Omise handle an event from webhook.
-		 *
-		 * @param WC_Order $order  an order object.
-		 * @param mixed $data      a data of an event object
-		 */
-		do_action( 'omise_handled_event_charge_capture', $order, $data );
-
-		return;
+		return true;
 	}
 }

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -36,4 +36,49 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 
 		return true;
 	}
+
+	/**
+	 * This `charge.capture` event is only being used
+	 * to catch a manual-capture action that happens on 'Omise Dashboard'.
+	 * For on-store capture, it will be handled by Omise_Payment_Creditcard::process_capture.
+	 */
+	public function resolve() {
+		$this->order->add_order_note( __( 'Omise: Received charge.capture webhook event.', 'omise' ) );
+
+		switch ( $this->data['status'] ) {
+			case 'failed':
+				if ( $this->order->has_status( 'failed' ) ) {
+					return;
+				}
+
+				$message         = __( 'Omise: Payment failed.<br/>%s', 'omise' );
+				$failure_message = $this->data['failure_message'] . ' (code: ' . $this->data['failure_code'] . ')';
+				$this->order->add_order_note(
+					sprintf(
+						wp_kses( $message, array( 'br' => array() ) ),
+						$failure_message
+					)
+				);
+				$this->order->update_status( 'failed' );
+				break;
+
+			case 'successful':
+				$message = __( 'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
+
+				$this->order->add_order_note(
+					sprintf(
+						wp_kses( $message, array( 'br' => array() ) ),
+						$this->order->get_total(),
+						$this->order->get_currency()
+					)
+				);
+
+				if ( ! $this->order->has_status( 'processing' ) ) {
+					$this->order->update_status( 'processing' );
+				}
+			break;
+		}
+
+		return;
+	}
 }

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -24,11 +24,11 @@ class Omise_Event_Charge_Capture {
 	 * @return void
 	 */
 	public function handle( $data ) {
-		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
-		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
@@ -39,9 +39,9 @@ class Omise_Event_Charge_Capture {
 			)
 		);
 
-		switch ($data->status) {
+		switch ($data['status']) {
 			case 'successful':
-				if ( $data->authorized && $data->paid ) {
+				if ( $data['authorized'] && $data['paid'] ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(
@@ -53,7 +53,7 @@ class Omise_Event_Charge_Capture {
 						)
 					);
 
-					$order->payment_complete( $data->id );
+					$order->payment_complete( $data['id'] );
 				}
 
 				break;

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -1,15 +1,32 @@
 <?php
-defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 
-if ( class_exists( 'Omise_Event_Charge_Complete' ) ) {
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 
-class Omise_Event_Charge_Complete {
+class Omise_Event_Charge_Complete extends Omise_Event {
 	/**
 	 * @var string  of an event name.
 	 */
-	public $event = 'charge.complete';
+	const EVENT_NAME = 'charge.complete';
+
+	/**
+	 * @inheritdoc
+	 */
+	public function validate() {
+		if ( 'charge' !== $this->data['object'] || ! isset( $this->data['metadata']['order_id'] ) ) {
+			return false;
+		}
+
+		if ( ! $this->order = wc_get_order( $this->data['metadata']['order_id'] ) ) {
+			return false;
+		}
+
+		// Making sure that an event's charge id is identical with an order transaction id.
+		if ( $this->order->get_transaction_id() !== $this->data['id'] ) {
+			return false;
+		}
+
+		return true;
+	}
 
 	/**
 	 * There are several cases with the following payment methods
@@ -43,77 +60,54 @@ class Omise_Event_Charge_Complete {
 	 *
 	 * @return void
 	 */
-	public function handle( $data ) {
-		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
-			return;
-		}
+	public function resolve() {
+		$this->order->add_order_note( __( 'Omise: Received charge.complete webhook event.', 'omise' ) );
 
-		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
-			return;
-		}
-
-		// Making sure that an event's charge id is identical with an order transaction id.
-		if ( $order->get_transaction_id() !== $data['id'] ) {
-			return;
-		}
-
-		$order->add_order_note(
-			__(
-				'Omise: an event charge.complete has been caught (webhook).',
-				'omise'
-			)
-		);
-
-		switch ($data['status']) {
+		switch ( $this->data['status'] ) {
 			case 'failed':
-				$order->add_order_note(
+				if ( $this->order->has_status( 'failed' ) ) {
+					return;
+				}
+
+				$message         = __( 'Omise: Payment failed.<br/>%s', 'omise' );
+				$failure_message = $this->data['failure_message'] . ' (code: ' . $this->data['failure_code'] . ')';
+				$this->order->add_order_note(
 					sprintf(
-						wp_kses(
-							__( 'Omise: Payment failed.<br/>%s', 'omise' ),
-							array( 'br' => array() )
-						),
-						$data['failure_message'] . ' (code: ' . $data['failure_code'] . ')'
+						wp_kses( $message, array( 'br' => array() ) ),
+						$failure_message
 					)
 				);
-
-				$order->update_status( 'failed' );
+				$this->order->update_status( 'failed' );
 				break;
 
 			case 'successful':
-				if ( $data['authorized'] && $data['paid'] ) {
-					$order->add_order_note(
-						sprintf(
-							wp_kses(
-								__( 'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' ),
-								array( 'br' => array() )
-							),
-							$order->get_total(),
-							$order->get_order_currency()
-						)
-					);
-
-					$order->payment_complete( $data['id'] );
+				if ( $this->order->has_status( 'processing' ) ) {
+					return;
 				}
+
+				$message = __( 'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
+
+				$this->order->add_order_note(
+					sprintf(
+						wp_kses( $message, array( 'br' => array() ) ),
+						$this->order->get_total(),
+						$this->order->get_currency()
+					)
+				);
+				$this->order->payment_complete();
 				break;
 			
 			case 'pending':
+				if ( $this->order->has_status( 'processing' ) ) {
+					return;
+				}
+
 				// Credit Card 3-D Secure with 'authorize only' payment action case.
-				if ( $data['authorized'] ) {
-					$order->update_status( 'processing' );
+				if ( $this->data['authorized'] ) {
+					$this->order->update_status( 'processing' );
 				}
 				break;
-
-			default:
-				break;
 		}
-
-		/**
-		 * Hook after Omise handle an event from webhook.
-		 *
-		 * @param WC_Order $order  an order object.
-		 * @param mixed $data      a data of an event object
-		 */
-		do_action( 'omise_handled_event_charge_complete', $order, $data );
 
 		return;
 	}

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -44,16 +44,16 @@ class Omise_Event_Charge_Complete {
 	 * @return void
 	 */
 	public function handle( $data ) {
-		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
-		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
 		// Making sure that an event's charge id is identical with an order transaction id.
-		if ( $order->get_transaction_id() !== $data->id ) {
+		if ( $order->get_transaction_id() !== $data['id'] ) {
 			return;
 		}
 
@@ -64,7 +64,7 @@ class Omise_Event_Charge_Complete {
 			)
 		);
 
-		switch ($data->status) {
+		switch ($data['status']) {
 			case 'failed':
 				$order->add_order_note(
 					sprintf(
@@ -72,7 +72,7 @@ class Omise_Event_Charge_Complete {
 							__( 'Omise: Payment failed.<br/>%s', 'omise' ),
 							array( 'br' => array() )
 						),
-						$data->failure_message . ' (code: ' . $data->failure_code . ')'
+						$data['failure_message'] . ' (code: ' . $data['failure_code'] . ')'
 					)
 				);
 
@@ -80,7 +80,7 @@ class Omise_Event_Charge_Complete {
 				break;
 
 			case 'successful':
-				if ( $data->authorized && $data->paid ) {
+				if ( $data['authorized'] && $data['paid'] ) {
 					$order->add_order_note(
 						sprintf(
 							wp_kses(
@@ -92,13 +92,13 @@ class Omise_Event_Charge_Complete {
 						)
 					);
 
-					$order->payment_complete( $data->id );
+					$order->payment_complete( $data['id'] );
 				}
 				break;
 			
 			case 'pending':
 				// Credit Card 3-D Secure with 'authorize only' payment action case.
-				if ( $data->authorized ) {
+				if ( $data['authorized'] ) {
 					$order->update_status( 'processing' );
 				}
 				break;

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -33,7 +33,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 			return true;
 		}
 
-		$schedule_action = 'omise_async_event_charge_complete';
+		$schedule_action = 'omise_async_webhook_event_handler';
 		$schedule_group  = 'omise_async_webhook';
 		$data            = array( 'key' => self::EVENT_NAME, 'data' => serialize( $this->data ) );
 		$this->schedule_single( $schedule_action, $data, $schedule_group );

--- a/includes/events/class-omise-event-charge-create.php
+++ b/includes/events/class-omise-event-charge-create.php
@@ -1,88 +1,68 @@
 <?php
-defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 
-if ( class_exists( 'Omise_Event_Charge_Create' ) ) {
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 
-class Omise_Event_Charge_Create {
+/**
+ * There are several cases when make a new charge with the following
+ * payment methods that would trigger the 'charge.create' event.
+ *
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * Alipay
+ * charge data in payload:
+ *     [status: 'pending' (always)], [authorized: 'false' (always)]
+ *
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * Internet Banking
+ * charge data in payload:
+ *     [status: 'pending' (always)], [authorized: 'false' (always)]
+ *
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * Credit Card (none 3-D Secure)
+ * CAPTURE = FALSE
+ * charge data in payload could be one of these sets:
+ *     [status: 'pending'], [authorized: 'true'], [paid: 'false']
+ *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+ *
+ * CAPTURE = TRUE
+ * charge data in payload could be one of these sets:
+ *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+ *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+ *
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * Credit Card (3-D Secure)
+ * CAPTURE = FALSE
+ * charge data in payload could be one of these sets:
+ *     [status: 'pending'], [authorized: 'false'], [paid: 'false']
+ *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+ *
+ * CAPTURE = TRUE
+ * charge data in payload could be one of these sets:
+ *     [status: 'pending'], [authorized: 'false'], [paid: 'false']
+ *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+ */
+class Omise_Event_Charge_Create extends Omise_Event {
 	/**
 	 * @var string  of an event name.
 	 */
-	public $event = 'charge.create';
+	const EVENT_NAME = 'charge.create';
 
 	/**
-	 * There are several cases when make a new charge with the following
-	 * payment methods that would trigger the 'charge.create' event.
-	 *
-	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-	 * Alipay
-	 * charge data in payload:
-	 *     [status: 'pending' (always)], [authorized: 'false' (always)]
-	 *
-	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-	 * Internet Banking
-	 * charge data in payload:
-	 *     [status: 'pending' (always)], [authorized: 'false' (always)]
-	 *
-	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-	 * Credit Card (none 3-D Secure)
-	 * CAPTURE = FALSE
-	 * charge data in payload could be one of these sets:
-	 *     [status: 'pending'], [authorized: 'true'], [paid: 'false']
-	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
-	 *
-	 * CAPTURE = TRUE
-	 * charge data in payload could be one of these sets:
-	 *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
-	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
-	 *
-	 * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-	 * Credit Card (3-D Secure)
-	 * CAPTURE = FALSE
-	 * charge data in payload could be one of these sets:
-	 *     [status: 'pending'], [authorized: 'false'], [paid: 'false']
-	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
-	 *
-	 * CAPTURE = TRUE
-	 * charge data in payload could be one of these sets:
-	 *     [status: 'pending'], [authorized: 'false'], [paid: 'false']
-	 *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
-	 *
-	 * @param  mixed $data
-	 *
-	 * @return void
+	 * @inheritdoc
 	 */
-	public function handle( $data ) {
-		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
-			return;
+	public function validate() {
+		if ( 'charge' !== $this->data['object'] || ! isset( $this->data['metadata']['order_id'] ) ) {
+			return false;
 		}
 
-		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
-			return;
+		if ( ! $this->order = wc_get_order( $this->data['metadata']['order_id'] ) ) {
+			return false;
 		}
 
-		$order->add_order_note(
-			__(
-				'Omise: an event charge.create has been caught (webhook).',
-				'omise'
-			)
-		);
+		// Making sure that an event's charge id is identical with an order transaction id.
+		if ( $this->order->get_transaction_id() !== $this->data['id'] ) {
+			return false;
+		}
 
-		/** 
-		 * Note. There is no special case for 'charge.create' event to handle with.
-		 *       Basically, just to pass this event in case some 3rd-party developer
-		 *       need to add extra process, then they can hook 'omise_handled_event_charge_create' action.
-		 */
-
-		/**
-		 * Hook after Omise handle an event from webhook.
-		 *
-		 * @param WC_Order $order  an order object.
-		 * @param mixed $data      a data of an event object
-		 */
-		do_action( 'omise_handled_event_charge_create', $order, $data );
-
-		return;
+		return true;
 	}
 }

--- a/includes/events/class-omise-event-charge-create.php
+++ b/includes/events/class-omise-event-charge-create.php
@@ -54,11 +54,11 @@ class Omise_Event_Charge_Create {
 	 * @return void
 	 */
 	public function handle( $data ) {
-		if ( 'charge' !== $data->object || ! isset( $data->metadata->order_id ) ) {
+		if ( 'charge' !== $data['object'] || ! isset( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 
-		if ( ! $order = wc_get_order( $data->metadata->order_id ) ) {
+		if ( ! $order = wc_get_order( $data['metadata']['order_id'] ) ) {
 			return;
 		}
 

--- a/includes/events/class-omise-event.php
+++ b/includes/events/class-omise-event.php
@@ -2,7 +2,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-class Omise_Event {
+class Omise_Event extends Omise_Queueable {
 	/**
 	 * @var array  of Omise event's payload.
 	 */

--- a/includes/events/class-omise-event.php
+++ b/includes/events/class-omise-event.php
@@ -2,6 +2,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * @since 4.0
+ */
 class Omise_Event extends Omise_Queueable {
 	/**
 	 * @var array  of Omise event's payload.

--- a/includes/events/class-omise-event.php
+++ b/includes/events/class-omise-event.php
@@ -1,0 +1,47 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+class Omise_Event {
+	/**
+	 * @var array  of Omise event's payload.
+	 */
+	protected $data;
+
+	/**
+	 * @var \WC_Abstract_Order
+	 */
+	protected $order;
+
+	public function __construct( $data ) {
+		$this->data = $data;
+	}
+	
+	/**
+	 * @return boolean
+	 */
+	public function validate() {
+		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function resolve() {
+		return true;
+	}
+
+	/**
+	 * @return array  of Omise event's payload.
+	 */
+	public function get_data() {
+		return $this->data;
+	}
+
+	/**
+	 * @return \WC_Abstract_Order
+	 */
+	public function get_order() {
+		return $this->order;
+	}
+}

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -187,6 +187,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		}
 
 		$order->add_order_note( sprintf( __( 'Omise: Processing a payment with %s', 'omise' ), $this->method_title ) );
+		$order->update_meta_data( 'is_omise_payment_resolved', 'no' );
 
 		try {
 			$charge = $this->charge( $order_id, $order );

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -188,6 +188,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 
 		$order->add_order_note( sprintf( __( 'Omise: Processing a payment with %s', 'omise' ), $this->method_title ) );
 		$order->add_meta_data( 'is_omise_payment_resolved', 'no', true );
+		$order->save();
 
 		try {
 			$charge = $this->charge( $order_id, $order );

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -187,7 +187,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		}
 
 		$order->add_order_note( sprintf( __( 'Omise: Processing a payment with %s', 'omise' ), $this->method_title ) );
-		$order->update_meta_data( 'is_omise_payment_resolved', 'no' );
+		$order->add_meta_data( 'is_omise_payment_resolved', 'no', true );
 
 		try {
 			$charge = $this->charge( $order_id, $order );

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -188,7 +188,7 @@ class Omise {
 	 * @since  4.0
 	 */
 	public function register_hooks() {
-		add_action( 'omise_async_event_charge_complete', 'Omise_Queue_Runner::execute_webhook_event_handler', 10, 3 );
+		add_action( 'omise_async_webhook_event_handler', 'Omise_Queue_Runner::execute_webhook_event_handler', 10, 3 );
 	}
 
 	/**

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -118,6 +118,7 @@ class Omise {
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/backends/class-omise-backend-installment.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-charge.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-card-image.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-capture.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-complete.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/events/class-omise-event-charge-create.php';

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -76,6 +76,7 @@ class Omise {
 		$this->init_admin();
 		$this->init_route();
 		$this->register_payment_methods();
+		$this->register_hooks();
 
 		prepare_omise_myaccount_panel();
 	}
@@ -114,6 +115,8 @@ class Omise {
 	private function include_classes() {
 		defined( 'OMISE_WOOCOMMERCE_PLUGIN_PATH' ) || define( 'OMISE_WOOCOMMERCE_PLUGIN_PATH', __DIR__ );
 
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-queue-runner.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-queueable.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/backends/class-omise-backend.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/backends/class-omise-backend-installment.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/classes/class-omise-charge.php';
@@ -179,6 +182,13 @@ class Omise {
 		add_filter( 'woocommerce_payment_gateways', function( $methods ) {
 			return array_merge( $methods, $this->payment_methods() );
 		} );
+	}
+
+	/**
+	 * @since  4.0
+	 */
+	public function register_hooks() {
+		add_action( 'omise_async_event_charge_complete', 'Omise_Queue_Runner::execute_webhook_event_handler', 10, 3 );
 	}
 
 	/**


### PR DESCRIPTION
## 1. Objective

In a race-condition where Omise Webhook is fired at the same time as buyer returns to the Callback URI (`return_uri`). A particular WooCommerce Order object will get updated its status twice which creates a consequence of a confirmation email is being sent to the recipient twice causing a confusion in a business flow that rely on this particular email.

<img width="1552" alt="Screen Shot 2563-07-15 at 01 52 59 copy" src="https://user-images.githubusercontent.com/2154669/87465191-6dc32900-c63e-11ea-86c1-d7d6d9218c2c.png">

This happens because at the moment where Omise Webhook and Callback URI are triggered asynchronously at the same time, they both retrieve WC Order object with the `pending` status and update it to `processing` using `WC_Order::payment_complete()`, which triggers an email function to be executed twice. 

This pull request is providing a solution to prevent the async request from creating a race-condition, by refactoring Event Handlers to make the code support for the Queue worker system in case if the race-condition happened.

**Related information**:
Related issue(s): T22125 (internal ticket)

## 2. Description of change


## 3. Quality assurance


**🔧 Environments:**

- **WooCommerce**: v4.2.2.
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3.

**✏️ Details:**



## 4. Impact of the change

There is a limitation of concurrent that `Action Scheduler` library can handle.
Please check the following document as reference: https://actionscheduler.org/perf

> **Action Scheduler will only process actions in a request until:**
> • 90% of available memory is used
> • processing another 3 actions would exceed 30 seconds of total request time, based on the average processing time for the current batch
> • in a single concurrent queue

Also

> By default, Action Scheduler will only process actions for a maximum of 30 seconds in each request. This time limit minimises the risk of a script timeout on unknown hosting environments, some of which enforce 30 second timeouts.

> By default, Action Scheduler will claim a batch of 25 actions. This small batch size is because the default time limit is only 30 seconds; however, if you know your actions are processing very quickly, e.g. taking microseconds not seconds, or that you have more than 30 second available to process each batch, increasing the batch size can slightly improve performance.

> By default, Action Scheduler will run only one concurrent batches of actions. This is to prevent consuming a lot of available connections or processes on your webserver.

However, it shall not effect to its capability to handle the queue. Just for some high-volume transaction per minute website, it may take some seconds or minutes until all the queue get executed. 

As stated in WP-Cron: https://developer.wordpress.org/plugins/cron/#what-is-wp-cron

## 5. Priority of change

Immediate.

## 6. Additional Notes

Just to clarify the relationship between 3 names.
- **WooCommerce** integrated **Action Scheduler** library in the project
- **Action Scheduler** is designed to work with **WP-Cron**
- **WP-Cron** is a default built-in Cron worker that WordPress provided.

However, there is one point that we should understand of WP-Cron behaviour, to understand how the WC_Queue work.
As stated in WP-Cron document: https://developer.wordpress.org/plugins/cron/#what-is-wp-cron
> **WP-Cron** works by checking, on every page load, a list of scheduled tasks to see what needs to be run. Any tasks due to run will be called during that page load.

> **WP-Cron** does not run constantly as the system cron does; it is only triggered on page load.

> With the system scheduler, if the time passes and the task did not run, it will not be re-attempted. With WP-Cron, all scheduled tasks are put into a queue and will run at the next opportunity (meaning the next page load). So while you can’t be 100% sure when your task will run, you can be 100% sure that it will run eventually.

The WP-Cron is only working when "any" of page get loaded. It's not time-based as a typical system scheduler.
Meaning that, even though we set some schedule to be executed after "5" mins, but if there is no one open "any" page of the WordPress website, then that schedule won't be triggered. 
