### PR TITLE
[ENGA3-453]: Fetching the keys from the user entered

### DIFF
--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -39,13 +39,15 @@ class Omise_Capabilities {
 		$publicKey = !$pKey ? $settings->public_key() : $pKey;
 		$secretKey = !$sKey ? $settings->secret_key() : $sKey;
 
+		$keys = self::getKeys($pKey, $sKey);
+
 		// Do not call capabilities API if keys are not present
-		if(empty($publicKey) || empty($secretKey)) {
+		if(empty($keys['public']) || empty($keys['secret'])) {
 			return null;
 		}
 
 		if(self::$instance) {
-			$keysNotChanged = self::$instance->publicKey === $publicKey && self::$instance->secretKey === $secretKey;
+			$keysNotChanged = self::$instance->publicKey === $keys['public'] && self::$instance->secretKey === $keys['secret'];
 
 			// if keys are same then we return the previous instance without calling
 			// capabilities API. This will prevent multiple calls that happens on each
@@ -56,7 +58,7 @@ class Omise_Capabilities {
 		}
 
 		try {
-			$capabilities = OmiseCapabilities::retrieve( $publicKey , $secretKey );
+			$capabilities = OmiseCapabilities::retrieve( $keys['public'] , $keys['secret'] );
 		} catch(\Exception $e) {
 			// logging the error and suppressing error on the admin dashboard
 			error_log(print_r($e, true));
@@ -65,9 +67,51 @@ class Omise_Capabilities {
 
 		self::$instance = new self();
 		self::$instance->capabilities = $capabilities;
-		self::$instance->publicKey = $publicKey;
-		self::$instance->secretKey = $secretKey;
+		self::$instance->publicKey = $keys['public'];
+		self::$instance->secretKey = $keys['secret'];
 		return self::$instance;
+	}
+
+	/**
+	 * @param string|null $pKey
+	 * @param string|null $sKey
+	*/
+	private static function getKeys($pKey = null, $sKey = null)
+	{
+		$settings = Omise_Setting::instance();
+
+		// Uncomment this for development and testing.
+		if ( ! empty( $_POST ) ) {
+			return self::getUserEnteredKeys();
+		}
+
+		return [
+			'public' => !$pKey ? $settings->public_key() : $pKey,
+			'secret' => !$sKey ? $settings->secret_key() : $sKey
+		];
+	}
+
+	/**
+	 * We have many classes that calls capabilities API before the user entered keys are saved.
+	 * This means they will use the old saved keys instead of new user entered keys. This will
+	 * cause issues like:
+	 *  - 401 unauthorized access
+	 *  - Expired keys
+	 *  - Others
+	 *
+	 * To avoid such issue we first get the user entered keys from $_POST so that other classes calls the
+	 * capabilities API from the user entered keys.
+	 */
+	private static function getUserEnteredKeys()
+	{
+		if ( ! isset( $_POST['omise_setting_page_nonce'] ) || ! wp_verify_nonce( $_POST['omise_setting_page_nonce'], 'omise-setting' ) ) {
+			wp_die( __( 'You are not allowed to modify the settings from a suspicious source.', 'omise' ) );
+		}
+
+		return [
+			'public' => isset( $_POST['sandbox'] ) ? $_POST['test_public_key'] : $_POST['live_public_key'],
+			'secret' => isset( $_POST['sandbox'] ) ? $_POST['test_private_key'] : $_POST['live_private_key']
+		];
 	}
 	
 	/**

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -105,17 +105,17 @@ class Omise_Capabilities {
 	private static function getUserEnteredKeys()
 	{
 		if (
-				! isset( sanitize_text_field($_POST['omise_setting_page_nonce']) ) ||
-				! wp_verify_nonce( sanitize_text_field($_POST['omise_setting_page_nonce']), 'omise-setting' )
+				! isset( $_POST['omise_setting_page_nonce'] ) ||
+				! wp_verify_nonce( $_POST['omise_setting_page_nonce'], 'omise-setting' )
 		) {
 			wp_die( __( 'You are not allowed to modify the settings from a suspicious source.', 'omise' ) );
 		}
 
 		return [
-			'public' => isset( sanitize_text_field($_POST['sandbox']) ) ?
+			'public' => isset( $_POST['sandbox'] ) ?
 				sanitize_text_field($_POST['test_public_key']) :
 				sanitize_text_field($_POST['live_public_key']),
-			'secret' => isset( sanitize_text_field($_POST['sandbox']) ) ?
+			'secret' => isset( $_POST['sandbox'] ) ?
 				sanitize_text_field($_POST['test_private_key']) :
 				sanitize_text_field($_POST['live_private_key'])
 		];

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -104,13 +104,20 @@ class Omise_Capabilities {
 	 */
 	private static function getUserEnteredKeys()
 	{
-		if ( ! isset( $_POST['omise_setting_page_nonce'] ) || ! wp_verify_nonce( $_POST['omise_setting_page_nonce'], 'omise-setting' ) ) {
+		if (
+				! isset( sanitize_text_field($_POST['omise_setting_page_nonce']) ) ||
+				! wp_verify_nonce( sanitize_text_field($_POST['omise_setting_page_nonce']), 'omise-setting' )
+		) {
 			wp_die( __( 'You are not allowed to modify the settings from a suspicious source.', 'omise' ) );
 		}
 
 		return [
-			'public' => isset( $_POST['sandbox'] ) ? $_POST['test_public_key'] : $_POST['live_public_key'],
-			'secret' => isset( $_POST['sandbox'] ) ? $_POST['test_private_key'] : $_POST['live_private_key']
+			'public' => isset( sanitize_text_field($_POST['sandbox']) ) ?
+				sanitize_text_field($_POST['test_public_key']) :
+				sanitize_text_field($_POST['live_public_key']),
+			'secret' => isset( sanitize_text_field($_POST['sandbox']) ) ?
+				sanitize_text_field($_POST['test_private_key']) :
+				sanitize_text_field($_POST['live_private_key'])
 		];
 	}
 	

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -81,7 +81,7 @@ class Omise_Capabilities {
 		$settings = Omise_Setting::instance();
 
 		// Check if user has submitted a form
-		if ( ! empty( $_POST ) ) {
+		if ( ! empty( $_POST ) && isset($_POST['sandbox']) && isset($_POST['test_public_key']) ) {
 			return self::getUserEnteredKeys();
 		}
 

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -80,7 +80,7 @@ class Omise_Capabilities {
 	{
 		$settings = Omise_Setting::instance();
 
-		// Uncomment this for development and testing.
+		// Check if user has submitted a form
 		if ( ! empty( $_POST ) ) {
 			return self::getUserEnteredKeys();
 		}
@@ -105,8 +105,8 @@ class Omise_Capabilities {
 	private static function getUserEnteredKeys()
 	{
 		if (
-				! isset( $_POST['omise_setting_page_nonce'] ) ||
-				! wp_verify_nonce( $_POST['omise_setting_page_nonce'], 'omise-setting' )
+			! isset( $_POST['omise_setting_page_nonce'] ) ||
+			! wp_verify_nonce( $_POST['omise_setting_page_nonce'], 'omise-setting' )
 		) {
 			wp_die( __( 'You are not allowed to modify the settings from a suspicious source.', 'omise' ) );
 		}

--- a/tests/unit/includes/class-omise-money-test.php
+++ b/tests/unit/includes/class-omise-money-test.php
@@ -31,10 +31,10 @@ class Omise_Money_Test extends TestCase {
 	 * @test
 	 */
 	public function convert_amount_with_4_decimal_points() {
-		$amount   = 4780.0409;
+		$amount   = 4780.0405;
 		$currency = 'thb';
 
-		$this->assertEquals( 478004.09, Omise_Money::to_subunit( $amount, $currency ) );
+		$this->assertEquals(478004.05, Omise_Money::to_subunit( $amount, $currency ));
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

Fix the issue of user unable to set new keys when their old keys are expired.

Jira Ticket: [#453](https://opn-ooo.atlassian.net/browse/ENGA3-453)

#### 2. Description of change

We have many classes that calls capabilities API before the user entered keys are saved. This means they will use the old saved keys instead of new user entered keys. This will cause issues like:
- 401 unauthorized access
- Expired keys

To avoid such issue we first get the user entered keys from $_POST so that other classes calls the capabilities API from the user entered keys.

#### 3. Quality assurance

- add valid keys in omise-woocommerce
- roll new keys
- revoke old keys
- use new keys in omise-woocommerce
- Save the settings.

**🔧 Environments:**

- WooCommerce: v6.8.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise plugin version: Omise-WooCommerce 4.24.0