### PR TITLE
Auto formatting card numbers in input field on checkout page and My account page.

### DIFF
--- a/assets/javascripts/omise-myaccount-card-handler.js
+++ b/assets/javascripts/omise-myaccount-card-handler.js
@@ -73,7 +73,6 @@
 
 		$.each( omise_card_fields, function( index, field ) {
 			omise_card[ index ] = (index === omise_card_number_field) ? field.val().replace(/\s/g, '') : field.val();
-			//omise_card[ index ] = field.val();
 			if ( "" === omise_card[ index ] ) {
 				errors.push( omise_params[ 'required_card_' + index ] );
 			}

--- a/assets/javascripts/omise-myaccount-card-handler.js
+++ b/assets/javascripts/omise-myaccount-card-handler.js
@@ -63,7 +63,7 @@
 		let errors                  = [],
 			omise_card              = {},
 			omise_card_number_field = 'number',
-		    omise_card_fields       = {
+			omise_card_fields       = {
 				'name'             : $( '#omise_card_name' ),
 				'number'           : $( '#omise_card_number' ),
 				'expiration_month' : $( '#omise_card_expiration_month' ),

--- a/assets/javascripts/omise-myaccount-card-handler.js
+++ b/assets/javascripts/omise-myaccount-card-handler.js
@@ -60,9 +60,10 @@
 			}
 		});
 
-		let errors            = [],
-		    omise_card        = {},
-		    omise_card_fields = {
+		let errors                  = [],
+			omise_card              = {},
+			omise_card_number_field = 'number',
+		    omise_card_fields       = {
 				'name'             : $( '#omise_card_name' ),
 				'number'           : $( '#omise_card_number' ),
 				'expiration_month' : $( '#omise_card_expiration_month' ),
@@ -71,7 +72,8 @@
 			};
 
 		$.each( omise_card_fields, function( index, field ) {
-			omise_card[ index ] = field.val();
+			omise_card[ index ] = (index === omise_card_number_field) ? field.val().replace(/\s/g, '') : field.val();
+			//omise_card[ index ] = field.val();
 			if ( "" === omise_card[ index ] ) {
 				errors.push( omise_params[ 'required_card_' + index ] );
 			}
@@ -84,7 +86,7 @@
 			hideError();
 			if(Omise){
 				Omise.setPublicKey(omise_params.key);
-				Omise.createToken("card", card, function (statusCode, response) {
+				Omise.createToken("card", omise_card, function (statusCode, response) {
 				    if (statusCode == 200) {
 						$.each( omise_card_fields, function( index, field ) {
 							field.val( '' );

--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -70,9 +70,10 @@
 					}
 				});
 
-				let errors            = [],
-				    omise_card        = {},
-				    omise_card_fields = {
+				let errors                  = [],
+					omise_card              = {},
+					omise_card_number_field = 'number',
+				    omise_card_fields       = {
 						'name'             : $( '#omise_card_name' ),
 						'number'           : $( '#omise_card_number' ),
 						'expiration_month' : $( '#omise_card_expiration_month' ),
@@ -81,7 +82,7 @@
 					};
 
 				$.each( omise_card_fields, function( index, field ) {
-					omise_card[ index ] = field.val();
+					omise_card[ index ] = (index === omise_card_number_field) ? field.val().replace(/\s/g, '') : field.val();
 					if ( "" === omise_card[ index ] ) {
 						errors.push( omise_params[ 'required_card_' + index ] );
 					}

--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -73,7 +73,7 @@
 				let errors                  = [],
 					omise_card              = {},
 					omise_card_number_field = 'number',
-				    omise_card_fields       = {
+					omise_card_fields       = {
 						'name'             : $( '#omise_card_name' ),
 						'number'           : $( '#omise_card_number' ),
 						'expiration_month' : $( '#omise_card_expiration_month' ),

--- a/templates/payment/form-creditcard.php
+++ b/templates/payment/form-creditcard.php
@@ -25,3 +25,29 @@
 		class="input-text" type="password" autocomplete="off"
 		placeholder="•••">
 </p>
+<script type="text/javascript">
+
+	/**
+	 * This reformats the input in #omise_card_number field
+	 * e.g. 1234123412 to 1234 1234 12
+	 * @param string value
+	 */
+	function format_cardnumber(value) {
+		var card_number = value.replace(/\s+/g, '').replace(/[^0-9]/gi, '')
+		var matches = card_number.match(/\d{4,16}/g);
+		var match = matches && matches[0] || ''
+		var parts = []
+		for (i=0, len=match.length; i<len; i+=4) {
+			parts.push(match.substring(i, i+4))
+		}
+		if (parts.length) {
+			return parts.join(' ')
+		} else {
+			return value
+		}
+	}
+
+	document.getElementById('omise_card_number').oninput = function() {
+		this.value = format_cardnumber(this.value)
+	}
+</script>


### PR DESCRIPTION
#### 1. Objective

This PR auto-formats the input number in card field at checkout field.

For example:
if user inputs, 
_411111_ which converts to `4111 11`
_4111111111_ which converts to `4111 1111 11`
_4111111111111_ which converts to `4111 1111 1111 1`

This changes has done in 'Save Card' section in _My account page_ and _Checkout page_.

Save Card page:
<img width="668" alt="Screen Shot 2020-12-01 at 13 44 25" src="https://user-images.githubusercontent.com/5526195/100707243-ee5fa780-33dc-11eb-8a7d-fb2f145ad5d8.png">

Checkout page:
<img width="937" alt="Screen Shot 2020-12-01 at 13 45 31" src="https://user-images.githubusercontent.com/5526195/100707254-f3bcf200-33dc-11eb-8432-b4c69ea3ab6c.png">


**Related information**:
Related issue(s): https://omise.atlassian.net/browse/FES-211

#### 2. Description of change

1. Updated Javascript files which reformats to input value of input field which also takes of spaces from input values before sending to omise api. modified files are assets/javascripts/omise-myaccount-card-handler.js , assets/javascripts/omise-payment-form-handler.js

2. Added javascript on the form template : templates/payment/form-creditcard.php


#### 3. Quality assurance

**🔧 Environments:**
i.e.
- **WooCommerce**: v4.3.0
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3
- **Omise plugin version**: Omise-WooCommerce 4.3 (optional, in case of submitting a new issue)

**✏️ Details:**

Steps for testing:
1. Checkout using card payment. 
2. Order should place successfully and Omise charge should get created in dashboard.
3. Go to My account > Omise setting > Save Card.
4. Input card number.
5. Card should get saved successfully.

#### 4. Impact of the change

Card payment method should work normally.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA