### PR TITLE
Adding support to online refunds in paynow

### DIFF
--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -15,7 +15,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 			__( 'Accept payments through <strong>PayNow</strong> via Omise payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
-
+		$this->supports           = array( 'products', 'refunds' );
 		$this->init_form_fields();
 		$this->init_settings();
 


### PR DESCRIPTION
#### 1. Objective

This PR is to implement refunds for PayNow QR payment in WooCommerce. WooCommerce's order edit page, added new button to refund.

WooCommerce backend:
![screencapture-127-0-0-1-8888-wp-wp-admin-post-php-1608088697220](https://user-images.githubusercontent.com/5526195/102301589-a8344780-3f89-11eb-8c54-157c146533f8.png)

New button added to refund:
<img width="955" alt="Screen Shot 2020-12-16 at 10 21 25" src="https://user-images.githubusercontent.com/5526195/102301627-bda97180-3f89-11eb-8948-a985ea1aa4c0.png">

Processed refund after order process:
<img width="962" alt="Screen Shot 2020-12-16 at 10 22 55" src="https://user-images.githubusercontent.com/5526195/102301646-cac66080-3f89-11eb-80d9-e66c8362cb6c.png">

Updated status of charge in Omise dashboard:
<img width="869" alt="Screen Shot 2020-12-16 at 10 24 17" src="https://user-images.githubusercontent.com/5526195/102301665-d6b22280-3f89-11eb-9e5f-a098f2df1531.png">


**Related information**:
Internal issue(s): https://omise.atlassian.net/browse/FES-246

#### 2. Description of change

- Added support of refund in Paynow Model class. `includes/gateway/class-omise-payment-paynow.php`

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v4.3.0
- **WordPress**: v5.5.2
- **PHP version**: 7.3.3
- **Omise plugin version**: Omise-WooCommerce 4.5 (optional, in case of submitting a new issue)

**✏️ Details:**

Steps to test:
- Checkout using Paynow QR payment.
- Mark order as paid in omise backend (make sure webhook is working)
- Go to woocommerce backend > order > click Refund > select products to refund > click "Refund via Omise".

#### 4. Impact of the change

Paynow QR payment should be able to refund online from backend.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA