### PR TITLE
Release 4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+### [v4.16 _(Dec 14, 2021)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.16)
+
+#### 👾 Bug Fixes
+- Allow non Omise payment to send email to merchant once make order with status as oh-hold (PR [#242](https://github.com/omise/omise-woocommerce/pull/242))
+
+# CHANGELOG
 ### [v4.15 _(Oct 26, 2021)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.15)
 
 #### 🚀 Enhancements

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     4.15
+ * Version:     4.16
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -20,7 +20,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '4.15';
+	public $version = '4.16';
 
 	/**
 	 * The Omise Instance.
@@ -48,10 +48,10 @@ class Omise {
 		do_action( 'omise_initiated' );
 	}
 
-	/** 
+	/**
 	 * Check if all dependencies are loaded
 	 * properly before Omise-WooCommerce.
-	 * 
+	 *
 	 * @since  3.2
 	 */
 	public function check_dependencies() {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 5.9.0
-Stable tag: 4.15
+Stable tag: 4.16
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,11 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 4.16 =
+
+#### 👾 Bug Fixes
+- Allow non Omise payment to send email to merchant once make order with status as oh-hold (PR [#242](https://github.com/omise/omise-woocommerce/pull/242))
 
 = 4.15 =
 


### PR DESCRIPTION
#### 1. Objective

Release information for version 4.16

#### 2. Description of change

#### 👾 Bug Fixes
- Allow non Omise payment to send email to merchant once make order with status as oh-hold (PR [#242](https://github.com/omise/omise-woocommerce/pull/242))

#### 3. Quality assurance

All test are done in each PR, refer to each for more info

**✏️ Details:**

Test can be done locally with wordpress and manual installation of omise-woocommerce

#### 4. Impact of the change

No impact

#### 5. Priority of change

Normal

#### 6. Additional Notes