### PR TITLE
Remove mobile banking OCBC PAO

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -395,12 +395,6 @@ ul.omise-banks-list {
  * mobile banking logo
  */
 
-/** OCBC PAO **/
-.mobile-banking-logo.ocbc_pao {
-	background: url('../images/ocbc-pao.png');
-	background-size: cover;
-}
-
 /** KPLUS **/
 .mobile-banking-logo.kplus {
 	background: url('../images/kplus.png');

--- a/includes/backends/class-omise-backend-mobile-banking.php
+++ b/includes/backends/class-omise-backend-mobile-banking.php
@@ -11,10 +11,6 @@ class Omise_Backend_Mobile_Banking extends Omise_Backend {
 
 	public function initiate() {
 		self::$providers = array(
-			'mobile_banking_ocbc_pao' => array(
-				'title'              => __( 'OCBC Pay Anyone', 'omise' ),
-				'logo'				 => 'ocbc_pao',
-			),
 			'mobile_banking_kbank' => array(
 				'title'              => __( 'Kasikorn Bank', 'omise' ),
 				'logo'				 => 'kplus',

--- a/includes/gateway/class-omise-payment-mobilebanking.php
+++ b/includes/gateway/class-omise-payment-mobilebanking.php
@@ -20,7 +20,7 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite {
 
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );
-		$this->restricted_countries = array( 'SG', 'TH');
+		$this->restricted_countries = array( 'TH' );
 
 		$this->backend     = new Omise_Backend_Mobile_Banking;
 


### PR DESCRIPTION
#### 1. Objective

Hold the mobile banking ocbc pao release because of we found issue when lunch order confirmation page.

#### 2. Description of change

Remove mobile banking ocbc pao.

#### 3. Quality assurance

OCBC PayAnyone mobile banking option not showing on the checkout page.

#### 4. Impact of the change

In Checkout Page, Mobile Banking will not show OCBC PayAnyone item in list.

#### 5. Priority of change

Normal.

#### 6. Additional Notes
