### PR TITLE
[APM2-59]no longer send merchant email for new order with status equal to on-hold

### DIFF
--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -79,13 +79,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		$this->payment_settings = $this->omise_settings->get_settings();
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'omise_checkout_assets' ) );
-        add_filter( 'woocommerce_email_recipient_new_order', array($this, 'disable_merchant_order_on_hold_email'), 10, 2 );
+		add_filter( 'woocommerce_email_recipient_new_order', array($this, 'disable_merchant_order_on_hold_email'), 10, 2 );
     }
 
-    public function disable_merchant_order_on_hold_email( $recipient, $order ) {
-        if ($order->get_status() == 'on-hold') $recipient = '';
-        return $recipient;
-    }
+	public function disable_merchant_order_on_hold_email( $recipient, $order ) {
+		if ($order->get_status() == 'on-hold') $recipient = '';
+		return $recipient;
+	}
 
 	/**
 	 * Register all required javascripts


### PR DESCRIPTION
#### 1. Objective

To prevent order email sending to merchant once order created with status as `on-hold` which happen when checkout card with PAYNOW.

**Related information**:
Related issue(s): #< GitHub ticket number > (optional)

#### 2. Description of change

Override Woocommerce filter for `woocommerce_email_recipient_new_order` which able to initiate with status as `on-hold` to not send order email to merchant. 

Additionally add the reasoning for change details if they're complex or abstract.

#### 3. Quality assurance

Ensure normal payment flow can be completed for Paynow

**🔧 Environments:**

Tested locally by pointing OMISE_API_URL to staging-omise

WooCommerce: v5.7.1
WordPress: v5.8
PHP version: 7.1

**✏️ Details:**
1. Make sure setting merchant email at `/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order` or /wp-admin/admin.php?page=wc-settings&tab=email to your valid email
1. Checkout cart with `Paynow` payment make sure customer email is valid and accessible
1. Go to `customer` mail box `should still receive` new order email
1. Go to `merchant` mail box `should not receive` new order email
1. Checkout cart with `Credit Card` and accessible
1. Go to `customer` mail box `should still receive` new order email
1. Go to `merchant` mail box `should still receive` new order email

#### 4. Impact of the change

List the steps that must be taken for this PR to work.
E.g.: rake yak:shave, Add "yak_key" to environment variables, ...

Be sure to include all systems that needs to be changed or which system is affected by the change
(Ex: Requires Elastic search to be installed and configured in secrets.yml).

Note: Please provide a screenshot if your changed impact to UI.

#### 5. Priority of change

Normal

#### 6. Additional Notes

No