### PR TITLE
[ENGA3-438]: Turn the function validateRequest to static

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # example: *.js    @octocat @github/js
 
 # These owners will be the default owners for everything in the repo.
-* @aashishgurung
+* @aashishgurung @ajzkk

--- a/includes/libraries/omise-plugin/helpers/request.php
+++ b/includes/libraries/omise-plugin/helpers/request.php
@@ -20,7 +20,7 @@ if (! class_exists('RequestHelper')) {
         /**
          * @param string|null $orderToken
          */
-        public function validateRequest($orderToken = null)
+        public static function validateRequest($orderToken = null)
         {
             $token = isset( $_GET['token'] ) ? sanitize_text_field( $_GET['token'] ) : null;
 


### PR DESCRIPTION
#### 1. Objective

Turn the function `validateRequest` to static as it is used statically in the `class-omise-callback` else it won't work in PHP 8 and above.

```
PHP Fatal error:  Uncaught Error: Non-static method RequestHelper::validateRequest() cannot be called statically.
```

Reference:
- https://php.watch/versions/8.0/non-static-static-call-fatal-error

**🔧 Environments:**

- WooCommerce: v6.8.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise plugin version: Omise-WooCommerce 4.23.3