### PR TITLE
Enable credit/debit card payment methods in WooCommerce for MY

### DIFF
--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -25,7 +25,7 @@ class Omise_Payment_Creditcard extends Omise_Payment {
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );
 		$this->payment_action       = $this->get_option( 'payment_action' );
-		$this->restricted_countries = array( 'TH', 'JP', 'SG' );
+		$this->restricted_countries = array( 'TH', 'JP', 'SG', 'MY' );
 
 		add_action( 'woocommerce_api_' . $this->id . '_callback', 'Omise_Callback::execute' );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );


### PR DESCRIPTION
#### 1. Objective

There are no payment methods available in WooCommerce with Malaysia account.
It’s working fine with both TH and SG accounts, but not for MY account.

This section will be used in the release notes. 

**Related information**:
Task : https://omise.atlassian.net/secure/RapidBoard.jspa?rapidView=113&projectKey=NDPNTS&modal=detail&selectedIssue=NDPNTS-313

#### 2. Description of change
add `MY` to `restricted_countries` in `includes/gateway/class-omise-payment-creditcard.php`

#### 3. Quality assurance
N/A

**✏️ Details:**
N/A

#### 4. Impact of the change
N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

Any further information that you would like to add.