### PR TITLE
Refresh QR payment screen once customer completes payment

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -99,6 +99,21 @@ fieldset.card-exists {
 	margin: auto;
 }
 
+.omise-paynow-payment-status {
+	margin-top: 15px;
+}
+
+.omise-paynow-payment-status #timer {
+	font-weight: 700;
+}
+
+.omise-paynow-payment-status .green-check {
+	background: url('../images/green-check.svg') no-repeat;
+	height: 150px;
+	width: 116px;
+	margin: auto;
+}
+
 /**
  * 2). Components
  * (stylesheets that are designed generally and may be commonly used as a component).

--- a/assets/images/green-check.svg
+++ b/assets/images/green-check.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 612 792;" version="1.1" viewBox="0 0 612 792" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
+	.st0{fill:#41AD49;}
+</style><g><path class="st0" d="M562,396c0-141.4-114.6-256-256-256S50,254.6,50,396s114.6,256,256,256S562,537.4,562,396L562,396z    M501.7,296.3l-241,241l0,0l-17.2,17.2L110.3,421.3l58.8-58.8l74.5,74.5l199.4-199.4L501.7,296.3L501.7,296.3z"/></g></svg>

--- a/includes/class-omise-rest-webhooks-controller.php
+++ b/includes/class-omise-rest-webhooks-controller.php
@@ -77,12 +77,12 @@ class Omise_Rest_Webhooks_Controller {
 	 */
 	public function callback_paynow_payment_status($request) {
 		$order_id = $request->get_param('order_id');
+		$data['status'] =  false;
 		if(isset( $order_id )) {
 			$order = new WC_Order( $order_id );
-			$charge = OmiseCharge::retrieve( $order->get_transaction_id() );
-			$data['status'] =  isset($charge) ? $charge['status'] : false;
-		} else {
-			$data['status'] =  false;
+			if(isset($order)) {
+				$data['status'] =  $order->get_status();
+			}
 		}
 		return rest_ensure_response( $data );
 	}

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -99,7 +99,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 					</div>
 					<div class="completed" style="display:none">
 						<div class="green-check"></div>
