### PR TITLE
[FRON-1370]: Fixed the issue of description for Installment and TrueM…

### DIFF
--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -61,6 +61,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite {
 	 * @inheritdoc
 	 */
 	public function payment_fields() {
+		parent::payment_fields();
 		$currency   = get_woocommerce_currency();
 		$cart_total = WC()->cart->total;
 

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -63,6 +63,8 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 	 * @inheritdoc
 	 */
 	public function payment_fields() {
+		parent::payment_fields();
+
 		$currency   = get_woocommerce_currency();
 		$cart_total = WC()->cart->total;
 

--- a/includes/gateway/class-omise-payment-konbini.php
+++ b/includes/gateway/class-omise-payment-konbini.php
@@ -62,6 +62,7 @@ class Omise_Payment_Konbini extends Omise_Payment_Offline {
 	 * @inheritdoc
 	 */
 	public function payment_fields() {
+		parent::payment_fields();
 		Omise_Util::render_view( 'templates/payment/form-konbini.php', array() );
 	}
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -62,6 +62,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite {
 	 * @inheritdoc
 	 */
 	public function payment_fields() {
+		parent::payment_fields();
 		Omise_Util::render_view( 'templates/payment/form-truemoney.php', array() );
 	}
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     4.19
+ * Version:     4.19.1
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise


### PR DESCRIPTION
#### 1. Objective
Fix the issue of description set for Installment and TrueMoney wallet not displayed in the checkout page.

#### 2. Description of change
`Omise_Payment_Truemoney` and `Omise_Payment_Installment` classes override the `payment_fields` method but didn't call the parent `payment_fields` which prevented description to be displayed in the checkout page. This PR adds the parent class `payment_fields` method into the local `parent_fields` method.

#### 3. Quality assurance

- Enable the Installment and TrueMoney payment method
- Set the description
- Checkout with an item and look for the description in the installment and TrueMoney payment method

**🔧 Environments:**
- **WooCommerce**: v6.4.1
- **WordPress**: v5.9.3
- **PHP version**: 7.4.28
- **Omise plugin version**: Omise-WooCommerce 4.19