### PR TITLE
Remove QR from email when charge is no longer pending

### DIFF
--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -82,6 +82,10 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 
 		$charge_id = $this->get_charge_id_from_order();
 		$charge    = OmiseCharge::retrieve( $charge_id );
+		if ( self::STATUS_PENDING !== $charge['status'] ) {
+			return;
+		}
+
 		$qrcode    = $charge['source']['scannable_code']['image']['download_uri'];
 
 		if ( 'view' === $context ) : ?>


### PR DESCRIPTION
#### 1. Objective

Remove PayNow QR from email when charge is no longer pending.

**Related information**:
Related issue(s): internal ticket [CS-675](https://omise.atlassian.net/browse/CS-675)

#### 2. Description of change

![Chanapa 2021-06-27 at 04 43 10 PM](https://user-images.githubusercontent.com/16201698/123540007-de3b5b00-d766-11eb-9ed5-9ef159320814.png)

WooCommerce sends two emails to customer. One is sent when an order is placed with PayNow (Order on-hold email). Another one is sent when the order is paid (Processing order email). This PR removes QR from the second email.

Screenshots before the fix:

First email:
![image](https://user-images.githubusercontent.com/16201698/123539853-ec3cac00-d765-11eb-913d-00539d40147f.png)

Second email:
![image](https://user-images.githubusercontent.com/16201698/123539864-feb6e580-d765-11eb-9150-cfcc7ade33dd.png)

#### 3. Quality assurance

**🔧 Environments:**
- **WooCommerce**: 5.4.1
- **WordPress**: 5.7.2
- **PHP**: 7.3.8
- **Omise-PHP**: 2.13.0
- **Omise-WooCommerce**: 4.8

**✏️ Details:**

1. Enable PayNow on WordPress Admin.
2. Set up webhook on Omise dashboard.
3. Go to storefront, order and checkout with PayNow.
4. Check the first email, it should contain QR.
5. Mark the PayNow charge as paid.
6. Check the second email, it should not contain QR.

#### 4. Impact of the change

QR is removed from the second email.

First email:

![image](https://user-images.githubusercontent.com/16201698/123540148-bc8ea380-d767-11eb-9fc9-d5654de2db3a.png)

Second email:

![image](https://user-images.githubusercontent.com/16201698/123540159-c9ab9280-d767-11eb-940c-f67c8db28a66.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

n/a