### PR TITLE
[PLUGINS-257: Sec-fetch header is checked to determine whether the re…

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -25,6 +25,10 @@ class Omise_Callback {
 	}
 
 	public static function execute() {
+		if(RequestHelper::isUserOriginated()) {
+			return wp_redirect( wc_get_checkout_url() );
+		}
+
 		$order_id = isset( $_GET['order_id'] ) ? sanitize_text_field( $_GET['order_id'] ) : null;
 
 		$callback = new self( wc_get_order( $order_id ) );
@@ -67,8 +71,8 @@ class Omise_Callback {
 	protected function invalid_result() {
 		$message = __(
 			'<strong>We cannot validate your payment result:</strong><br/>
-			 Note that your payment may have already been processed.<br/>
-			 Please contact our support team if you have any questions.',
+			Note that your payment may have already been processed.<br/>
+			Please contact our support team if you have any questions.',
 			'omise'
 		);
 
@@ -108,7 +112,7 @@ class Omise_Callback {
 			// Card authorized case.
 			$message = __(
 				'Omise: The payment is being processed.<br/>
-				 An amount %1$s %2$s has been authorized.',
+				An amount %1$s %2$s has been authorized.',
 				'omise'
 			);
 
@@ -134,8 +138,8 @@ class Omise_Callback {
 		// Offsite case.
 		$message = __(
 			'Omise: The payment is being processed.<br/>
-			 Depending on the payment provider, this may take some time to process.<br/>
-			 Please do a manual \'Sync Payment Status\' action from the <strong>Order Actions</strong> panel, or check the payment status directly at the Omise Dashboard later.',
+			Depending on the payment provider, this may take some time to process.<br/>
+			Please do a manual \'Sync Payment Status\' action from the <strong>Order Actions</strong> panel, or check the payment status directly at the Omise Dashboard later.',
 			'omise'
 		);
 
@@ -152,7 +156,7 @@ class Omise_Callback {
 	 * Resolving a case of charge status: failed.
 	 */
 	protected function payment_failed() {
-		$message         = __( "It seems we've been unable to process your payment properly:<br/>%s", 'omise' );
+		$message = __( "It seems we've been unable to process your payment properly:<br/>%s", 'omise' );
 		$failure_message = Omise()->translate( $this->charge['failure_message'] ) . ' (code: ' . $this->charge['failure_code'] . ')';
 
 		$this->order->add_order_note( sprintf( wp_kses( __( 'OMISE: Payment failed.<br/>%s', 'omise' ), array( 'br' => array() ) ), $failure_message ) );

--- a/includes/libraries/omise-plugin/Omise.php
+++ b/includes/libraries/omise-plugin/Omise.php
@@ -3,3 +3,4 @@
 require_once dirname(__FILE__).'/helpers/charge.php';
 require_once dirname(__FILE__).'/helpers/wc_order.php';
 require_once dirname(__FILE__).'/helpers/mailer.php';
+require_once dirname(__FILE__).'/helpers/request.php';

--- a/includes/libraries/omise-plugin/helpers/request.php
+++ b/includes/libraries/omise-plugin/helpers/request.php
@@ -1,0 +1,20 @@
+<?php
+if (! class_exists('RequestHelper')) {
+    class RequestHelper
+    {
+        /**
+         * Check whether the request is a user-originated operation or not.
+         * For example: entering a URL into the address bar, opening a bookmark,
+         * or dragging-and-dropping a file into the browser window.
+         * 
+         * Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
+         */
+        public static function isUserOriginated()
+        {
+            $fetchSite = sanitize_text_field($_SERVER['HTTP_SEC_FETCH_SITE']);
+
+            // "none" means the request is a user-originated operation
+            return 'none' === $fetchSite;
+        }   
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Prevent customer to reach return_uri before success payment

Jira: [#257](https://opn-ooo.atlassian.net/browse/SHOPIFYAPP-257)

#### 2. Description of change

Sec-fetch header is checked to determine whether the request is a user originated operation or not. Created a new helper class request for it. This can be used to add request related helper function in the future.

**Reference**
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
- https://stackoverflow.com/questions/66115532/what-does-the-sec-fetch-site-header-mean-why-is-the-origin-header-undefined

HTTP_REFERER header was not present this time. We might need to change the implementation in Magento.

 **Reference**
- https://stackoverflow.com/questions/5551094/http-referer-coming-back-with-null-key-does-not-exist-in-server

#### 3. Quality assurance

- Setup to use manual capture
- Checkout with some items via Card.
- You will be redirected to the authorize page
  - Do nothing on authorize page. Open a new tab
- Go to the return URI `http://{YOUR_BASE_PATH}/?wc-api=omise_callback&order_id={ORDER_ID}`
- You should be redirected to the checkout page.
- Go to the authorize page and complete the transaction
- You should be redirected to the thank you page.

**🔧 Environments:**

- WooCommerce: v6.4.1
- WordPress: v5.9.3
- PHP version: 7.3.33
- Omise plugin version: Omise-WooCommerce 4.22.0