### PR TITLE
FES-79 Removing name attribute from card payment form

### DIFF
--- a/templates/payment/form-creditcard.php
+++ b/templates/payment/form-creditcard.php
@@ -1,30 +1,27 @@
 <p class="form-row form-row-wide omise-required-field">
 	<label for="omise_card_number"><?php _e( 'Card number', 'omise' ); ?></label>
 	<input id="omise_card_number" class="input-text" type="text"
-		maxlength="20" autocomplete="off" placeholder="•••• •••• •••• ••••"
-		name="omise_card_number">
+		maxlength="20" autocomplete="off" placeholder="•••• •••• •••• ••••">
 </p>
 
 <p class="form-row form-row-wide omise-required-field">
 	<label for="omise_card_name"><?php _e( 'Name on card', 'omise' ); ?></label>
 	<input id="omise_card_name" class="input-text" type="text"
-		maxlength="255" autocomplete="off" placeholder="<?php _e( 'FULL NAME', 'omise' ); ?>"
-		name="omise_card_name">
+		maxlength="255" autocomplete="off" placeholder="<?php _e( 'FULL NAME', 'omise' ); ?>">
 </p>
 <p class="form-row form-row-first omise-required-field">
 	<label for="omise_card_expiration_month"><?php _e( 'Expiration month', 'omise' ); ?></label>
 	<input id="omise_card_expiration_month" class="input-text" type="text"
-		autocomplete="off" placeholder="<?php _e( 'MM', 'omise' ); ?>" name="omise_card_expiration_month">
+		autocomplete="off" placeholder="<?php _e( 'MM', 'omise' ); ?>">
 </p>
 <p class="form-row form-row-last omise-required-field">
 	<label for="omise_card_expiration_year"><?php _e( 'Expiration year', 'omise' ); ?></label>
 	<input id="omise_card_expiration_year" class="input-text" type="text"
-		autocomplete="off" placeholder="<?php _e( 'YYYY', 'omise' ); ?>"
-		name="omise_card_expiration_year">
+		autocomplete="off" placeholder="<?php _e( 'YYYY', 'omise' ); ?>">
 </p>
 <p class="form-row form-row-first omise-required-field">
 	<label for="omise_card_security_code"><?php _e( 'Security code', 'omise' ); ?></label>
 	<input id="omise_card_security_code"
 		class="input-text" type="password" autocomplete="off"
-		placeholder="•••" name="omise_card_security_code">
+		placeholder="•••">
 </p>


### PR DESCRIPTION
#### 1. Objective

Removing html name attributes from credit form.

**Related information**:
Related issue(s): https://omise.atlassian.net/browse/FES-79

#### 2. Description of change

Removed name attribute from `templates/payment/form-creditcard.php`

#### 3. Quality assurance
**🔧 Environments:**
i.e.
- **WooCommerce**: v4.3.0
- **WordPress**: v5.5.3
- **PHP version**: 7.3.3
- **Omise plugin version**: Omise-WooCommerce 4.4 (optional, in case of submitting a new issue)

#### 4. Impact of the change

- Card payment should work normally.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA