### PR TITLE
[ENGA3-485] : Fixed wrong initialization cause conflict with other gateway

### DIFF
--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,9 @@
 /**
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
- * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
+ * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin 
+ * designed specifically for WooCommerce. The plugin adds support for 
+ * Omise Payment Gateway payment method to WooCommerce.
  * Version:     4.24.2
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
@@ -115,7 +117,15 @@ class Omise
 		defined('OMISE_PUBLIC_KEY') || define('OMISE_PUBLIC_KEY', $this->settings()->public_key());
 		defined('OMISE_SECRET_KEY') || define('OMISE_SECRET_KEY', $this->settings()->secret_key());
 		defined('OMISE_API_VERSION') || define('OMISE_API_VERSION', '2017-11-02');
-		defined('OMISE_USER_AGENT_SUFFIX') || define('OMISE_USER_AGENT_SUFFIX', sprintf('OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', OMISE_WOOCOMMERCE_PLUGIN_VERSION, $wp_version, WC()->version));
+		defined('OMISE_USER_AGENT_SUFFIX') || define(
+			'OMISE_USER_AGENT_SUFFIX', 
+			sprintf(
+				'OmiseWooCommerce/%s WordPress/%s WooCommerce/%s', 
+				OMISE_WOOCOMMERCE_PLUGIN_VERSION, 
+				$wp_version, 
+				WC()->version
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

Fixed wrong initialization cause conflict with other gateway

**Related information**:
[#ENGA3-485](https://opn-ooo.atlassian.net/browse/ENGA3-485)

#### 2. Description of change

- change action name in Omise class from `init` to `woocommerce_init`

#### 3. Quality assurance

- added other payment gateway such as stripe
- go to woocommerce setting -> payment tab and check omise payment methods are there.

**🔧 Environments:**

- **WooCommerce**: v6.8.2
- **WordPress**: v6.0.2
- **PHP version**: 8.1

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal