### PR TITLE
Rendering barcode in mobile phones vertically to avoid breakline.

### DIFF
--- a/assets/css/omise-billpayment-print.css
+++ b/assets/css/omise-billpayment-print.css
@@ -82,3 +82,18 @@
         font-size: 85%;
     }
 }
+
+@media screen and (max-width:480px) {
+    .omise-billpayment-tesco-barcode-wrapper {
+        position: relative;
+        height: 700px;
+    }
+
+    .omise-billpayment-tesco-barcode {
+        transform: translateX(-50%) translateY(-50%) rotate(-90deg);
+        position: absolute;
+        width: 650px;
+        margin-top: 250px;
+        z-index: -1;
+    }
+}


### PR DESCRIPTION
#### 1. Objective

This PR is to fix issue for display of Tesco Lotus barcode on Order success page. Whenever barcode width is longer than width of screen, it breaks into 2 lines which is not readable by Barcode scanner. To overcome this issue, displaying barcode in mobile phones vertically. Keeping desktop version same.

![final](https://user-images.githubusercontent.com/5526195/100562442-5aafad80-32ee-11eb-87f2-559c8e339df3.png)


**Related information**:
Related issue(s): https://omise.atlassian.net/browse/FES-228

#### 2. Description of change

- Update assets/css/omise-billpayment-print.css, Added media css selector to rotate Barcode div by -90 degree.

#### 3. Quality assurance

**🔧 Environments:**

i.e.
- **WooCommerce**: v4.3.0
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3
- **Omise plugin version**: Omise-WooCommerce 4.3 (optional, in case of submitting a new issue)

**✏️ Details:**

Try to checkout using tesco lotus barcode payment. See the result on the order success page.

#### 4. Impact of the change

Barcode shouldn't break into 2 lines.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA