### PR TITLE
[ENGA3-290]: Issue of displaying an error as an option of Online bank…

### DIFF
--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -2,7 +2,6 @@
 defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 
 class Omise_Payment_FPX extends Omise_Payment_Offsite {
- 
 
 	public function __construct() {
 		parent::__construct();
@@ -24,9 +23,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite {
 		add_action( 'woocommerce_api_' . $this->id . '_callback', 'Omise_Callback::execute' );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
-  }
-  
- 
+	}
 
 
 	/**

--- a/templates/payment/form-fpx.php
+++ b/templates/payment/form-fpx.php
@@ -8,7 +8,7 @@
 					<option	
 						class="<?php echo $bank["code"];?>" 
 						value="<?php echo $bank["code"]; ?>"
-						<?= !$bank['active'] ? "disabled" : "" ; ?>
+						<?= $bank['active'] ?: "disabled" ?>
 					>
 							<?php echo $bank["name"]; ?> 
 							<?php if (!$bank['active']) echo " (offline)" ; ?>

--- a/templates/payment/form-fpx.php
+++ b/templates/payment/form-fpx.php
@@ -8,12 +8,12 @@
 					<option	
 						class="<?php echo $bank["code"];?>" 
 						value="<?php echo $bank["code"]; ?>"
-						<?php if (!$bank['active']) echo disabled ; ?>
+						<?= !$bank['active'] ? "disabled" : "" ; ?>
 					>
 							<?php echo $bank["name"]; ?> 
 							<?php if (!$bank['active']) echo " (offline)" ; ?>
 					</option>
-			 	<?php endforeach; ?>
+			<?php endforeach; ?>
 			</select>
 		</div>
 		<div class="fpx-terms-and-conditions-block">


### PR DESCRIPTION
#### 1. Objective

Fix the issue of displaying an error as an option of Online bank ing (FPX) when one of the bank is set as inactive

Jira: [#290](https://opn-ooo.atlassian.net/browse/ENGA3-290)

#### 2. Description of change

In `templates/payment/form-fpx.php` line 11, `disabled` was not wrapped by quote so PHP interpreted it as a constant. I changed the `disabled` into `"disabled"` to fix the issue.

#### 3. Quality assurance

Change to Malaysia PSP and see the drop down of the online banking (FPX) by going to the checkout page.

**Before**

<img width="1435" alt="Screen Shot 2565-08-22 at 10 55 35" src="https://user-images.githubusercontent.com/101558497/185845022-c9279bd7-2cc1-4472-9c48-ed8de0969e49.png">


**After**

<img width="971" alt="Screen Shot 2565-08-22 at 10 54 01" src="https://user-images.githubusercontent.com/101558497/185845514-8f29b618-ac42-4090-8461-8ce04440354b.png">



**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **WooCommerce**: v6.8.0
- **WordPress**: v6.0.1
- **PHP version**: 8.0.22
- **Omise plugin version**: Omise-WooCommerce 4.23.2