### PR TITLE
Credit Card payment, updating order status to 'processing' for successful 'auth-only' payment.

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -116,6 +116,7 @@ class Omise_Callback {
 					$this->order->get_order_currency()
 				)
 			);
+			$this->order->payment_complete();
 
 			// Remove cart
 			WC()->cart->empty_cart();

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -299,6 +299,7 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 								$order->get_order_currency()
 							)
 						);
+						$order->payment_complete();
 					}
 
 					break;
@@ -306,7 +307,6 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 				case self::PAYMENT_ACTION_AUTHORIZE_CAPTURE:
 					$success = Omise_Charge::is_paid( $charge );
 					if ( $success ) {
-						$order->payment_complete();
 						$order->add_order_note(
 							sprintf(
 								wp_kses(
@@ -317,6 +317,7 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 								$order->get_order_currency()
 							)
 						);
+						$order->payment_complete();
 					}
 
 					break;


### PR DESCRIPTION
### 1. Objective

At the moment, the plugin will leave the order status as `pending payment` for a successful 'auth-only' Credit Card payment method. As the original idea, we were assuming that the `authorized` charge status (`charge.authorized=true`, `charge.paid=false`, `charge.status=pending`) is equal as WooCommerce Order pending payment status. 

However, as researched. It's more correct behaviour to update WC Order status to `processing` for those authorised-charges instead of leaving it as `pending payment`.

### 2. Description of change

Executing `WC_Order::payment_complete()` right at the moment when the charge transaction has authorized (`charge.authorized=true`, `charge.paid=false`, `charge.status=pending`)

### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3.0
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3.

**✏️ Details:**

1. Making sure that the WC Order status will be updated to `processing` if placing order using Credit Card payment method with `auth-only` action.
<img width="1552" alt="processing-001" src="https://user-images.githubusercontent.com/2154669/87910412-2d2b3b80-ca94-11ea-8280-3f6d7faa92dd.png">

2. There is a change on `auto-capture`. This simply just to re-order the order-note messages so the 
> Omise: Payment successful.
> An amount of {amount} {currency} has been paid

will come first before
> Order status changed from Pending payment to Processing.

<img width="1552" alt="processing-002" src="https://user-images.githubusercontent.com/2154669/87910637-84311080-ca94-11ea-941c-03def4dbadb1.png">


#### 4. Impact of the change

The order flow will be changed.

However, as we are in a stage of releasing a major version, I think it is a good time to correct it from the beginning.

### 5. Priority of change

Normal

### 6. Additional Notes

None