### PR TITLE
Fix CVE-2020-29156 security vulnerability

### DIFF
--- a/includes/class-omise-ajax-actions.php
+++ b/includes/class-omise-ajax-actions.php
@@ -17,7 +17,13 @@ class Omise_Ajax_Actions {
      * @see    Omise::register_ajax_actions()
      */
     public static function fetch_order_status() {
-        $order = wc_get_order( $_POST['order_id'] );
-        wp_send_json_success( array( 'order_status' => $order->get_status() ) );
+        $order_id = wc_get_order( $_POST['order_id'] );
+        $order_key = OmisePluginHelperWcOrder::get_order_key_by_id( $order_id );
+
+        if ( ! wp_verify_nonce( $_POST['nonce'], $order_key ) ) {
+            die ( 'Busted!');
+        }
+
+        wp_send_json_success( array( 'order_status' => $order_id->get_status() ) );
     }
 }

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -90,6 +90,8 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 		$expires_datetime = new WC_DateTime( $charge['expires_at'], new DateTimeZone( 'UTC' ) );
 		$expires_datetime->set_utc_offset( wc_timezone_offset() );
 
+		$nonce = wp_create_nonce( OmisePluginHelperWcOrder::get_order_key_by_id( $order ) );
+
 		if ( 'view' === $context ) : ?>
 			<div id="omise-offline-additional-details" class="omise omise-additional-payment-details-box omise-promptpay-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
 				<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
@@ -153,7 +155,8 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 								dataType: 'json',
 								data: {
 									'action': 'fetch_order_status',
-									'order_id': '<?php echo $order; ?>'
+									'order_id': '<?php echo $order; ?>',
+									'nonce': '<?php echo $nonce ?>'
 								},
 								success: function( response ) {
 									if ( 'processing' === response.data.order_status ) {

--- a/includes/libraries/omise-plugin/Omise.php
+++ b/includes/libraries/omise-plugin/Omise.php
@@ -1,3 +1,4 @@
 <?php
 
 require_once dirname(__FILE__).'/helpers/charge.php';
+require_once dirname(__FILE__).'/helpers/wc_order.php';

--- a/includes/libraries/omise-plugin/helpers/wc_order.php
+++ b/includes/libraries/omise-plugin/helpers/wc_order.php
@@ -1,0 +1,19 @@
+<?php
+if (! class_exists('OmisePluginHelperWcOrder')) {
+    class OmisePluginHelperWcOrder
+    {
+        /**
+         * @param int|WC_Order $order_id
+         * @return string
+         */
+        public static function get_order_key_by_id( $order_id ) {
+            $order = wc_get_order($order_id);
+    
+            if ($order && !is_wp_error($order)) {
+                $order_key = $order->get_order_key();
+            }
+    
+            return $order_key;
+        }
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Explain in non-technical terms **WHY this PR is required**.
E.g.: What feature it adds, what problem it solves...

It solves this security vulnerability https://github.com/Ko-kn3t/CVE-2020-29156

This section will be used in the release notes. 

**Related information**:
Related issue(s): #< GitHub ticket number > (optional)

#### 2. Description of change

A general description of **WHAT changed in the codebase**, but short of an English version of the diff. Assume that people reading this will also be looking at the output of `git diff` and guide them to the highlights.

Additionally add the reasoning for change details if they're complex or abstract.

Added a nonce in the AJAX call that is created with the nonce key and the WooCommerce order object key. This means without these 2 keys, these endpoints will not be accessible. Since the nonce is created with the order key, it also means that the nonce could not be reused to fetch order statuses of other orders as the nonce and requested order ID will not match and the endpoint will return an error message.

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

Test that the AJAX call to fetch the order number still works in the payments flow.
Test that the endpoint could not be called by users that don't go through the payments flow.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **WooCommerce**: v4.5.2
- **WordPress**: v5.7
- **PHP version**: 7.4.16

**✏️ Details:**

Explain how to manually test this feature.
For example if changes were made in the UI or in the API, explain where and if any specific access is needed.

Test that the AJAX call to fetch the order number still works in the payments flow.
Test that the endpoint could not be called by users that don't go through the payments flow

#### 4. Impact of the change

List the steps that must be taken for this PR to work.
E.g.: rake yak:shave, Add "yak_key" to environment variables, ...

Be sure to include all systems that needs to be changed or which system is affected by the change
(Ex: Requires Elastic search to be installed and configured in secrets.yml).

Note: Please provide a screenshot if your changed impact to UI.

No impact to users at all.

#### 5. Priority of change

Normal, High or Immediate.

High

#### 6. Additional Notes

Any further information that you would like to add.