### PR TITLE
Preparing the release of v4.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### [v4.25.0 _(Oct 6, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.25.0)
+- Fixed the conflict between Omise and other payment gateway (PR [#317](https://github.com/omise/omise-woocommerce/pull/317))
+- Added Validation on FPX and DuitNow checkout to select the bank (PR [#316](https://github.com/omise/omise-woocommerce/pull/316))
+- Fixed customer cannot pay if the omise customer is removed from the API. (PR [#318](https://github.com/omise/omise-woocommerce/pull/318))
+- Fixed Promptpay QR image format error on KPlus Android App (PR [#319](https://github.com/omise/omise-woocommerce/pull/319))
 
 ### [v4.24.2 _(Sep 20, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.24.2)
 - Fix the issue of not being able to add new live keys. (PR [#313](https://github.com/omise/omise-woocommerce/pull/313))

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -6,7 +6,7 @@
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin 
  * designed specifically for WooCommerce. The plugin adds support for 
  * Omise Payment Gateway payment method to WooCommerce.
- * Version:     4.24.2
+ * Version:     4.25.0
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -24,7 +24,7 @@ class Omise
 	 *
 	 * @var string
 	 */
-	public $version = '4.24.2';
+	public $version = '4.25.0';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 6.0.2
-Stable tag: 4.24.2
+Stable tag: 4.25.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,14 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 4.25.0 =
+
+#### 👾 Bug Fixes
+- Fixed the conflict between Omise and other payment gateway (PR [#317](https://github.com/omise/omise-woocommerce/pull/317))
+- Added Validation on FPX and DuitNow checkout to select the bank (PR [#316](https://github.com/omise/omise-woocommerce/pull/316))
+- Fixed customer cannot pay if the omise customer is removed from the API. (PR [#318](https://github.com/omise/omise-woocommerce/pull/318))
+- Fixed Promptpay QR image format error on KPlus Android App (PR [#319](https://github.com/omise/omise-woocommerce/pull/319))
 
 = 4.24.2 =
 


### PR DESCRIPTION
## Objective

Preparing the release of v4.25.0

- Fixed the conflict between Omise and other payment gateway (PR [#317](https://github.com/omise/omise-woocommerce/pull/317))
- Added Validation on FPX and DuitNow checkout to select the bank (PR [#316](https://github.com/omise/omise-woocommerce/pull/316))
- Fixed customer cannot pay if the omise customer is removed from the API. (PR [#318](https://github.com/omise/omise-woocommerce/pull/318))
- Fixed Promptpay QR image format error on KPlus Android App (PR [#319](https://github.com/omise/omise-woocommerce/pull/319))
