### PR TITLE
[FRON-1433]: Issue of PromptPay QR code download button not downloadi…

### DIFF
--- a/assets/javascripts/omise-download-promptpay-as-png.js
+++ b/assets/javascripts/omise-download-promptpay-as-png.js
@@ -4,7 +4,7 @@
     $('a#omise-download-promptpay-qr').click(function(e) {
         if (isCanvasSupported()) {
             e.preventDefault();
-            var svg = document.querySelector('svg');
+            var svg = document.getElementById('omise-promptpay-qrcode-svg');
 
             /*
             Because of a Webkit (Safari) bug, where it won't fetch images from the SVG in time the first time around,
@@ -28,17 +28,17 @@
         for (var cd = 0; cd < destinationNode.childNodes.length; cd++) {
             var child = destinationNode.childNodes[cd];
             if (containerElements.indexOf(child.tagName) != -1) {
-                 copyStylesInline(child, sourceNode.childNodes[cd]);
-                 continue;
+                copyStylesInline(child, sourceNode.childNodes[cd]);
+                continue;
             }
             var style = sourceNode.childNodes[cd].currentStyle;
             if (style == "undefined" || style == null) continue;
             for (var st = 0; st < style.length; st++){
-                 child.style.setProperty(style[st], style.getPropertyValue(style[st]));
+                child.style.setProperty(style[st], style.getPropertyValue(style[st]));
             }
         }
     }
-     
+
     function triggerDownload (imgURI, fileName) {
         var evt = new MouseEvent("click", {
             view: window,
@@ -67,13 +67,12 @@
             canvas.height = bbox.height;
             var ctx = canvas.getContext("2d");
             ctx.clearRect(0, 0, bbox.width, bbox.height);
-
             ctx.drawImage(img, 0, 0);
+
             if (typeof navigator !== "undefined" && navigator.msSaveOrOpenBlob) {
                 var blob = canvas.msToBlob();         
                 navigator.msSaveOrOpenBlob(blob, fileName);
-            } 
-            else {
+            } else {
                 var imgURI = canvas
                     .toDataURL("image/png")
                     .replace("image/png", "image/octet-stream");

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -75,21 +75,26 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 	}
 
 	/**
-	 * @param string $url	url for the QR SVG image
+	 * @param string $url URL for the QR SVG image
+	 * @param string $id Value to be added in the id attribute of the svg element
 	 */
-	private function load_qr_svg_to_DOM($url) {
+	private function load_qr_svg_to_DOM($url, $id = null) {
 		$svg_file = file_get_contents($url);
 
 		$find_string   = '<svg';
 		$position = strpos($svg_file, $find_string);
 		
 		$svg_file_new = substr($svg_file, $position);
+
+		if($id) {
+			$svg_file_new = substr($svg_file_new, 0, 4) . " id='{$id}' " . substr($svg_file_new, 4);
+		}
 		
 		echo "<div class='omise-qr-image'>" . $svg_file_new . "</div>";
 	}
 
 	/**
-	 * @param WC_Order $order
+	 * @param WC_Order $order,
 	 *
 	 * @see   woocommerce/templates/emails/email-order-details.php
 	 * @see   woocommerce/templates/emails/plain/email-order-details.php
@@ -125,7 +130,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 			<div id="omise-offline-additional-details" class="omise omise-additional-payment-details-box omise-promptpay-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
 				<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
 				<div class="omise omise-promptpay-qrcode" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
-					<?php $this->load_qr_svg_to_DOM($qrcode) ?>
+					<?php $this->load_qr_svg_to_DOM($qrcode, 'omise-promptpay-qrcode-svg') ?>
 				</div>
 				<a id="omise-download-promptpay-qr" class="omise-download-promptpay-qr" href="<?php echo $qrcode ?>" download="qr_code.svg">Download QR</a>
 				<div>

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -87,7 +87,11 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 		$svg_file_new = substr($svg_file, $position);
 
 		if($id) {
-			$svg_file_new = substr($svg_file_new, 0, 4) . " id='{$id}' " . substr($svg_file_new, 4);
+			$svgTagLength = 4; // length of tag <svg
+
+			// adding the id after <svg
+			// e.g: <svg id="id" remainging-text>
+			$svg_file_new = substr($svg_file_new, 0, $svgTagLength) . " id='{$id}' " . substr($svg_file_new, $svgTagLength);
 		}
 		
 		echo "<div class='omise-qr-image'>" . $svg_file_new . "</div>";


### PR DESCRIPTION
#### 1. Objective

Fix the issue of PromptPay QR code download button downloading an empty file.

**Jira Ticket**:
https://omise.atlassian.net/browse/FRON-1433

#### 2. Description of change

The query selector was pulling the first `svg` from the document. There were more than one `svg` element in the document and the intended `svg` was not the first one. This resulted in selecting a `svg` element which had no content. So, the download button downloaded a file with no content.

A second parameter `id` is added the `load_qr_svg_to_DOM` method to optionally add the id into the `svg` element. The default value will be null for `id`. This will help to query the specific element. The query selector is changed in the JS to target the specific svg element.

#### 3. Quality assurance

- Add an item to the card
- Go to checkout page
- Select PromptPay as the payment method
- Place order
- Click on Download QR

You should see a PNG file in your local machine. You should see a QR code opening the file.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

WooCommerce: v6.4.1
WordPress: v5.9.3
PHP version: 7.4.28
Omise plugin version: Omise-WooCommerce 4.19.2