### PR TITLE
[bug/ENGA3-453]: Fixing the issue of unable to add new live keys

### DIFF
--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -35,8 +35,6 @@ class Omise_Capabilities {
 	 */
 	public static function retrieve($pKey = null, $sKey = null)
 	{
-		$settings = Omise_Setting::instance();
-
 		$keys = self::getKeys($pKey, $sKey);
 
 		// Do not call capabilities API if keys are not present
@@ -76,12 +74,12 @@ class Omise_Capabilities {
 	*/
 	private static function getKeys($pKey = null, $sKey = null)
 	{
-		$settings = Omise_Setting::instance();
-
 		// Check if user has submitted a form
 		if ( ! empty( $_POST ) && isset($_POST['submit']) && $_POST['submit'] === 'Save Settings' ) {
 			return self::getUserEnteredKeys();
 		}
+
+		$settings = Omise_Setting::instance();
 
 		return [
 			'public' => !$pKey ? $settings->public_key() : $pKey,

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -36,8 +36,6 @@ class Omise_Capabilities {
 	public static function retrieve($pKey = null, $sKey = null)
 	{
 		$settings = Omise_Setting::instance();
-		$publicKey = !$pKey ? $settings->public_key() : $pKey;
-		$secretKey = !$sKey ? $settings->secret_key() : $sKey;
 
 		$keys = self::getKeys($pKey, $sKey);
 
@@ -81,7 +79,7 @@ class Omise_Capabilities {
 		$settings = Omise_Setting::instance();
 
 		// Check if user has submitted a form
-		if ( ! empty( $_POST ) && isset($_POST['sandbox']) && isset($_POST['test_public_key']) ) {
+		if ( ! empty( $_POST ) && isset($_POST['submit']) && $_POST['submit'] === 'Save Settings' ) {
 			return self::getUserEnteredKeys();
 		}
 


### PR DESCRIPTION
#### 1. Objective

Fix the hotfix issue of unable to save live keys.

#### 2. Description of change

Added a check that checks if `$_POST` has `submit` or not and if the value is `Save Settings`.

#### 3. Quality assurance

Saving the live keys
- add valid keys in omise-woocommerce
- roll new keys
- revoke old keys
- use new keys in omise-woocommerce
- Save the settings.

Checkout
- Checkout with any payment methods

**🔧 Environments:**

- WooCommerce: v6.8.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise plugin version: Omise-WooCommerce 4.24.1