### PR TITLE
[ENGA3-420]: Updated Omise_Capabilities class to prevent calling capabilities API when the keys are null.

### DIFF
--- a/includes/admin/class-omise-page-settings.php
+++ b/includes/admin/class-omise-page-settings.php
@@ -58,10 +58,11 @@ class Omise_Page_Settings extends Omise_Admin_Page {
 		
 		$available_payment_methods = array();
 		$capabilities = Omise_Capabilities::retrieve();
-		
+
 		if ( $capabilities ){
 			$available_payment_methods = $capabilities->get_available_payment_methods();
 		}
+
 		/**
 		 * Added later at Omise-WooCommerce v3.11.
 		 * To migrate all the users that haven been using Omise-WooCommerce

--- a/includes/backends/class-omise-backend-installment.php
+++ b/includes/backends/class-omise-backend-installment.php
@@ -112,7 +112,7 @@ class Omise_Backend_Installment extends Omise_Backend {
 
 			$provider->provider_code   = str_replace( 'installment_', '', $provider->_id );
 			$provider->provider_name   = isset( $provider_detail ) ? $provider_detail['title'] : strtoupper( $provider->code );
-			$provider->interest_rate   = $this->capabilities()->is_zero_interest() ? 0 : ( $provider_detail['interest_rate'] );
+			$provider->interest_rate   = $capabilities->is_zero_interest() ? 0 : ( $provider_detail['interest_rate'] );
 			$provider->available_plans = $this->get_available_plans(
 				$purchase_amount,
 				$provider->allowed_installment_terms,

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -56,7 +56,8 @@ class Omise_Capabilities {
 		try {
 			$capabilities = OmiseCapabilities::retrieve( $publicKey , $secretKey );
 		} catch(\Exception $e) {
-			// suppressing error on the admin dashboard
+			// logging the error and suppressing error on the admin dashboard
+			error_log(print_r($e, true));
 			return null;
 		}
 

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -40,14 +40,16 @@ class Omise_Capabilities {
 		$secretKey = !$sKey ? $settings->secret_key() : $sKey;
 
 		// Do not call capabilities API if keys are not present
-		if($publicKey === null || $secretKey === null) {
+		if(empty($publicKey) || empty($secretKey)) {
 			return null;
 		}
 
 		if(self::$instance) {
 			$keysNotChanged = self::$instance->publicKey === $publicKey && self::$instance->secretKey === $secretKey;
 
-			// if keys are same then no need to call capabilities API as t
+			// if keys are same then we return the previous instance without calling
+			// capabilities API. This will prevent multiple calls that happens on each
+			// page refresh.
 			if($keysNotChanged) {
 				return self::$instance;
 			}

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -8,7 +8,7 @@ class Omise_Capabilities {
 	/**
 	 * @var self
 	 */
-	protected static $the_instance = null;
+	protected static $instance = null;
 
 	/**
 	 * @var \OmiseCapabilities
@@ -16,22 +16,55 @@ class Omise_Capabilities {
 	protected $capabilities;
 
 	/**
+	 * Stores previously used public key to compare with the newly fetched public key
+	 * @var string
+	 */
+	protected $publicKey = null;
+
+	/**
+	 * Stores previously used secret key to compare with the newly fetched secret key
+	 * @var string
+	 */
+	protected $secretKey = null;
+
+	/**
+	 * @param string|null $pKey
+	 * @param string|null $sKey
+	 *
 	 * @return self  The instance of Omise_Capabilities
 	 */
-	public static function retrieve( $publickey = null, $secretkey = null ) {
-		if ( ! self::$the_instance ) {
-			try {
-				$capabilities = OmiseCapabilities::retrieve( $publickey , $secretkey );
-			} catch(\Exception $e) {
-				// suppressing error on the admin dashboard
-				return null;
-			}
-	
-			self::$the_instance = new self();
-			self::$the_instance->capabilities = $capabilities;
+	public static function retrieve($pKey = null, $sKey = null)
+	{
+		$settings = Omise_Setting::instance();
+		$publicKey = !$pKey ? $settings->public_key() : $pKey;
+		$secretKey = !$sKey ? $settings->secret_key() : $sKey;
+
+		// Do not call capabilities API if keys are not present
+		if($publicKey === null || $secretKey === null) {
+			return null;
 		}
-	
-		return self::$the_instance;
+
+		if(self::$instance) {
+			$keysNotChanged = self::$instance->publicKey === $publicKey && self::$instance->secretKey === $secretKey;
+
+			// if keys are same then no need to call capabilities API as t
+			if($keysNotChanged) {
+				return self::$instance;
+			}
+		}
+
+		try {
+			$capabilities = OmiseCapabilities::retrieve( $publicKey , $secretKey );
+		} catch(\Exception $e) {
+			// suppressing error on the admin dashboard
+			return null;
+		}
+
+		self::$instance = new self();
+		self::$instance->capabilities = $capabilities;
+		self::$instance->publicKey = $publicKey;
+		self::$instance->secretKey = $secretKey;
+		return self::$instance;
 	}
 	
 	/**

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -67,12 +67,13 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 
 		$currency   = get_woocommerce_currency();
 		$cart_total = WC()->cart->total;
+		$capabilities = $this->backend->capabilities();
 
 		Omise_Util::render_view(
 			'templates/payment/form-installment.php',
 			array(
 				'installment_backends' => $this->backend->get_available_providers( $currency, $cart_total ),
-				'is_zero_interest'     => $this->backend->capabilities() ? $this->backend->capabilities()->is_zero_interest() : false
+				'is_zero_interest'     => $capabilities ? $capabilities->is_zero_interest() : false
 			)
 		);
 	}


### PR DESCRIPTION
#### 1. Objective

Prevent calling capabilities  API when the keys are null.

Jira Ticket: [#420](https://opn-ooo.atlassian.net/browse/ENGA3-420)

#### 2. Description of change

Updated `Omise_Capabilities` class to prevent calling capabilities API when the keys are null. Added a check that compares the newly fetched keys with the previously saved keys. If the keys are different then then we call to capabilities API else we return previously built instance.

**🔧 Environments:**

- WooCommerce: v6.8.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise plugin version: Omise-WooCommerce 4.23.3