### PR TITLE
Release 4.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### [v4.19.2 _(Apr 21, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.19.2)
+
+#### 👾 Bug Fixes
+- Fixed the issue of cannot go to order confimation page after pay with OCBC Pay Anyone. (PR [#262](https://github.com/omise/omise-woocommerce/pull/262))
+
 ### [v4.19.1 _(Apr 20, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.19.1)
 
 #### 🚀 Bug Fixes

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     4.19.1
+ * Version:     4.19.2
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -20,7 +20,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '4.19.1';
+	public $version = '4.19.2';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 5.9.0
-Stable tag: 4.19.1
+Stable tag: 4.19.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,24 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 4.19.2 =
+
+#### 👾 Bug Fixes
+- Fixed the issue of cannot go to order confimation page after pay with OCBC Pay Anyone. (PR [#262](https://github.com/omise/omise-woocommerce/pull/262))
+
+= 4.19.1 =
+
+#### 🚀 Bug Fixes
+- Fixed the issue of description set for Installment and TrueMoney wallet not displayed in the checkout page. (PR [#260](https://github.com/omise/omise-woocommerce/pull/260))
+
+= 4.19 =
+
+#### 🚀 Enhancements
+- Update assets for mobile banking logos (PR [#257](https://github.com/omise/omise-woocommerce/pull/257))
+
+#### 👾 Bug Fixes
+- Fix issue with Rabbit LINE Pay being incompabible with older PHP versions (PR [#256](https://github.com/omise/omise-woocommerce/pull/256))
 
 = 4.18 =
 


### PR DESCRIPTION
**1. Objective**
Release information for version 4.18

**2. Description of change**
#### 👾 Bug Fixes
- Fixed the issue of cannot go to order confimation page after pay with OCBC Pay Anyone. (PR [#262](https://github.com/omise/omise-woocommerce/pull/262))

**3. Quality assurance**
All test are done in each PR, refer to each for more info.

✏️ Details:

Test can be done locally with wordpress and manual installation of omise-woocommerce

**4. Impact of the change**
No impact

**5. Priority of change**
Normal