### PR TITLE
Adding permission to callback which helps to removes a warning message on Wordpress 5.5.

### DIFF
--- a/includes/class-omise-rest-webhooks-controller.php
+++ b/includes/class-omise-rest-webhooks-controller.php
@@ -28,6 +28,7 @@ class Omise_Rest_Webhooks_Controller {
 			array(
 				'methods' => WP_REST_Server::EDITABLE,
 				'callback' => array( $this, 'callback' ),
+				'permission_callback' => '__return_true'
 			)
 		);
 	}


### PR DESCRIPTION
#### 1. Objective

Warning messages are shown on Admin backend page regarding rest api once Wordpress version is upgraded to 5.5. This messages are shown on backend page or error logs.

Warning message screenshot (WooCommerce product page):
![wp-warning-message](https://user-images.githubusercontent.com/5526195/91686692-28c06b00-eb88-11ea-8de5-1aa2380a85cd.png)


**Related information**:
Internal Ticket: https://phabricator.omise.co/T22923

#### 2. Description of change

Updated PHP class Omise_Rest_Webhooks_Controller. Added "permission_callback" parameter to register_rest_route() which defines this webhook as Public.

Adding this parameter is required in Wordpress 5.5 and warning message gets removed.

#### 3. Quality assurance

**🔧 Environments:**
- **WooCommerce**: v4.4.1
- **WordPress**: v5.5
- **PHP version**: 7.2.1
- **Omise plugin version**: Omise-WooCommerce 4.1 
**✏️ Details:**

Try to visit admin backend pages this should not display any error message. e.g. Edit Product page.

#### 4. Impact of the change

NA

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA