### PR TITLE
Change minimum amount for installment payments from 3000 to 2000 THB

### DIFF
--- a/includes/libraries/omise-php/lib/omise/OmiseCapabilities.php
+++ b/includes/libraries/omise-php/lib/omise/OmiseCapabilities.php
@@ -3,7 +3,7 @@
 class OmiseCapabilities extends OmiseApiResource
 {
     const ENDPOINT = 'capability';
-    const INSTALLMENT_MINIMUM = 300000;
+    const INSTALLMENT_MINIMUM = 200000;
 
     /**
      * @var array  of the filterable keys.

--- a/templates/payment/form-installment.php
+++ b/templates/payment/form-installment.php
@@ -46,6 +46,6 @@
 	</fieldset>
 <?php else: ?>
 	<p>
-		<?php echo __( 'There are no installment plans available for this purchase amount  (minimum amount is 3,000 THB).', 'omise' ); ?>
+		<?php echo __( 'There are no installment plans available for this purchase amount  (minimum amount is 2,000 THB).', 'omise' ); ?>
 	</p>
 <?php endif; ?>


### PR DESCRIPTION
#### 0. To-Do
- [x] [Change min amount for installment on Omise-PHP](https://github.com/omise/omise-php/pull/132) and publish a new version
- [x] Update Omise-PHP to the latest version on Omise-WooCommerce #211 

#### 1. Objective

Change the display amount for installment payments from 3000 to 2000 THB WooCommerce.
Reference: https://www.omise.co/installment-payments#limits

**Related information**:
Related issue(s): #209
Related PR(s): #211 
Internal task(s): [CS-649](https://omise.atlassian.net/browse/CS-649)

#### 2. Description of change

Change the display amount for installment payments from 3000 to 2000 THB. This is shown installment is selected and the amount is less than 2000 THB.

#### 3. Quality assurance

**🔧 Environments:**

- **WooCommerce**: v5.1.0
- **WordPress**: v5.6.1
- **PHP**: v7.3.8
- **Omise PHP**: v2.13.0
- **Omise WooCommerce**: v4.7

**✏️ Details:**

1. Enable installment payment on WordPress Admin.
2. Go to storefront, order and checkout with amount >= 2000 THB.

Installment option should appear when the amount is at least 2000 THB. Otherwise, this message should be displayed:
`There are no installment plans available for this purchase amount (minimum amount is 2,000 THB).`

#### 4. Impact of the change

The correct minimum amount is shown.

![Chanapa 2021-04-12 at 11 32 42 AM](https://user-images.githubusercontent.com/16201698/114341014-fdbce180-9b82-11eb-967f-eeb452183f85.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

n/a