### PR TITLE
[APM2-137] Fix order paid with Promptpay not send email when order status change to processing

### DIFF
--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -16,6 +16,8 @@ abstract class Omise_Payment_Offline extends Omise_Payment {
 	 */
 	protected $source_type;
 
+	protected $enabled_processing_notification = true;
+
 	/**
 	 * @inheritdoc
 	 */
@@ -54,7 +56,7 @@ abstract class Omise_Payment_Offline extends Omise_Payment {
 				'redirect' => $this->get_return_url( $order )
 			);
 		}
-		
+
 		return $this->payment_failed(
 			sprintf(
 				__( 'Please feel free to try submitting your order again, or contact our support team if you have any questions (Your temporary order id is \'%s\')', 'omise' ),

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -24,8 +24,6 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 		$this->restricted_countries = array( 'SG' );
 		$this->source_type          = 'paynow';
 
-		$this->enabled_processing_notification = true;
-
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
 		add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'display_qrcode' ) );


### PR DESCRIPTION
1. Objective

To fix order paid with Promptpay not send email when order status change to processing

2. Description of change

Offline Payment method will send email when order status change to processing by default

3. Quality assurance

email sent to merchant when order status change of order such as PayNow or Promptypay to processing.
![Screen Shot 2564-10-26 at 15 24 02](https://user-images.githubusercontent.com/90759391/138838253-4138cfdf-7f5e-4e48-826e-365f9352f035.png)
![Screen Shot 2564-10-26 at 15 24 16](https://user-images.githubusercontent.com/90759391/138838493-aabc8aa3-6194-40ce-a9c8-1557f02c7464.png)

email of other payment method will be sent as usual.

🔧 Environments:

Tested locally by pointing OMISE_API_URL to Staging

WooCommerce: v5.7.1
WordPress: v5.8
PHP version: 7.1

4. Impact of the change

No impact, this is to ensure the behavior remains the same as before

5. Priority of change

High

6. Additional Notes

Any further information that you would like to add.