### PR TITLE
PayNow, adding a link to the QR code url at the order-confirmation email

### DIFF
--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -94,7 +94,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 					<img src="<?php echo $qrcode; ?>" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
 				</div>
 			</div>
-		<?php elseif ( 'email' === $context ) : ?>
+		<?php elseif ( 'email' === $context && !$order->has_status('failed')) : ?>
 			<p><a href="<?php echo $qrcode; ?>"><?php echo __( 'Click this link to display the QR code', 'omise' ); ?></a></p>
 		<?php endif;
 	}

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -95,7 +95,10 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 				</div>
 			</div>
 		<?php elseif ( 'email' === $context && !$order->has_status('failed')) : ?>
-			<p><a href="<?php echo $qrcode; ?>"><?php echo __( 'Click this link to display the QR code', 'omise' ); ?></a></p>
+			<p>
+				<?php echo __( 'Scan the QR code to complete', 'omise' ); ?>
+			</p>
+			<p><img src="<?php echo $qrcode; ?>"/></p>
 		<?php endif;
 	}
 }


### PR DESCRIPTION
## 1. Objective

Currently when placing an order using PayNow payment method, the QR code will be shown only on the order-received (thank-you) page.

This pull request is adding the QR code's link to the WC order-confirmation email as well.

**Related information**:
Related issue(s): T22531 (internal ticket)

## 2. Description of change

Adding a QR code link to the order-confirmation email when placing a new order using PayNow payment method.

## 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3.0
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3

**✏️ Details:**

An order-confirmation email that is sent by placing a new order using PayNow payment method should contain a link to the PayNow QR code.
<img width="622" alt="Screen Shot 2563-08-18 at 05 03 43" src="https://user-images.githubusercontent.com/2154669/90449012-ba53c580-e110-11ea-8a52-44660f663c5f.png">


## 4. Impact of the change

Nothing

## 5. Priority of change

Normal

## 6. Additional Notes

None