### PR TITLE
hotfix fpx banks not showing

### DIFF
--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -46,7 +46,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite {
 				'title'       => __( 'Title', 'omise' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
-				'default'     => __( 'Online Banking by Omise', 'omise' ),
+				'default'     => __( 'Online Banking (FPX)', 'omise' ),
 			),
 
 			'description' => array(

--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -46,7 +46,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite {
 				'title'       => __( 'Title', 'omise' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
-				'default'     => __( 'FPX', 'omise' ),
+				'default'     => __( 'Online Banking by Omise', 'omise' ),
 			),
 
 			'description' => array(

--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -8,7 +8,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite {
 		parent::__construct();
 
 		$this->id                 = 'omise_fpx';
-		$this->has_fields         = false;
+		$this->has_fields         = true;
 		$this->method_title       = __( 'Omise FPX', 'omise' );
 		$this->method_description = __( 'Accept payment through FPX', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );


### PR DESCRIPTION
#### 1. Objective

Fix FPX form not showing correctly
<img width="584" alt="Screen Shot 2564-07-16 at 18 09 49" src="https://user-images.githubusercontent.com/25361029/125938826-4ec4ac68-1adf-4c83-a9e0-eb40e179e0dc.png">

#### 2. Description of change

has_field flag was mistakenly false which resulted in the bank list being hidden

#### 3. Quality assurance

Test this update locally and ensure FPX banklist shows up correctly

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **WooCommerce**: v4.3.0
- **WordPress**: v5.4.2
- **PHP version**: 7.3.3

**✏️ Details:**

Enable FPX through Omise setting and try to checkout selecting FPX as payment method, a bank form should show.

#### 4. Impact of the change

Fix FPX bank list UI, should be no impact since this wasn't released yet

#### 5. Priority of change
High

#### 6. Additional Notes

Any further information that you would like to add.