### PR TITLE
Release 4.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 # CHANGELOG
 
 ### [v4.23.0 _(Jul 25, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.23.0)
+
 #### 🚀 Enhancements
 - Added Boost, DuitNow QR, DuitNow Online Banking/Wallets, Maybank QRPay and ShopeePay payment methods. Update Touch 'n Go to support non Alipay+. (PR [#287](https://github.com/omise/omise-woocommerce/pull/287))
 
 ### [v4.22.0 _(Jul 5, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.22.0)
-- Fix the issue of order status changing to failed when user tries to capture a charge that's already been captured. (PR [#281](https://github.com/omise/omise-woocommerce/pull/281)
-- Allow GrabPay payment in Thailand (PR [#282](https://github.com/omise/omise-woocommerce/pull/282)
 
+#### 🚀 Enhancements
+- Allow GrabPay payment in Thailand (PR [#282](https://github.com/omise/omise-woocommerce/pull/282))
+
+#### 👾 Bug Fixes
+- Fix the issue of order status changing to failed when user tries to capture a charge that's already been captured. (PR [#281](https://github.com/omise/omise-woocommerce/pull/281))
 
 ### [v4.21.1 _(Jun 16, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.21.1)
 
 #### 👾 Bug Fixes
-- Fixed the issue of creating GooglePay live mode payments (PR [#280](https://github.com/omise/omise-woocommerce/pull/280)
+- Fixed the issue of creating GooglePay live mode payments (PR [#280](https://github.com/omise/omise-woocommerce/pull/280))
 
 ### [v4.21.0 _(Jun 15, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.21.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### [v4.23.0 _(Jul 25, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.23.0)
+#### 🚀 Enhancements
+- Added Boost, DuitNow QR, DuitNow Online Banking/Wallets, Maybank QRPay and ShopeePay payment methods. Update Touch 'n Go to support non Alipay+. (PR [#287](https://github.com/omise/omise-woocommerce/pull/287))
 
 ### [v4.22.0 _(Jul 5, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.22.0)
 - Fix the issue of order status changing to failed when user tries to capture a charge that's already been captured. (PR [#281](https://github.com/omise/omise-woocommerce/pull/281)

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
- * Version:     4.22.0
+ * Version:     4.23.0
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -20,7 +20,7 @@ class Omise {
 	 *
 	 * @var string
 	 */
-	public $version = '4.22.0';
+	public $version = '4.23.0';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -41,8 +41,10 @@ From there:
 = 4.22.0 = 
 
 #### 🚀 Enhancements
-- Fix the issue of order status changing to failed when user tries to capture a charge that's already been captured.
-- Allow GrabPay payment in Thailand
+- Allow GrabPay payment in Thailand (PR [#282](https://github.com/omise/omise-woocommerce/pull/282))
+
+#### 👾 Bug Fixes
+- Fix the issue of order status changing to failed when user tries to capture a charge that's already been captured. (PR [#281](https://github.com/omise/omise-woocommerce/pull/281))
 
 = 4.21.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 5.9.0
-Stable tag: 4.22.0
+Stable tag: 4.23.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,11 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 4.23.0 = 
+
+#### 🚀 Enhancements
+- Added Boost, DuitNow QR, DuitNow Online Banking/Wallets, Maybank QRPay and ShopeePay payment methods. Update Touch 'n Go to support non Alipay+. (PR [#287](https://github.com/omise/omise-woocommerce/pull/287))
 
 = 4.22.0 = 
 


### PR DESCRIPTION
#### 🚀 Enhancements
- Added Boost, DuitNow QR, DuitNow Online Banking/Wallets, Maybank QRPay and ShopeePay payment methods. Update Touch 'n Go to support non Alipay+. (PR [#287](https://github.com/omise/omise-woocommerce/pull/287))