### PR TITLE
[APM2-60] No longer sends qr code when order process

### DIFF
--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -68,6 +68,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 	 * @see   woocommerce/templates/emails/plain/email-order-details.php
 	 */
 	public function email_qrcode( $order, $sent_to_admin = false ) {
+		// Avoid sending QR code if email is sent to admin or if order is processing
 		if ( $sent_to_admin || is_a($order, 'WC_Order') && $order->get_status() == 'processing') {
 			return;
 		}


### PR DESCRIPTION
#### 1. Objective

The email sent to customer when processing contains a qr code which can cause confusion, it's re

#### 2. Description of change

Fix QR code showing in processing order email

#### 3. Quality assurance

email sent to customer when order processing does not contain QR code
🔧 Environments:

Tested locally by pointing OMISE_API_URL to Staging

WooCommerce: v5.7.1
WordPress: v5.8
PHP version: 7.1

#### 4. Impact of the change
No impact, this is to ensure the behavior remains the same as before

#### 5. Priority of change

High

#### 6. Additional Notes

Any further information that you would like to add.