### PR TITLE
✨ Releasing Omise-WooCommerce v4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+### [v4.2 _(Sep 15, 2020)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.2)
+
+#### 🚀 Enhancements
+- Removing Gruntfile and package.json as no longer needed grunt-wp-i18n library. (PR [#187](https://github.com/omise/omise-woocommerce/pull/187))
+
+#### 👾 Bug Fixes
+- Updating deprecated functions in WooCommerce v3. (PR [#189](https://github.com/omise/omise-woocommerce/pull/189))
+- Adding permission to callback which helps to removes a warning message on Wordpress 5.5. (PR [#188](https://github.com/omise/omise-woocommerce/pull/188))
+
+---
+
 ### [v4.1 _(Aug 21, 2020)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.1)
 
 #### ✨ Highlights

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     4.1
+ * Version:     4.2
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -18,7 +18,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '4.1';
+	public $version = '4.2';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
-Tested up to: 5.4.2
-Stable tag: 4.1
+Tested up to: 5.5.1
+Stable tag: 4.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,15 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 4.2 =
+
+#### 🚀 Enhancements
+- Removing Gruntfile and package.json as no longer needed grunt-wp-i18n library. (PR [#187](https://github.com/omise/omise-woocommerce/pull/187))
+
+#### 👾 Bug Fixes
+- Updating deprecated functions in WooCommerce v3. (PR [#189](https://github.com/omise/omise-woocommerce/pull/189))
+- Adding permission to callback which helps to removes a warning message on Wordpress 5.5. (PR [#188](https://github.com/omise/omise-woocommerce/pull/188))
 
 = 4.1 =
 


### PR DESCRIPTION
### This release contains 3 PRs as below:

#### 🚀 Enhancements
- Removing Gruntfile and package.json as no longer needed grunt-wp-i18n library. (PR [#187](https://github.com/omise/omise-woocommerce/pull/187))

#### 👾 Bug Fixes
- Updating deprecated functions in WooCommerce v3. (PR [#189](https://github.com/omise/omise-woocommerce/pull/189))
- Adding permission to callback which helps to removes a warning message on Wordpress 5.5. (PR [#188](https://github.com/omise/omise-woocommerce/pull/188))

### Tested on
- WooCommerce: **v4.4.1**
- WordPress: **v5.5.1**
- PHP: **v7.4.2**