### PR TITLE
Feature/plugins 269

### DIFF
--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -22,9 +22,7 @@
 		}
 		
 		$form.prepend( $ulError );
-		$("html, body").animate({
-			 scrollTop:0
-			 },"slow");
+		$("html, body").animate({ scrollTop:0 },"slow");
 	}
 	
 	function omiseFormHandler(){		
@@ -70,21 +68,21 @@
 					}
 				});
 
-				let errors                  = [],
-					omise_card              = {},
+				let errors = [],
+					omise_card = {},
 					omise_card_number_field = 'number',
-					omise_card_state_field  = 'state',
-					omise_card_fields       = {
-						'name'             : $( '#omise_card_name' ),
-						'number'           : $( '#omise_card_number' ),
+					omise_card_state_field = 'state',
+					omise_card_fields = {
+						'name' : $( '#omise_card_name' ),
+						'number' : $( '#omise_card_number' ),
 						'expiration_month' : $( '#omise_card_expiration_month' ),
-						'expiration_year'  : $( '#omise_card_expiration_year' ),
-						'security_code'    : $( '#omise_card_security_code' ),
-						'city'			   : $( '#billing_city' ),
-						'state'			   : $( '#billing_state' ),
-						'country'		   : $( '#billing_country' ),
-						'postal_code'	   : $( '#billing_postcode' ),
-						'street1'		   : $( '#billing_address_1' )
+						'expiration_year' : $( '#omise_card_expiration_year' ),
+						'security_code' : $( '#omise_card_security_code' ),
+						'city' : $( '#billing_city' ),
+						'state'	: $( '#billing_state' ),
+						'country' : $( '#billing_country' ),
+						'postal_code' : $( '#billing_postcode' ),
+						'street1' : $( '#billing_address_1' )
 					};
 
 				$.each( omise_card_fields, function( index, field ) {
@@ -123,7 +121,7 @@
 							handleTokensApiError(response);
 						};
 					});
-				}else{
+				} else {
 					showError( omise_params.cannot_load_omisejs + '<br/>' + omise_params.check_internet_connection );
 					$form.unblock();
 				}

--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -73,16 +73,27 @@
 				let errors                  = [],
 					omise_card              = {},
 					omise_card_number_field = 'number',
+					omise_card_state_field  = 'state',
 					omise_card_fields       = {
 						'name'             : $( '#omise_card_name' ),
 						'number'           : $( '#omise_card_number' ),
 						'expiration_month' : $( '#omise_card_expiration_month' ),
 						'expiration_year'  : $( '#omise_card_expiration_year' ),
-						'security_code'    : $( '#omise_card_security_code' )
+						'security_code'    : $( '#omise_card_security_code' ),
+						'city'			   : $( '#billing_city' ),
+						'state'			   : $( '#billing_state' ),
+						'country'		   : $( '#billing_country' ),
+						'postal_code'	   : $( '#billing_postcode' ),
+						'street1'		   : $( '#billing_address_1' )
 					};
 
 				$.each( omise_card_fields, function( index, field ) {
-					omise_card[ index ] = (index === omise_card_number_field) ? field.val().replace(/\s/g, '') : field.val();
+					if (index === omise_card_state_field) {
+						omise_card[ index ] = field.find(":selected").text();
+					} else {
+						omise_card[ index ] = (index === omise_card_number_field) ? field.val().replace(/\s/g, '') : field.val();
+					}
+
 					if ( "" === omise_card[ index ] ) {
 						errors.push( omise_params[ 'required_card_' + index ] );
 					}
@@ -101,7 +112,10 @@
 					Omise.createToken("card", omise_card, function (statusCode, response) {
 						if (statusCode == 200) {
 							$.each( omise_card_fields, function( index, field ) {
-								field.val( '' );
+								const sensitiveDataIndex = ['name', 'number', 'expiration_year', 'expiration_month', 'security_code'];
+								if (sensitiveDataIndex.includes(index)) {
+									field.val( '' );
+								}
 							} );
 							$form.append( '<input type="hidden" class="omise_token" name="omise_token" value="' + response.id + '"/>' );
 							$form.submit();


### PR DESCRIPTION
#### 1. Objective

Add billing address when creating a token.

Jira: [#269](https://opn-ooo.atlassian.net/browse/SHOPIFYAPP-269)

#### 2. Description of change

Added the billing address info while creating the token in the `assets/javascripts/omise-payment-form-handler.js` file.

**To do**: Discuss about adding billing address while adding card from the customer's dashboard.

#### 3. Quality assurance

- Checkout using 3DS
- Login to the dashboard and switch to your charge specific PSP
- Go to the charge page
- Click on the event charge.create
- Go to the body section of the event page.
- Look in the card object. You should see the billing address info.

Example: https://dashboard.staging-omise.co/admin/events/evnt_5sie9qtshuwswtamz78

**🔧 Environments:**

- WooCommerce: v6.4.1
- WordPress: v5.9.3
- PHP version: 7.3.33
- Omise plugin version: Omise-WooCommerce 4.22.0