### PR TITLE
Manual Sync, handling more cases: 'expired', 'refunded', 'reversed'.

### DIFF
--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -385,7 +385,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			}
 		} catch ( Exception $e ) {
 			$message = wp_kses(
-				__( 'Omise: Sync failed (manual sync).<br/>%s (manual sync).', 'omise' ),
+				__( 'Omise: Sync failed (manual sync).<br/>%s.', 'omise' ),
 				array( 'br' => array() )
 			);
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -314,7 +314,9 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 
 			switch ( $charge['status'] ) {
 				case self::STATUS_SUCCESSFUL:
-					if ( $charge['funding_amount'] == $charge['refunded_amount'] ) {
+					// Omise API 2017-11-02 uses `refunded`, Omise API 2019-05-29 uses `refunded_amount`.
+					$refunded_amount = isset( $charge['refunded_amount'] ) ? $charge['refunded_amount'] : $charge['refunded'];
+					if ( $charge['funding_amount'] == $refunded_amount ) {
 						$message = wp_kses( __(
 							'Omise: Payment refunded.<br/>An amount %1$s %2$s has been refunded (manual sync).', 'omise' ),
 							array( 'br' => array() )

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -317,15 +317,15 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 					// Omise API 2017-11-02 uses `refunded`, Omise API 2019-05-29 uses `refunded_amount`.
 					$refunded_amount = isset( $charge['refunded_amount'] ) ? $charge['refunded_amount'] : $charge['refunded'];
 					if ( $charge['funding_amount'] == $refunded_amount ) {
+						if ( ! $this->order()->has_status( 'refunded' ) ) {
+							$this->order()->update_status( 'refunded' );
+						}
+
 						$message = wp_kses( __(
 							'Omise: Payment refunded.<br/>An amount %1$s %2$s has been refunded (manual sync).', 'omise' ),
 							array( 'br' => array() )
 						);
 						$this->order()->add_order_note( sprintf( $message, $this->order()->get_total(), $this->order()->get_currency() ) );
-
-						if ( ! $this->order()->has_status( 'refunded' ) ) {
-							$this->order()->update_status( 'refunded' );
-						}
 					} else {
 						$message = wp_kses( __(
 							'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync).', 'omise' ),


### PR DESCRIPTION
## 1. Objective

There are some cases that the manual-sync feature at the moment cannot handle (expired, refunded, reversed).
This pull request is providing am improvement of this feature.

**Related information**:
Related issue(s): T18954 (internal ticket), T22392 (internal ticket), T22486 (internal ticket)

## 2. Description of change

Note, the change has been accidentally rebased and merged to the `master` branch within the prior pull request: #182, **"Cleaning up code style & indentation"**, commit: https://github.com/omise/omise-woocommerce/pull/182/commits/864eb4e2069e855f1ccd2fd219e12c49c7deb238

This pull request is to write a test to cover all possible cases, and to re-review (if possible) the change.
(Please check the core-actual change from this commit: https://github.com/omise/omise-woocommerce/pull/182/commits/864eb4e2069e855f1ccd2fd219e12c49c7deb238)

## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3.0
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3

**✏️ Details:**

From this change, the manual-sync feature will be supporting for 6 different cases as the following:
`successful`, `failed`, `pending`, `refunded`, `expired`, `reversed`.

In this section, we will be testing all the 6 cases.
To prepare for the test, you may make sure that the Webhook endpoint has not been set to Omise Account in order to test for the manual sync.

#### Pending

The pending case will happen only when the `charge.status` = `pending`.
The plugin will "only" add an order note saying that payment is still in progress.

Reference: https://github.com/omise/omise-woocommerce/pull/182/commits/864eb4e2069e855f1ccd2fd219e12c49c7deb238#diff-b2a67ad6a97418df7dddcefcfc2a5319R352-R360

<img width="1552" alt="pending" src="https://user-images.githubusercontent.com/2154669/89173421-71e3c600-d5ae-11ea-9081-478f36112632.png">


#### Successful

If `charge.status` = `successful` and `charge.funding_amount` != `charge.refunded_amount`, then the plugin will add a new order note saying that the payment is successful. Also update the Order status to `processing` if it hasn't already.

Reference: https://github.com/omise/omise-woocommerce/pull/182/commits/864eb4e2069e855f1ccd2fd219e12c49c7deb238#diff-b2a67ad6a97418df7dddcefcfc2a5319R328-R338

<img width="1552" alt="successful" src="https://user-images.githubusercontent.com/2154669/89173468-83c56900-d5ae-11ea-8bdf-e90e64ae568f.png">

#### Manual Capture
Manual capture will give the same result as **Successful** case above.
<img width="1552" alt="capture" src="https://user-images.githubusercontent.com/2154669/89174421-06025d00-d5b0-11ea-9763-2fa1e728f8f1.png">

#### Failed

The plugin will add a new order note to inform that the payment is failed.
As well, if not already then the plugin will update Order status to `failed`.

Reference: https://github.com/omise/omise-woocommerce/pull/182/commits/864eb4e2069e855f1ccd2fd219e12c49c7deb238#diff-b2a67ad6a97418df7dddcefcfc2a5319R340-R350

<img width="1552" alt="failed" src="https://user-images.githubusercontent.com/2154669/89173337-4d87e980-d5ae-11ea-86cf-6dbb241ca870.png">

#### Refunded

Reference: https://github.com/omise/omise-woocommerce/commit/864eb4e2069e855f1ccd2fd219e12c49c7deb238?branch=864eb4e2069e855f1ccd2fd219e12c49c7deb238&diff=split#diff-b2a67ad6a97418df7dddcefcfc2a5319R317-R326

<img width="1552" alt="refund" src="https://user-images.githubusercontent.com/2154669/89175359-d3596400-d5b1-11ea-9b7b-8e8881fd6add.png">
<img width="1552" alt="refund-2" src="https://user-images.githubusercontent.com/2154669/89175376-d9e7db80-d5b1-11ea-8892-cd3e5f7c7a99.png">

#### Reversed

In case of reversed-charge, the plugin will add a new order note to inform so, and if not already, then Order status will be marked as `cancelled`.
Reference: https://github.com/omise/omise-woocommerce/pull/182/commits/864eb4e2069e855f1ccd2fd219e12c49c7deb238#diff-b2a67ad6a97418df7dddcefcfc2a5319R371-R378

<img width="1552" alt="reversed" src="https://user-images.githubusercontent.com/2154669/89175541-26cbb200-d5b2-11ea-9327-46f02ad25f1f.png">

#### Expired

To test expired transaction, you may modify the charge.status result at the core code to simulate the response from Omise Charge API.
At `includes/gateway/class-omise-payment.php::sync_payment()` Line: 314.
You may add the following code above the `switch` condition.

```php
$charge['status'] = self::STATUS_EXPIRED;
```
The case of expired is similar to `reversed`. However, the order note's message is different.
Reference: https://github.com/omise/omise-woocommerce/pull/182/commits/864eb4e2069e855f1ccd2fd219e12c49c7deb238#diff-b2a67ad6a97418df7dddcefcfc2a5319R362-R369

## 4. Impact of the change

None

#### 5. Priority of change

Normal

#### 6. Additional Notes

