### PR TITLE
[EM-611] Unable to view PromptPay QR after downloading from email

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -115,6 +115,31 @@ fieldset.card-exists {
 }
 
 /**
+* Omise Promptpay
+*/
+@media all and (min-width: 768px) {
+	.omise-promptpay-qrcode > img {
+		max-width: 300px !important;
+	}
+}
+
+.omise-download-promptpay-qr {
+	display: inline-block;
+	color: white !important;
+	padding: 6px 12px;
+	font-weight: bold;
+	background-color: #1A53F0;
+	border-radius: 4px;
+	margin-bottom: 0.75rem;
+	cursor: pointer;
+}
+
+.omise-download-promptpay-qr:hover {
+	background-color: #0c3abb;
+}
+
+
+/**
  * 2). Components
  * (stylesheets that are designed generally and may be commonly used as a component).
  */

--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -117,8 +117,14 @@ fieldset.card-exists {
 /**
 * Omise Promptpay
 */
+
+.omise-qr-image > svg {
+	max-width: 100%;
+	height: auto;
+}
+
 @media all and (min-width: 768px) {
-	.omise-promptpay-qrcode > img {
+	.omise-qr-image > svg {
 		max-width: 300px !important;
 	}
 }

--- a/assets/javascripts/omise-download-promptpay-as-png.js
+++ b/assets/javascripts/omise-download-promptpay-as-png.js
@@ -1,0 +1,75 @@
+(function ( $ ) {
+    'use strict';
+    
+    $('a#omise-download-promptpay-qr').click(function(e) {
+        e.preventDefault();
+
+        var svg = document.querySelector('svg');
+        $("#qr-image").show();
+        downloadSvg(svg, "qr_code.png");
+    });
+
+    function copyStylesInline(destinationNode, sourceNode) {
+        var containerElements = ["svg","g"];
+        for (var cd = 0; cd < destinationNode.childNodes.length; cd++) {
+            var child = destinationNode.childNodes[cd];
+            if (containerElements.indexOf(child.tagName) != -1) {
+                 copyStylesInline(child, sourceNode.childNodes[cd]);
+                 continue;
+            }
+            var style = sourceNode.childNodes[cd].currentStyle;
+            if (style == "undefined" || style == null) continue;
+            for (var st = 0; st < style.length; st++){
+                 child.style.setProperty(style[st], style.getPropertyValue(style[st]));
+            }
+        }
+     }
+     
+    function triggerDownload (imgURI, fileName) {
+        var evt = new MouseEvent("click", {
+            view: window,
+            bubbles: false,
+            cancelable: true
+        });
+        var a = document.createElement("a");
+        a.setAttribute("download", fileName);
+        a.setAttribute("href", imgURI);
+        a.setAttribute("target", '_blank');
+        a.dispatchEvent(evt);
+    }
+    
+    function downloadSvg(svg, fileName) {
+        var copy = svg.cloneNode(true);
+        copyStylesInline(copy, svg);
+        var canvas = document.createElement("canvas");
+        var bbox = svg.getBBox();
+        canvas.width = bbox.width;
+        canvas.height = bbox.height;
+        var ctx = canvas.getContext("2d");
+        ctx.clearRect(0, 0, bbox.width, bbox.height);
+        var data = (new XMLSerializer()).serializeToString(copy);
+        var DOMURL = window.URL || window.webkitURL || window;
+        var img = new Image();
+        var svgBlob = new Blob([data], {type: "image/svg+xml;charset=utf-8"});
+        var url = DOMURL.createObjectURL(svgBlob);
+        img.onload = function () {
+            ctx.drawImage(img, 0, 0);
+            DOMURL.revokeObjectURL(url);
+            if (typeof navigator !== "undefined" && navigator.msSaveOrOpenBlob)
+            {
+                var blob = canvas.msToBlob();         
+                navigator.msSaveOrOpenBlob(blob, fileName);
+            } 
+            else {
+                var imgURI = canvas
+                    .toDataURL("image/png")
+                    .replace("image/png", "image/octet-stream");
+                triggerDownload(imgURI, fileName);
+            }
+            document.removeChild(canvas);
+        };
+        $("#qr-image").hide();
+        img.src = url;
+    }
+}
+)(jQuery);

--- a/assets/javascripts/omise-download-promptpay-as-png.js
+++ b/assets/javascripts/omise-download-promptpay-as-png.js
@@ -11,7 +11,9 @@
             // we have to render the PNG twice or it will give us an empty PNG the first time :'(
             // Similar issue: https://github.com/exupero/saveSvgAsPng/issues/223
             downloadSvg(svg, "qr_code.png", false);
-            setTimeout(function(){ downloadSvg(svg, "qr_code.png", true); }, 10);
+            setTimeout(function(){
+                downloadSvg(svg, "qr_code.png", true);
+            }, 10);
         }
     });
 