-						<?php echo __( 'We\'ve recieved your payment.', 'omise' ); ?>
+						<?php echo __( 'We\'ve received your payment.', 'omise' ); ?>
 					</div>
 					<div class="timeout" style="display:none">
 						<?php echo __( 'Payment session timed out. You can still complete QR payment by scanning code sent on your email.', 'omise' ); ?>

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -76,7 +76,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 	 * @param string       $context  pass 'email' value through this argument only for 'sending out an email' case.
 	 */
 	public function display_qrcode( $order, $context = 'view' ) {
-		if ( ! $this->load_order( $order ) ) {
+		if ( ! $order = $this->load_order( $order ) ) {
 			return;
 		}
 
@@ -93,7 +93,61 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 				<div class="omise omise-paynow-qrcode">
 					<img src="<?php echo $qrcode; ?>" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
 				</div>
+				<div class="omise-paynow-payment-status">
+					<div class="pending">
+						Waiting for payment <span id="time"></span>
+					</div>
+					<div class="completed" style="display:none">
+						We've recieved your payment.
+					</div>
+				</div>
 			</div>
+			<script type="text/javascript">
+				let xhr_param_name          = "?order_id="+"<?php echo $this->order->get_id() ?>";
+				    refresh_status_url      = "<?php echo get_rest_url( null, 'omise/paynow-payment-status' ); ?>"+xhr_param_name;
+				    class_payment_pending   = document.getElementsByClassName("pending");
+				    class_payment_completed = document.getElementsByClassName("pending");
+						var refresh_payment_status = function(intervalIterator) {
+							var xmlhttp = new XMLHttpRequest();
+							xmlhttp.addEventListener("load", function() {
+								if (this.status == 200) {
+									var chargeState = JSON.parse(this.responseText);
+									if(chargeState.status == "successful") {
+										class_payment_pending[0].style.display = "none";
+										class_payment_completed[0].style.display.display = "block";
+										clearInterval(intervalIterator);
+									}
+								}
+							});
+							/*xmlhttp.onreadystatechange = function(data) {
+								
+							};*/
+							xmlhttp.open("GET", refresh_status_url, true);
+							xmlhttp.send();
+						},
+						intervalTime = function(duration, display) {
+							var timer    = duration, minutes, seconds;
+							intervalIterator = setInterval(function () {
+								minutes      = parseInt(timer / 60, 10);
+								seconds      = parseInt(timer % 60, 10);
+								minutes = minutes < 10 ? "0" + minutes : minutes;
+								seconds = seconds < 10 ? "0" + seconds : seconds;
+								display.textContent = minutes + ":" + seconds;
+								if (--timer < 0) {
+									timer = duration;
+								}
+								if((timer % 5) == 0 && timer >= 5) {
+									refresh_payment_status(intervalIterator);
+								}
+							}, 1000);
+						};
+
+				window.onload = function () {
+					var duration = 60 * 5,
+					    display  = document.querySelector('#time');
+					intervalTime(duration, display);
+				};
+			</script>
 		<?php elseif ( 'email' === $context && !$order->has_status('failed')) : ?>
 			<p>
 				<?php echo __( 'Scan the QR code to complete', 'omise' ); ?>

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -95,7 +95,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 				</div>
 				<div class="omise-paynow-payment-status">
 					<div class="pending">
-						<?php echo __( 'Waiting for payment. Session on this window for payment would timeout in <span id="timer">10:00</span> minutes.', 'omise' ); ?>
+						<?php echo __( 'Payment session will time out in <span id="timer">10:00</span> minutes.', 'omise' ); ?>
 					</div>
 					<div class="completed" style="display:none">
 						<div class="green-check"></div>

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -102,7 +102,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 						<?php echo __( 'We\'ve received your payment.', 'omise' ); ?>
 					</div>
 					<div class="timeout" style="display:none">
-						<?php echo __( 'Payment session timed out. You can still complete QR payment by scanning code sent on your email.', 'omise' ); ?>
+						<?php echo __( 'Payment session timed out. You can still complete QR payment by scanning the code sent to your email address.', 'omise' ); ?>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
#### 1. Objective

This PR is to removes QR code from order success page and show actual status of payment in real time, once customer scans the QR code and make the payment. Timeout of 10 minutes has been added on the order success page to keep checking status of charge.

Payment Pending screen:

<img width="953" alt="Screen Shot 2020-11-30 at 14 11 29" src="https://user-images.githubusercontent.com/5526195/100580309-47b1d300-3318-11eb-8951-91a50928cb95.png">

Payment complete screen:

<img width="921" alt="Screen Shot 2020-11-30 at 14 12 06" src="https://user-images.githubusercontent.com/5526195/100580348-58624900-3318-11eb-8f7d-fbc7bfe4822f.png">

Payment timeout screen:

<img width="877" alt="Screen Shot 2020-11-30 at 14 11 14" src="https://user-images.githubusercontent.com/5526195/100580554-b68f2c00-3318-11eb-8d35-cc9158c9ee74.png">


**Related information**:
Related issue(s): https://omise.atlassian.net/browse/FES-207

#### 2. Description of change

- Updated `includes/gateway/class-omise-payment-paynow.php` template page by adding javascript code which sends xhr request to rest api.
- Updated `includes/class-omise-rest-webhooks-controller.php` to add new rest api controller.
- Modified omise-css.css, added new image file 

#### 3. Quality assurance

**🔧 Environments:**

i.e.
- **WooCommerce**: v4.3.0
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3
- **Omise plugin version**: Omise-WooCommerce 4.3 (optional, in case of submitting a new issue)

**✏️ Details:**

- Added product to cart.
- Checkout using Paynow QR payment.
- Observe order success page.

#### 4. Impact of the change

Order success page should be modified after this PR. It should show actual payment status.

#### 5. Priority of change

Normal

#### 6. Additional Notes

None