### PR TITLE
Release the version v4.19.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+
+### [v4.19.1 _(Apr 20, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.19.1)
+
+#### 🚀 Bug Fixes
+- Fixed the issue of description set for Installment and TrueMoney wallet not displayed in the checkout page. (PR [#260](https://github.com/omise/omise-woocommerce/pull/260))
+
 ### [v4.19 _(Apr 4, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.19)
 
 #### 🚀 Enhancements

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -20,7 +20,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '4.19';
+	public $version = '4.19.1';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 5.9.0
-Stable tag: 4.19
+Stable tag: 4.19.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 


### PR DESCRIPTION
  #### 1. Objective
  
  Release v4.19.1
  
  #### 2. Description of change
  
 ### [v4.19.1 _(Apr 20, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.19.1)

#### 🚀 Bug Fixes
- Fixed the issue of description set for Installment and TrueMoney wallet not displayed in the checkout page. (PR [#260](https://github.com/omise/omise-woocommerce/pull/260))