### PR TITLE
[APM2-561] [APM2-551] Add support for moblie banking BAY and BBL

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -414,6 +414,21 @@ ul.omise-banks-list {
 	border: 4px solid #4e2e7f;
 }
 
+/** BAY **/
+.mobile-banking-logo.bay {
+	background: url('../images/bay.svg') #fec43b;
+	border-color: #fec43b;
+	border: 4px solid #fec43b;
+}
+
+/** BBL **/
+.mobile-banking-logo.bbl {
+	background: url('../images/bbl.svg') #1e4598;
+	border-color: #1e4598;
+	border: 4px solid #1e4598;
+}
+
+
 /**
 fpx bank logos
 **/

--- a/includes/backends/class-omise-backend-mobile-banking.php
+++ b/includes/backends/class-omise-backend-mobile-banking.php
@@ -23,6 +23,14 @@ class Omise_Backend_Mobile_Banking extends Omise_Backend {
 				'title'              => __( 'Siam Commercial Bank', 'omise' ),
 				'logo'				 => 'scb',
 			),
+			'mobile_banking_bay' => array(
+				'title'              => __( 'Krungsri', 'omise' ),
+				'logo'				 => 'bay',
+			),
+			'mobile_banking_bbl' => array(
+				'title'              => __( 'Bangkok Bank', 'omise' ),
+				'logo'				 => 'bbl',
+			)
 		);
 	}
 

--- a/includes/backends/class-omise-backend-mobile-banking.php
+++ b/includes/backends/class-omise-backend-mobile-banking.php
@@ -24,7 +24,7 @@ class Omise_Backend_Mobile_Banking extends Omise_Backend {
 				'logo'				 => 'scb',
 			),
 			'mobile_banking_bay' => array(
-				'title'              => __( 'Krungsri', 'omise' ),
+				'title'              => __( 'Bank of Ayudhya', 'omise' ),
 				'logo'				 => 'bay',
 			),
 			'mobile_banking_bbl' => array(


### PR DESCRIPTION
#### 1. Objective

Add support for mobile banking BAY and BBL.

**Related information**:
Related task(s): https://omise.atlassian.net/browse/APM2-561, https://omise.atlassian.net/browse/APM2-551

#### 2. Description of change

- Add mobile banking BAY payment type .
- Add mobile banking BBL payment type .

#### 3. Quality assurance

Test charge creation for BAY and BBL mobile banking.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **WooCommerce**: v6.2.2
- **WordPress**: v5.9.1
- **PHP version**: 7.3.33
- **Omise plugin version**: Omise-WooCommerce 4.16

**✏️ Details:**

Enable Mobile banking through Omise setting and try to checkout selecting mobile banking bbl or bay 
and click checkout charge should created on dashboard 

#### 4. Impact of the change

![image](https://user-images.githubusercontent.com/97080697/158511004-bb1a5529-53a8-42b8-b1f8-73f065bd0bd1.png)


Be sure to include all systems that needs to be changed or which system is affected by the change
(Ex: Requires Elastic search to be installed and configured in secrets.yml).

Note: Please provide a screenshot if your changed impact to UI.

#### 5. Priority of change

Normal

#### 6. Additional Notes

Any further information that you would like to add.