### PR TITLE
Fix - phone number input box not showing

### DIFF
--- a/templates/payment/form-truemoney.php
+++ b/templates/payment/form-truemoney.php
@@ -18,8 +18,8 @@
 </fieldset>
 
 <script type="text/javascript">
-	let phone_number_field   = document.getElementById( 'omise_phone_number_field' );
-	let phone_number_default = document.getElementById( 'omise_phone_number_default' );
+	var phone_number_field   = document.getElementById( 'omise_phone_number_field' );
+	var phone_number_default = document.getElementById( 'omise_phone_number_default' );
 
 	phone_number_default.addEventListener( 'change', ( e ) => {
 		phone_number_field.style.display = e.target.checked ? "none" : "block";


### PR DESCRIPTION
#### 1. Objective

![image](https://user-images.githubusercontent.com/16201698/125892515-edb6cd3f-05e9-4813-b9a8-6bf8324cb9f7.png)

Fix - input box not showing after unchecking **Same as Billing Detail**

**Related information**:
Related issue(s): internal ticket [CS-814](https://omise.atlassian.net/browse/CS-814)

#### 2. Description of change

Fix error:

![image](https://user-images.githubusercontent.com/16201698/125892441-4fa8e4ca-c4b5-48bf-bd85-1b7ee45a5f01.png)

#### 3. Quality assurance

**🔧 Environments:**
- **WooCommerce**: 5.5.1
- **WordPress**: 5.7.2
- **PHP**: 7.3.8
- **Omise-PHP**: 2.13.0
- **Omise-WooCommerce**: 4.9

**✏️ Details:**

1. Enable TrueMoney Wallet on WordPress Admin.
2. Go to storefront, order and select TrueMoney Wallet as a payment method.
3. Uncheck **Same as Billing Detail**, an input box should appear.
4. Fill in your phone number and click **Place order**.
5. Check the charge log on dashboard to see if the phone number used is correct.

#### 4. Impact of the change

![Chanapa 2021-07-16 at 11 11 28 AM](https://user-images.githubusercontent.com/16201698/125890628-9ce6b567-1aab-41e3-b15e-60784a7e698f.png)

If this option is selected, the phone number on Billing details will be used.
Otherwise, users will be able to input a different phone number.

#### 5. Priority of change

Normal

#### 6. Additional Notes

n/a