### PR TITLE
[APM2-579] Add checkout filter currency for mobile banking

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -249,7 +249,8 @@ ul.omise-banks-list {
 	background-size: cover;
 	width: 32px;
 	height: 32px;
-	margin: auto;
+	margin-bottom: 6px;
+	margin-left: 10px;
 	vertical-align: middle;
 }
 
@@ -278,6 +279,7 @@ ul.omise-banks-list {
 
 	.omise-banks-list .mobile-banking-label {
 		padding-left: 8px;
+		padding-bottom: 5px;
 	}
 }
 

--- a/includes/backends/class-omise-backend-mobile-banking.php
+++ b/includes/backends/class-omise-backend-mobile-banking.php
@@ -28,7 +28,7 @@ class Omise_Backend_Mobile_Banking extends Omise_Backend {
 
 	/**
 	 *
-	 * @return array  of an available mobile banking providers
+	 * @return array of an available mobile banking providers
 	 */
 	public function get_available_providers($currency) {
 

--- a/includes/backends/class-omise-backend-mobile-banking.php
+++ b/includes/backends/class-omise-backend-mobile-banking.php
@@ -30,7 +30,7 @@ class Omise_Backend_Mobile_Banking extends Omise_Backend {
 	 *
 	 * @return array of an available mobile banking providers
 	 */
-	public function get_available_providers($currency) {
+	public function get_available_providers( $currency ) {
 
 		$providers = $this->capabilities()->getBackends( $currency );
 

--- a/includes/backends/class-omise-backend-mobile-banking.php
+++ b/includes/backends/class-omise-backend-mobile-banking.php
@@ -32,7 +32,7 @@ class Omise_Backend_Mobile_Banking extends Omise_Backend {
 	 */
 	public function get_available_providers($currency) {
 
-		$providers = $this->capabilities()->getBackends($currency);
+		$providers = $this->capabilities()->getBackends( $currency );
 
 		$mobile_banking_providers = array();
 

--- a/includes/backends/class-omise-backend-mobile-banking.php
+++ b/includes/backends/class-omise-backend-mobile-banking.php
@@ -30,9 +30,9 @@ class Omise_Backend_Mobile_Banking extends Omise_Backend {
 	 *
 	 * @return array  of an available mobile banking providers
 	 */
-	public function get_available_providers() {
+	public function get_available_providers($currency) {
 
-		$providers = $this->capabilities()->getBackends();
+		$providers = $this->capabilities()->getBackends($currency);
 
 		$mobile_banking_providers = array();
 

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -53,7 +53,7 @@ class Omise_Capabilities {
 	 * @return string
 	 */
 	public function getBackends( $currency = '' ) {
-		$params   = array();
+		$params = array();
 		if ( $currency ) {
 			$params[] = $this->capabilities->backendFilter['currency']( $currency );
 		}

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -52,14 +52,12 @@ class Omise_Capabilities {
 	 *
 	 * @return string
 	 */
-	public function getBackends( $currency = '') {
-
+	public function getBackends( $currency = '' ) {
 		$params   = array();
-
 		if ( $currency ) {
 			$params[] = $this->capabilities->backendFilter['currency']( $currency );
 		}
-
+		
 		return $this->capabilities->getBackends( $params );
 	}
 

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -52,8 +52,15 @@ class Omise_Capabilities {
 	 *
 	 * @return string
 	 */
-	public function getBackends() {
-		return $this->capabilities->getBackends();
+	public function getBackends( $currency = '') {
+
+		$params   = array();
+
+		if ( $currency ) {
+			$params[] = $this->capabilities->backendFilter['currency']( $currency );
+		}
+
+		return $this->capabilities->getBackends( $params );
 	}
 
 	/**

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -57,7 +57,7 @@ class Omise_Capabilities {
 		if ( $currency ) {
 			$params[] = $this->capabilities->backendFilter['currency']( $currency );
 		}
-		
+
 		return $this->capabilities->getBackends( $params );
 	}
 

--- a/includes/gateway/class-omise-payment-mobilebanking.php
+++ b/includes/gateway/class-omise-payment-mobilebanking.php
@@ -67,7 +67,7 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite {
 
 		Omise_Util::render_view( 'templates/payment/form-mobilebanking.php', 
 		array(
-			'mobile_banking_backends' => $this->backend->get_available_providers($currency),
+			'mobile_banking_backends' => $this->backend->get_available_providers( $currency ),
 		) );
 	}
 

--- a/includes/gateway/class-omise-payment-mobilebanking.php
+++ b/includes/gateway/class-omise-payment-mobilebanking.php
@@ -62,11 +62,12 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite {
 	 * @see woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
 	 */
 	public function payment_fields() {
+		$currency   = get_woocommerce_currency();
 		parent::payment_fields();
 
 		Omise_Util::render_view( 'templates/payment/form-mobilebanking.php', 
 		array(
-			'mobile_banking_backends' => $this->backend->get_available_providers(),
+			'mobile_banking_backends' => $this->backend->get_available_providers($currency),
 		) );
 	}
 


### PR DESCRIPTION
#### 1. Objective

Fix displaying payment options for mobile banking to display only support checkout currency 

Task: https://omise.atlassian.net/browse/APM2-579

#### 2. Description of change

add backend filter by checkout currency from woocommerce api

#### 3. Quality assurance

Test this update locally and ensure pyament methods shows up correctly

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

- **WooCommerce**: v6.2.2
- **WordPress**: v5.9.1
- **PHP version**: 7.3.33
- **Omise plugin version**: Omise-WooCommerce 4.16 

**✏️ Details:**

Enable Mobile banking through Omise setting and try to checkout selecting mobile banking as payment method, a form should show only support options. (try switching currency in woocommerce setting in `Currency options`
#### 4. Impact of the change
**Before**
![image](https://user-images.githubusercontent.com/97080697/157803073-3dab3514-a1a4-43ee-9084-1f6a127167ad.png)

**After**
![image](https://user-images.githubusercontent.com/97080697/157803100-ca3c534c-149c-4d90-a013-cdbc8ebed362.png)

![image](https://user-images.githubusercontent.com/97080697/157803203-4eb6abcd-8395-4a08-9b96-7db8128b3795.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

Any further information that you would like to add.