### PR TITLE
Bypassing Callback function for Offline payment methods.

### DIFF
--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -46,6 +46,8 @@ abstract class Omise_Payment_Offline extends Omise_Payment {
 
 		if ( self::STATUS_PENDING === $charge['status'] ) {
 			$order->update_status( 'on-hold', sprintf( __( 'Omise: Awaiting %s to be paid.', 'omise' ), $this->title ) );
+			$order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
+			$order->save();
 
 			return array(
 				'result'   => 'success',


### PR DESCRIPTION
## 1. Objective

It seems the 'is_omise_payment_resolved' flag is not working smoothly with Offline payment flow.

For those Credit Card and Offsite payment methods, we have `is_omise_payment_resolved` as an indicator to tell the plugin if a specific Webhook event is needed to be queued (if the store's callback has triggered). However, as Offline has no redirection behaviour after payment, this `is_omise_payment_resolved` will stay as `false` forever.

Event handler flow at the moment:
1). if "Order.is_omise_payment_resolved" is "false"?
2). if Queue.try < 3, queue the event again.
3). Otherwise, bypass the "is_omise_payment_resolved" check to execute Charge.Complete event handler class.

The current flow is working just fine, however increases unnecessary steps to force all the Offline payment webhook to be in Queue as `is_omise_payment_resolved` as in the current, will never be set to `true`.

**Related information**:
Related issue(s): T22534 (internal ticket)

## 2. Description of change

- Immediately flags WC Order, `is_omise_payment_resolved` to `yes` if place a new order with offline payment method.

## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3.1
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3

**✏️ Details:**

To test this, you may try place a new order using one of the offline payment methods that Omise-WooCommerce supports.
Once the order has been placed, `is_omise_payment_resolved` flag will be updated to `yes`.

<img width="1552" alt="Screen Shot 2563-08-06 at 02 16 45" src="https://user-images.githubusercontent.com/2154669/89454523-03a82a80-d78b-11ea-802f-20c981276909.png">

Which, will result in the `charge.complete` webhook event will get executed right after the Omise Webhook event is fired without being put in WC Queue.

<img width="1552" alt="Screen Shot 2563-08-06 at 02 17 55 copy" src="https://user-images.githubusercontent.com/2154669/89454760-5bdf2c80-d78b-11ea-8419-418e3ee4e374.png">


## 4. Impact of the change

None

## 5. Priority of change

Normal

## 6. Additional Notes

None
