### PR TITLE
Update min amount for installment bay and kbank

### DIFF
--- a/includes/backends/class-omise-backend-installment.php
+++ b/includes/backends/class-omise-backend-installment.php
@@ -30,7 +30,7 @@ class Omise_Backend_Installment extends Omise_Backend {
 				'bank_code'          => 'bay',
 				'title'              => __( 'Krungsri', 'omise' ),
 				'interest_rate'      => 0.8,
-				'min_allowed_amount' => 300.00,
+				'min_allowed_amount' => 500.00,
 			),
 
 			'installment_ktc' => array(
@@ -51,7 +51,7 @@ class Omise_Backend_Installment extends Omise_Backend {
 				'bank_code'          => 'kbank',
 				'title'              => __( 'Kasikorn Bank', 'omise' ),
 				'interest_rate'      => 0.65,
-				'min_allowed_amount' => 500.00,
+				'min_allowed_amount' => 300.00,
 			),
 
 			'installment_scb' => array(

--- a/tests/unit/includes/backends/class-omise-backend-installment-test.php
+++ b/tests/unit/includes/backends/class-omise-backend-installment-test.php
@@ -11,6 +11,45 @@ class Omise_Backend_Installment_Test extends TestCase {
 	/**
 	 * @test
 	 */
+	public function get_only_valid_plans_from_given_bay_allowed_installment_terms() {
+		$installment_backend = new Omise_Backend_Installment();
+		$purchase_amount     = 2000.00;
+		$allowed_terms       = array( 3, 4, 6, 9, 10 );
+		$interest_rate       = 0.8;
+		$min_allowed_amount  = 500.00;
+
+		$result = $installment_backend->get_available_plans( $purchase_amount, $allowed_terms, $interest_rate, $min_allowed_amount );
+
+		$this->assertEquals( 2, count( $result ) );
+		$this->assertEquals( array(
+			array( 'term_length' => 3, 'monthly_amount' => 682.67 ),
+			array( 'term_length' => 4, 'monthly_amount' => 516.00 ),
+		), $result );
+	}
+	
+	/**
+	 * @test
+	 */
+	public function get_only_valid_plans_from_given_kbank_allowed_installment_terms() {
+		$installment_backend = new Omise_Backend_Installment();
+		$purchase_amount     = 2000.00;
+		$allowed_terms       = array( 3, 4, 6, 10 );
+		$interest_rate       = 0.65;
+		$min_allowed_amount  = 300.00;
+
+		$result = $installment_backend->get_available_plans( $purchase_amount, $allowed_terms, $interest_rate, $min_allowed_amount );
+
+		$this->assertEquals( 3, count( $result ) );
+		$this->assertEquals( array(
+			array( 'term_length' => 3, 'monthly_amount' => 679.67 ),
+			array( 'term_length' => 4, 'monthly_amount' => 513.00 ),
+			array( 'term_length' => 6, 'monthly_amount' => 346.33 ),
+		), $result );
+	}
+
+	/**
+	 * @test
+	 */
 	public function get_only_valid_plans_from_given_scb_allowed_installment_terms() {
 		$installment_backend = new Omise_Backend_Installment();
 		$purchase_amount     = 2000.00;


### PR DESCRIPTION
#### 1. Objective

Update minimum allowed amount for installment bay and kbank.

**Related information**:
Related issue(s): internal ticket [CS-713](https://omise.atlassian.net/browse/CS-713)

#### 2. Description of change

bay (Krungsri)
- from 300 THB to 500 THB

kbank (Kasikorn)
- from 500 THB to 300 THB

Reference: https://www.omise.co/installment-payments#supported-cards

![image](https://user-images.githubusercontent.com/16201698/123399802-3fc8c180-d5cf-11eb-8e0c-22efa7f32d1e.png)

#### 3. Quality assurance

**🔧 Environments:**
- **WooCommerce**: 5.4.1
- **WordPress**: 5.7.2
- **PHP**: 7.3.8
- **Omise-PHP**: 2.13.0
- **Omise-WooCommerce**: 4.8

**✏️ Details:**

1. Enable installment payment on WordPress Admin.
2. Go to storefront, order and checkout with amount >= 2000 THB.

bay and kbank installment options should appear correctly.
- bay: only show terms with monthly payment at least 500 THB
- kbank: only show terms with monthly payment at least 300 THB

#### 4. Impact of the change

The correct installment terms are shown.

![image](https://user-images.githubusercontent.com/16201698/123401683-36405900-d5d1-11eb-8dec-d7edb182213e.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

n/a