### PR TITLE
[FRON-1599]: Fixed the issue of order status changing to failed when we try to capture a charge that's already been captured.

### DIFF
--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -291,11 +291,11 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			);
 
 			// we don't want to delete the capture metadata for other errors like 401, 403, and 500
-			if ( static::ERROR_CODES['FAILED_CAPTURE'] === $omiseError['code'] || static::ERROR_CODES['EXPIRED_CHARGE'] === $omiseError['code'] ) {
+			if ( self::ERROR_CODES['FAILED_CAPTURE'] === $omiseError['code'] || self::ERROR_CODES['EXPIRED_CHARGE'] === $omiseError['code'] ) {
 				$this->delete_capture_metadata();
 			}
 
-			if ( static::ERROR_CODES['EXPIRED_CHARGE'] === $omiseError['code'] ) {
+			if ( self::ERROR_CODES['EXPIRED_CHARGE'] === $omiseError['code'] ) {
 				$this->order()->update_status( 'failed' );
 			}
 		}

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -285,7 +285,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$omiseError = $e->getOmiseError();
 			$this->order()->add_order_note(
 				sprintf(
-					wp_kses( __( 'Omise: Payment failed (manual capture).<br/>%s', 'omise' ), array( 'br' => array() ) ),
+					wp_kses( __( 'Omise: Capture failed (manual capture).<br/>%s', 'omise' ), array( 'br' => array() ) ),
 					$e->getMessage()
 				)
 			);


### PR DESCRIPTION
#### 1. Objective

Fix the issue of order status changing from processing to failed when user tries to capture a charge that's already been captured.
Jira Ticket:  [#1599](https://opn-ooo.atlassian.net/browse/FRON-1599)

#### 2. Description of change

A logic is added to delete the capture metadata only if `failed_capture` and `expired_charge` error codes are present because we don't to delete it for 400, 401, 403, and 500 errors. The order status will be changed to failed only if the error code is `expired_charge`.

#### 3. Quality assurance

- Use manual capture (Card, Google Pay, or Rabbit LinePay)
- Add items to cart and pay via card, Google pay or Rabbit LinePay
   - Check the order status. It should be processing.
- Go to Omise dashboard and capture the charge
- Go to the order in woocommerce and try to capture it. (See ticket description for image reference)
   - You should see `Omise: Payment failed (manual capture). charge was already captured` in the order note
- Check the order status. It should be processing, not failed.

**🔧 Environments:**

- WooCommerce: v6.4.1
- WordPress: v5.9.3
- PHP version: 7.3.33
- Omise plugin version: Omise-WooCommerce 4.21.1
