### PR TITLE
fix other payment won't send email on on-hold order

### DIFF
--- a/includes/libraries/omise-plugin/helpers/mailer.php
+++ b/includes/libraries/omise-plugin/helpers/mailer.php
@@ -21,7 +21,9 @@ if (! class_exists('OmisePluginHelperMailer')) {
          * @return mixed|string
          */
         public function disable_merchant_order_on_hold( $recipient, $order ) {
-            if (is_a($order, 'WC_Order') && $order->get_status() == 'on-hold' ) $recipient = '';
+            $payment_gateway = wc_get_payment_gateway_by_order( $order );
+            if (is_a($order, 'WC_Order') && is_a( $payment_gateway, 'Omise_Payment' ) &&
+                $order->get_status() == 'on-hold' ) $recipient = '';
             return $recipient;
         }
     }


### PR DESCRIPTION
1. Objective

To fix issue when user make a payment via non omise payment then order email for on-hold status won't be send to merchant

2. Description of change

Non Omise Payment will always send email to merchant for order with status on-hold

3. Quality assurance

When user make payment with non Omise payment then order email with status on-hold will always send to the merchant but with Omise payment there should be no order email with status on-hold send to the merchant

🔧 Environments:

Tested locally by pointing OMISE_API_URL to Staging

WooCommerce: v5.7.1
WordPress: v5.8
PHP version: 7.1

4. Impact of the change

No impact, this is to ensure the behavior remains the same as before

5. Priority of change

High
