### PR TITLE
[FRON-1463]: The method 'disable_merchant_order_on_hold' is made into…

### DIFF
--- a/includes/backends/class-omise-backend-fpx.php
+++ b/includes/backends/class-omise-backend-fpx.php
@@ -21,7 +21,12 @@ class Omise_Backend_FPX extends Omise_Backend {
 		$providers = $this->capabilities()->getFPXBanks();
 		$first_value = reset($providers);
 
-		if (property_exists($first_value, 'banks')) {
+		// Preventing the following error:
+		// Uncaught TypeError: property_exists(): Argument #1 must be of type object|string, bool given
+		$typeofFirstValue = gettype($first_value);
+		$isObjectOrString = 'object' === $typeofFirstValue || 'string' === $typeofFirstValue;
+
+		if ($isObjectOrString && property_exists($first_value, 'banks')) {
 			return $first_value->banks;
 		}
 	}

--- a/includes/classes/class-omise-image.php
+++ b/includes/classes/class-omise-image.php
@@ -10,7 +10,7 @@ if ( ! class_exists( 'Omise_Image' ) ) {
 		 * @param string $alternate_text Alternate text for the image
 		 * @return string HTML &lt;img&gt; element
 		 */
-		public function get_image( $file, $alternate_text ) {
+		public static function get_image( $file, $alternate_text ) {
 			$url = WC_HTTPS::force_https_url( plugin_dir_url( '' ) . 'omise/assets/images/' );
 			return "<img src='$url/$file' class='Omise-Image' style='width: 30px; max-height: 30px;' alt='$alternate_text' />";
 		}

--- a/includes/libraries/omise-plugin/helpers/mailer.php
+++ b/includes/libraries/omise-plugin/helpers/mailer.php
@@ -20,7 +20,7 @@ if (! class_exists('OmisePluginHelperMailer')) {
          * @param string|WC_Order $order
          * @return mixed|string
          */
-        public function disable_merchant_order_on_hold( $recipient, $order ) {
+        public static function disable_merchant_order_on_hold( $recipient, $order ) {
             $payment_gateway = wc_get_payment_gateway_by_order( $order );
             if (is_a($order, 'WC_Order') && is_a( $payment_gateway, 'Omise_Payment' ) &&
                 $order->get_status() == 'on-hold' ) $recipient = '';


### PR DESCRIPTION
#### 1. Objective

Fix the PHP 8 breaking change with `call_user_func_array()`.

Jira Ticket: [#1463](https://omise.atlassian.net/browse/FRON-1463)

#### 2. Description of change

The method 'disable_merchant_order_on_hold' is made into a static method because it is passed as a static method to the WP filter.

#### 3. Quality assurance

- Setup the WP development environment with this [PR](https://github.com/OmisePayments/docker-omise-woocommerce/pull/1). 
- On `docker-omise-woocommerce`,
- - Go to `build/apache`
- - Rename `Dockerfile` to any other namej
- - Rename `Dockerfile_PHP8` to `Dockerfile`
- - Run the container with `docker-compose up -d --build`
- Open storefront and checkout with Omise payment method
- You should not see the error mentioned in the ticket.

If you are using different development environment then make necessary changes to install PHP 8.

**🔧 Environments:**

- WooCommerce: v6.4.1
- WordPress: v5.9.3
- PHP version: 7.4.28
- Omise plugin version: Omise-WooCommerce 4.19.2