--- a/assets/javascripts/omise-download-promptpay-as-png.js
+++ b/assets/javascripts/omise-download-promptpay-as-png.js
@@ -2,12 +2,18 @@
     'use strict';
     
     $('a#omise-download-promptpay-qr').click(function(e) {
-        e.preventDefault();
+        if (isCanvasSupported()) {
+            e.preventDefault();
 
-        var svg = document.querySelector('svg');
-        $("#qr-image").show();
-        downloadSvg(svg, "qr_code.png");
+            var svg = document.querySelector('svg');
+            downloadSvg(svg, "qr_code.png");
+        }
     });
+
+    function isCanvasSupported() {
+        var elem = document.createElement('canvas');
+        return !!(elem.getContext && elem.getContext('2d'));
+    }
 
     function copyStylesInline(destinationNode, sourceNode) {
         var containerElements = ["svg","g"];
@@ -66,9 +72,7 @@
                     .replace("image/png", "image/octet-stream");
                 triggerDownload(imgURI, fileName);
             }
-            document.removeChild(canvas);
         };
-        $("#qr-image").hide();
         img.src = url;
     }
 }

--- a/assets/javascripts/omise-download-promptpay-as-png.js
+++ b/assets/javascripts/omise-download-promptpay-as-png.js
@@ -4,12 +4,13 @@
     $('a#omise-download-promptpay-qr').click(function(e) {
         if (isCanvasSupported()) {
             e.preventDefault();
-
             var svg = document.querySelector('svg');
 
-            // Because of a Webkit (Safari) bug, where it won't fetch images from the SVG in time the first time around,
-            // we have to render the PNG twice or it will give us a PNG without the logo and QR code the first time :'(
-            // Similar issue: https://github.com/exupero/saveSvgAsPng/issues/223
+            /*
+            Because of a Webkit (Safari) bug, where it won't fetch images from the SVG in time the first time around,
+            we have to render the PNG twice or it will give us a PNG without the logo and QR code the first time :'(
+            Similar issue: https://github.com/exupero/saveSvgAsPng/issues/223
+            */
             downloadSvg(svg, "qr_code.png", false);
             setTimeout(function(){
                 downloadSvg(svg, "qr_code.png", true);

--- a/assets/javascripts/omise-download-promptpay-as-png.js
+++ b/assets/javascripts/omise-download-promptpay-as-png.js
@@ -8,7 +8,7 @@
             var svg = document.querySelector('svg');
 
             // Because of a Webkit (Safari) bug, where it won't fetch images from the SVG in time the first time around,
-            // we have to render the PNG twice or it will give us an empty PNG the first time :'(
+            // we have to render the PNG twice or it will give us a PNG without the logo and QR code the first time :'(
             // Similar issue: https://github.com/exupero/saveSvgAsPng/issues/223
             downloadSvg(svg, "qr_code.png", false);
             setTimeout(function(){

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -28,7 +28,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 		wp_enqueue_script(
 			'omise-download-promptpay-as-png',
 			plugins_url( '../assets/javascripts/omise-download-promptpay-as-png.js', dirname( __FILE__ ) ),
-			array( 'jquery', 'canvg' ),
+			array( 'jquery' ),
 			WC_VERSION,
 			true
 		);

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -36,7 +36,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 	/**
 	 * Register all scripts
 	 */
-	public function register_omise_promptpay_scripts() {
+	private function register_omise_promptpay_scripts() {
 		wp_enqueue_script(
 			'omise-download-promptpay-as-png',
 			plugins_url( '../assets/javascripts/omise-download-promptpay-as-png.js', dirname( __FILE__ ) ),
@@ -77,7 +77,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 	/**
 	 * @param string $url	url for the QR SVG image
 	 */
-	public function load_qr_svg_to_DOM($url) {
+	private function load_qr_svg_to_DOM($url) {
 		$svg_file = file_get_contents($url);
 
 		$find_string   = '<svg';
@@ -127,7 +127,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 				<div class="omise omise-promptpay-qrcode" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
 					<?php $this->load_qr_svg_to_DOM($qrcode) ?>
 				</div>
-				<a id="omise-download-promptpay-qr" class="omise-download-promptpay-qr">Download QR</a>
+				<a id="omise-download-promptpay-qr" class="omise-download-promptpay-qr" href="<?php echo $qrcode ?>" download="qr_code.svg">Download QR</a>
 				<div>
 					<?php echo __( 'Payment expires in: ', 'omise' ); ?>
 					<?php echo wc_format_datetime( $expires_datetime, wc_date_format() ); ?>

--- a/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
+++ b/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
@@ -1,7 +1,7 @@
 <?php
 
 define('OMISE_PHP_LIB_VERSION', '2.13.0');
-define('OMISE_API_URL', 'https://api.staging-omise.co/');
+define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
 class OmiseApiResource extends OmiseObject

--- a/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
+++ b/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
@@ -1,7 +1,7 @@
 <?php
 
 define('OMISE_PHP_LIB_VERSION', '2.13.0');
-define('OMISE_API_URL', 'https://api.omise.co/');
+define('OMISE_API_URL', 'https://api.staging-omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
 class OmiseApiResource extends OmiseObject


### PR DESCRIPTION
#### 1. Objective

Explain in non-technical terms **WHY this PR is required**.
E.g.: What feature it adds, what problem it solves...

This section will be used in the release notes. 

When a customer creates an order and chooses Promptpay as their payment method, we send an order received in the email. The email includes the link to download the QR code to pay with, problem is the image is in an SVG format which isn't an ideal for customers to pay with. For many systems, there default application to open SVG images are a text editor to show it's XML.

**Related information**:
Related issue(s): #< GitHub ticket number > (optional)

#### 2. Description of change

A general description of **WHAT changed in the codebase**, but short of an English version of the diff. Assume that people reading this will also be looking at the output of `git diff` and guide them to the highlights.

Additionally add the reasoning for change details if they're complex or abstract.

Firstly, the email links to the order received woocommerce page instead of the image download link. Then in that page, we add a download image link to download the image as an SVG.

We add a script that runs on the page to create a canvas from the SVG and then create a PNG download link from that canvas. If the browser doesn't support the use of canvas, we will fallback to downloading the original SVG image instead. However, [most modern browsers supports canvas](https://caniuse.com/canvas) so users should be able to get the PNG image. 

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

Tested on Chrome, Firefox and Safari on Mac OS. Since we have a fallback to SVG and all the tests I conducted passed, I think it's OK to not test on more browsers.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **WooCommerce**: v5.4.1
- **WordPress**: v5.7.2
- **PHP version**: 7.4

**✏️ Details:**

Explain how to manually test this feature.
For example if changes were made in the UI or in the API, explain where and if any specific access is needed.

Create a Promptpay charge on test/live mode and download the PNG. Also go to your email and click the link to come back to the order page and download the PNG.

#### 4. Impact of the change

List the steps that must be taken for this PR to work.
E.g.: rake yak:shave, Add "yak_key" to environment variables, ...

Be sure to include all systems that needs to be changed or which system is affected by the change
(Ex: Requires Elastic search to be installed and configured in secrets.yml).

Note: Please provide a screenshot if your changed impact to UI.

<img width="403" alt="Screen Shot 2564-07-13 at 17 00 31" src="https://user-images.githubusercontent.com/34004612/125432913-7999bfe1-8083-47d0-9881-8ff544bd8ecd.png">

[qr_code.png](https://user-images.githubusercontent.com/34004612/125432913-7999bfe1-8083-47d0-9881-8ff544bd8ecd.png)

#### 5. Priority of change

Normal, High or Immediate.

Normal

#### 6. Additional Notes

Any further information that you would like to add.