### PR TITLE
[ENGA3-447]: Added a delay of 0.5 seconds before calling the charge A…

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -42,6 +42,11 @@ class Omise_Callback {
 		$this->order->add_order_note( __( 'OMISE: Validating the payment result...', 'omise' ) );
 
 		try {
+			// Sometimes cancelling a transaction does not updates the status on the Omise backend
+			// which causes the status to be pending even thought the transaction was cancelled.
+			// To avoid this random issue of status being 'Pending` when it should have been 'Cancelled',
+			// we are adding a delay of half a second to avoid random
+			usleep(500000);
 			$this->charge = OmiseCharge::retrieve( $this->order->get_transaction_id() );
 
 			switch ( strtolower( $this->charge['status'] ) ) {


### PR DESCRIPTION
#### 1. Objective

Added a delay of 0.5 seconds before calling the charge API in callback class so that we can fetch correct charge status.

Jira Ticket: [#447](https://opn-ooo.atlassian.net/browse/ENGA3-447)

#### 2. Description of change

With RMS payment method, when customer cancels the transaction and redirect back to the plugin, sometimes, randomly, the charge it fetches from API has the status value as pending instead of cancelled . This will redirect customer to success page instead of back to checkout page.

To fix this, we have added a delay of 0.5 secs before calling the charge API.

#### 3. Quality assurance

- Switch to Malaysia PSP
- Checkout with RMS payment method. 
- Cancel the transaction

**Note: You have to try multiple cancel transaction as this issue occurs in random.**

You should see the following page, not the success page.

<img width="1359" alt="Screen Shot 2565-10-12 at 17 13 09" src="https://user-images.githubusercontent.com/101558497/195331292-59ef1044-ef72-4a33-92bb-0772f4143fb5.png">


**🔧 Environments:**

- WooCommerce: v6.8.2
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 4.25.0