### PR TITLE
Add installment SCB support

### DIFF
--- a/includes/backends/class-omise-backend-installment.php
+++ b/includes/backends/class-omise-backend-installment.php
@@ -53,6 +53,13 @@ class Omise_Backend_Installment extends Omise_Backend {
 				'interest_rate'      => 0.65,
 				'min_allowed_amount' => 500.00,
 			),
+
+			'installment_scb' => array(
+				'bank_code'          => 'scb',
+				'title'              => __( 'Siam Commercial Bank', 'omise' ),
+				'interest_rate'      => 0.74,
+				'min_allowed_amount' => 500.00,
+			),
 		);
 	}
 

--- a/tests/unit/includes/backends/class-omise-backend-installment-test.php
+++ b/tests/unit/includes/backends/class-omise-backend-installment-test.php
@@ -11,6 +11,25 @@ class Omise_Backend_Installment_Test extends TestCase {
 	/**
 	 * @test
 	 */
+	public function get_only_valid_plans_from_given_scb_allowed_installment_terms() {
+		$installment_backend = new Omise_Backend_Installment();
+		$purchase_amount     = 2000.00;
+		$allowed_terms       = array( 3, 4, 6, 8, 10 );
+		$interest_rate       = 0.74;
+		$min_allowed_amount  = 500.00;
+
+		$result = $installment_backend->get_available_plans( $purchase_amount, $allowed_terms, $interest_rate, $min_allowed_amount );
+
+		$this->assertEquals( 2, count( $result ) );
+		$this->assertEquals( array(
+			array( 'term_length' => 3, 'monthly_amount' => 681.47 ),
+			array( 'term_length' => 4, 'monthly_amount' => 514.80 ),
+		), $result );
+	}
+
+	/**
+	 * @test
+	 */
 	public function get_only_valid_plans_from_given_bbl_allowed_installment_terms() {
 		$installment_backend = new Omise_Backend_Installment();
 		$purchase_amount     = 3000.00;
@@ -88,6 +107,20 @@ class Omise_Backend_Installment_Test extends TestCase {
 		$result = $installment_backend->calculate_monthly_payment_amount( $purchase_amount, $term, $interest_rate );
 
 		$this->assertEquals( 540.00, $result );
+	}
+
+	/**
+	 * @test
+	 */
+	public function correctly_calculating_monthly_payment_amount_as_buyer_absorbs_case_4() {
+		$installment_backend = new Omise_Backend_Installment();
+		$purchase_amount     = 3000.00;
+		$term                = 4;
+		$interest_rate       = 0.74;
+
+		$result = $installment_backend->calculate_monthly_payment_amount( $purchase_amount, $term, $interest_rate );
+
+		$this->assertEquals( 772.20, $result );
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

Add installment SCB support

#### 2. Description of change

- Added installment SCB to backends

#### 3. Quality assurance

**Works with Omise core#6704**

Test both test and live charges, make sure Installment SCB can be selected on checkout page:

<img width="679" alt="Screen Shot 2020-10-08 at 17 41 09" src="https://user-images.githubusercontent.com/34070466/95442211-aea4b280-098d-11eb-8ad5-3233a38f7b79.png">

Test result:

<img width="871" alt="Screen Shot 2020-10-09 at 14 55 20" src="https://user-images.githubusercontent.com/34070466/95553167-9346af80-0a40-11eb-92e7-b4e55affbde9.png">


#### 4. Impact of the change

Supports installment SCB.

#### 5. Priority of change

High.

#### 6. Additional Notes
