### PR TITLE
[ENGA3-438]: Mobile banking redirect URI not working in Andoird Chrome.

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -24,14 +24,17 @@ class Omise_Callback {
 		if ( ! $this->order || ! $this->order instanceof WC_Abstract_Order ) $this->invalid_result();
 	}
 
-	public static function execute() {
-		if(RequestHelper::isUserOriginated()) {
+	public static function execute()
+	{
+		$order_id = isset( $_GET['order_id'] ) ? sanitize_text_field( $_GET['order_id'] ) : null;
+		$token = isset( $_GET['token'] ) ? sanitize_text_field( $_GET['token'] ) : null;
+		$order = wc_get_order( $order_id );
+
+		if(!RequestHelper::validateRequest($order->get_meta('token'))) {
 			return wp_redirect( wc_get_checkout_url() );
 		}
 
-		$order_id = isset( $_GET['order_id'] ) ? sanitize_text_field( $_GET['order_id'] ) : null;
-
-		$callback = new self( wc_get_order( $order_id ) );
+		$callback = new self( $order );
 		$callback->validate();
 	}
 

--- a/includes/gateway/class-omise-payment-mobilebanking.php
+++ b/includes/gateway/class-omise-payment-mobilebanking.php
@@ -81,7 +81,16 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite {
 		);
 
 		$source_type = sanitize_text_field( $_POST['omise-offsite']);
-		$return_uri = add_query_arg('order_id', $order_id, home_url('wc-api/omise_mobilebanking_callback'));
+		$token = TokenHelper::random();
+		$return_uri = add_query_arg(
+			[
+				'order_id' => $order_id,
+				'token' => $token
+			],
+			home_url('wc-api/omise_mobilebanking_callback')
+		);
+
+		$order->add_meta_data( 'token', $token, true );
 
 		return OmiseCharge::create( array(
 			'amount'      => Omise_Money::to_subunit( $order->get_total(), $order->get_currency() ),

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -107,7 +107,26 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		add_action( 'wp_enqueue_scripts', array( $this, 'omise_checkout_assets' ) );
 		add_action( 'woocommerce_order_status_processing', 'OmisePluginHelperMailer::processing_admin_notification', 10, 2 );
 		add_filter( 'woocommerce_email_recipient_new_order', 'OmisePluginHelperMailer::disable_merchant_order_on_hold', 10, 2 );
+		add_filter('is_protected_meta', [ $this, 'protectMetadata'], 10, 2);
     }
+
+	/**
+	 * Protect the metadata that is included in the return URI. The token is used to
+	 * validate the session for the order.
+	 *
+	 * @param boolean $protected
+	 * @param array   $metadataKeys
+	 *
+	 * @return boolean
+	 */
+	public function protectMetadata($protected, $metadataKeys)
+	{
+		if ( in_array( $metadataKeys, [ 'session' ] )) {
+			return true;
+		}
+
+		return $protected;
+	}
 
 	/**
 	 * Register all required javascripts

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -121,7 +121,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 */
 	public function protectMetadata($protected, $metadataKeys)
 	{
-		if ( in_array( $metadataKeys, [ 'session' ] )) {
+		if ( in_array( $metadataKeys, [ 'token' ] )) {
 			return true;
 		}
 

--- a/includes/libraries/omise-plugin/Omise.php
+++ b/includes/libraries/omise-plugin/Omise.php
@@ -4,3 +4,4 @@ require_once dirname(__FILE__).'/helpers/charge.php';
 require_once dirname(__FILE__).'/helpers/wc_order.php';
 require_once dirname(__FILE__).'/helpers/mailer.php';
 require_once dirname(__FILE__).'/helpers/request.php';
+require_once dirname(__FILE__).'/helpers/token.php';

--- a/includes/libraries/omise-plugin/helpers/request.php
+++ b/includes/libraries/omise-plugin/helpers/request.php
@@ -15,6 +15,22 @@ if (! class_exists('RequestHelper')) {
 
             // "none" means the request is a user-originated operation
             return 'none' === $fetchSite;
-        }   
+        }
+
+        /**
+         * @param string|null $orderToken
+         */
+        public function validateRequest($orderToken = null)
+        {
+            $token = isset( $_GET['token'] ) ? sanitize_text_field( $_GET['token'] ) : null;
+
+            // For mobile banking. This will be implemented for all other payment methods later.
+            if ($token) {
+                return $token === $orderToken;
+            }
+
+            // For other payment methods that does not include token in the return URI.
+            return !self::isUserOriginated();
+        }
     }
 }

--- a/includes/libraries/omise-plugin/helpers/token.php
+++ b/includes/libraries/omise-plugin/helpers/token.php
@@ -1,0 +1,18 @@
+<?php
+if (! class_exists('TokenHelper')) {
+    class TokenHelper
+    {
+        public static function random($length = 32)
+        {
+            // For PHP 7.0 and up
+            if (function_exists('random_bytes')) {
+                return bin2hex(random_bytes($length));
+            }
+
+            // For PHP 7.0 and down
+            if (function_exists('mcrypt_create_iv')) {
+                return bin2hex(mcrypt_create_iv($length, MCRYPT_DEV_URANDOM));
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Fix the issue of mobile banking redirect URI not working in Android chrome.

Jira Ticket: [#438](https://opn-ooo.atlassian.net/browse/ENGA3-438)

#### 2. Description of change

The `HTTP_SEC_FETCH_SITE` header returned `none` which indicates that the request is user originated even though it was originated from the mobile banking app. This caused the site to redirect to checkout page.

In this PR, we created a random unique token, saved it as a metadata to the order and added it to the return URI. When the site gets the redirect URI request, if the token is present, we check the token with the token saved in the order. If it matches we continue the process and show the success/failed page else we redirect to checkout page.

For now, it is just in mobile banking payment to solve the redirect URI issue. In the future we will implement this in all other payment methods as relying on HEADERs is not reliable.

#### 3. Quality assurance

Use UAT testing mobile app and checkout with mobile banking payment. If it is not available then use the production keys and test in production environment.

**🔧 Environments:**

- WooCommerce: v6.8.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise plugin version: Omise-WooCommerce 4.23.3