### PR TITLE
Updating deprecated functions in WooCommerce v3

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -88,7 +88,7 @@ class Omise_Callback {
 			sprintf(
 				wp_kses( $message, array( 'br' => array() ) ),
 				$this->order->get_total(),
-				$this->order->get_order_currency()
+				$this->order->get_currency()
 			)
 		);
 
@@ -116,7 +116,7 @@ class Omise_Callback {
 				sprintf(
 					wp_kses( $message, array( 'br' => array() ) ),
 					$this->order->get_total(),
-					$this->order->get_order_currency()
+					$this->order->get_currency()
 				)
 			);
 			$this->order->payment_complete();

--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -21,7 +21,7 @@ abstract class Omise_Payment_Offline extends Omise_Payment {
 	 */
 	public function charge( $order_id, $order ) {
 		$total    = $order->get_total();
-		$currency = $order->get_order_currency();
+		$currency = $order->get_currency();
 		$metadata = array_merge(
 			apply_filters( 'omise_charge_params_metadata', array(), $order ),
 			array( 'order_id' => $order_id ) // override order_id as a reference for webhook handlers.

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -68,8 +68,8 @@ class Omise_Payment_Alipay extends Omise_Payment_Offsite {
 		);
 
 		return OmiseCharge::create( array(
-			'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
-			'currency'    => $order->get_order_currency(),
+			'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_currency() ),
+			'currency'    => $order->get_currency(),
 			'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 			'source'      => array( 'type' => 'alipay' ),
 			'return_uri'  => $return_uri,

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -232,8 +232,8 @@ class Omise_Payment_Creditcard extends Omise_Payment {
 			home_url()
 		);
 		$data    = array(
-			'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
-			'currency'    => $order->get_order_currency(),
+			'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_currency() ),
+			'currency'    => $order->get_currency(),
 			'description' => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 			'return_uri'  => $return_uri
 		);
@@ -296,7 +296,7 @@ class Omise_Payment_Creditcard extends Omise_Payment {
 								array( 'br' => array() )
 							),
 							$order->get_total(),
-							$order->get_order_currency()
+							$order->get_currency()
 						)
 					);
 					$order->payment_complete();
@@ -314,7 +314,7 @@ class Omise_Payment_Creditcard extends Omise_Payment {
 								array( 'br' => array() )
 							),
 							$order->get_total(),
-							$order->get_order_currency()
+							$order->get_currency()
 						)
 					);
 					$order->payment_complete();
@@ -373,7 +373,7 @@ class Omise_Payment_Creditcard extends Omise_Payment {
 						array( 'br' => array() )
 					),
 					$this->order()->get_total(),
-					$this->order()->get_order_currency()
+					$this->order()->get_currency()
 				)
 			);
 			$this->order()->payment_complete();

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -94,8 +94,8 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 		);
 
 		return OmiseCharge::create( array(
-			'amount'            => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
-			'currency'          => $order->get_order_currency(),
+			'amount'            => Omise_Money::to_subunit( $order->get_total(), $order->get_currency() ),
+			'currency'          => $order->get_currency(),
 			'description'       => apply_filters( 'omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order ),
 			'source'            => array(
 				'type'              => sanitize_text_field( $source_type ),

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -82,8 +82,8 @@ class Omise_Payment_Internetbanking extends Omise_Payment_Offsite {
 		);
 
 		return OmiseCharge::create( array(
-			'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_order_currency() ),
-			'currency'    => $order->get_order_currency(),
+			'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_currency() ),
+			'currency'    => $order->get_currency(),
 			'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
 			'source'      => array( 'type' => sanitize_text_field( $_POST['omise-offsite'] ) ),
 			'return_uri'  => $return_uri,

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -71,7 +71,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite {
 	public function charge( $order_id, $order ) {
 		$phone_number = isset( $_POST['omise_phone_number_default'] ) && 1 == $_POST['omise_phone_number_default'] ? $order->get_billing_phone() : sanitize_text_field( $_POST['omise_phone_number'] );
 		$total        = $order->get_total();
-		$currency     = $order->get_order_currency();
+		$currency     = $order->get_currency();
 		$return_uri   = add_query_arg(
 			array( 'wc-api' => 'omise_truemoney_callback', 'order_id' => $order_id ), home_url()
 		);

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -253,7 +253,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		try {
 			$charge = OmiseCharge::retrieve( $order->get_transaction_id() );
 			$refund = $charge->refunds()->create( array(
-				'amount'   => Omise_Money::to_subunit( $amount, $order->get_order_currency() ),
+				'amount'   => Omise_Money::to_subunit( $amount, $order->get_currency() ),
 				'metadata' => array( 'reason' => sanitize_text_field( $reason ) )
 			) );
 
@@ -264,7 +264,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 						array( 'br' => array() )
 					),
 					$amount,
-					$order->get_order_currency(),
+					$order->get_currency(),
 					$refund['id']
 				);
 			} else {
@@ -274,7 +274,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 						array( 'br' => array() )
 					),
 					$amount,
-					$order->get_order_currency(),
+					$order->get_currency(),
 					$refund['id']
 				);
 			}


### PR DESCRIPTION
#### 1. Objective

This PR is to remove deprecated functions in WooCommerce Version 3 and up.

<img width="710" alt="image" src="https://user-images.githubusercontent.com/5526195/93034737-42bc7c00-f665-11ea-8bc0-02f8ec566263.png">


**Related information**:
Internal Ticket: https://phabricator.omise.co/T23019

#### 2. Description of change

Replaced deprecate function WC_Order::get_order_currency with WC_Order::get_currency in all plugin files.

#### 3. Quality assurance

**🔧 Environments:**
- **WooCommerce**: v4.4.1
- **WordPress**: v5.5.1
- **PHP version**: 7.4.1
- **Omise plugin version**: Omise-WooCommerce 4.1

#### 4. Impact of the change

All payment methods should work normally.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA