### PR TITLE
[APM2-60] Remove Paynow QR code from merchant new order email

### DIFF
--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -27,7 +27,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 		add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_qrcode' ) );
-		add_action( 'woocommerce_email_after_order_table', array( $this, 'email_qrcode' ) );
+		add_action( 'woocommerce_email_after_order_table', array( $this, 'email_qrcode' ), 10, 2);
 	}
 
 	/**
@@ -65,7 +65,11 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 	 * @see   woocommerce/templates/emails/email-order-details.php
 	 * @see   woocommerce/templates/emails/plain/email-order-details.php
 	 */
-	public function email_qrcode( $order ) {
+	public function email_qrcode( $order, $sent_to_admin = false ) {
+	  if ( $sent_to_admin ) {
+  		return;
+  	}
+
 		if ( $this->id == $order->get_payment_method() ) {
 			$this->display_qrcode( $order, 'email' );
 		}

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -27,7 +27,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 		add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_qrcode' ) );
-		add_action( 'woocommerce_email_after_order_table', array( $this, 'email_qrcode' ), 10, 2);
+		add_action( 'woocommerce_email_after_order_table', array( $this, 'email_qrcode' ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

Solve issue where a Paynow QR code is also sent to merchant in New Order email which causes confusion.

This section will be used in the release notes. 

**Related information**:
Fixed Issue: Paynow QR code sent to merchant email

#### 2. Description of change

Merchant that choses to receive Paynow New Order email will no longer get QR code

#### 3. Quality assurance

Ensure normal payment flow can be completed for Paynow

**🔧 Environments:**

Tested locally with latest Omise.js

WooCommerce: v5.4.2
WordPress: v5.8
PHP version: 7.1

**✏️ Details:**

Explain how to manually test this feature.

Ensure merchant email is set in New Order email subscription, make a purchase choosing Paynow and an email should be sent to merchant without the QR code

#### 4. Impact of the change
Only email template change for merchant

Note: Please provide a screenshot if your changed impact to UI.
<img width="555" alt="Screen Shot 2564-10-15 at 14 13 24" src="https://user-images.githubusercontent.com/25361029/137447044-109a17fc-f985-4fef-a298-0684d674a63b.png">

#### 5. Priority of change

Normal

#### 6. Additional Notes

Any further information that you would like to add.