### PR TITLE
[ENGA3-458]: Fixed the credit card form's UI issue with default theme

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -4,12 +4,22 @@ label.omise-label-inline {
 	display: inline-block;
 }
 
-.omise-remember-card input,
-.omise-remember-card label {
-	display: inline-block;
+.omise-new-card-form {
+	display: flex;
+  	flex-direction: column;
+}
+
+.omise-form-child {
+	margin-top: auto;
+}
+
+.omise-remember-card {
+	margin-top: 0.5em;
+	margin-left: 0.2em;
 }
 
 .omise-customer-card-list {
+	list-style-type: none;
 	padding-bottom: .75em;
 	border-bottom: 1px solid #ddd;
 	box-shadow: 0 1px 1px #fff;
@@ -25,7 +35,7 @@ fieldset.card-exists {
 }
 
 #new_card_info:checked ~ fieldset.card-exists {
-	display: block;
+	display: flex;
 }
 
 /**

--- a/templates/payment/form-creditcard.php
+++ b/templates/payment/form-creditcard.php
@@ -1,30 +1,32 @@
-<p class="form-row form-row-wide omise-required-field">
-	<label for="omise_card_number"><?php _e( 'Card number', 'omise' ); ?></label>
-	<input id="omise_card_number" class="input-text" type="text"
-		maxlength="20" autocomplete="off" placeholder="•••• •••• •••• ••••">
-</p>
+<div class="omise-form-child">
+	<p class="form-row form-row-wide omise-required-field">
+		<label for="omise_card_number"><?php _e( 'Card number', 'omise' ); ?></label>
+		<input id="omise_card_number" class="input-text" type="text"
+			maxlength="20" autocomplete="off" placeholder="•••• •••• •••• ••••">
+	</p>
 
-<p class="form-row form-row-wide omise-required-field">
-	<label for="omise_card_name"><?php _e( 'Name on card', 'omise' ); ?></label>
-	<input id="omise_card_name" class="input-text" type="text"
-		maxlength="255" autocomplete="off" placeholder="<?php _e( 'FULL NAME', 'omise' ); ?>">
-</p>
-<p class="form-row form-row-first omise-required-field">
-	<label for="omise_card_expiration_month"><?php _e( 'Expiration month', 'omise' ); ?></label>
-	<input id="omise_card_expiration_month" class="input-text" type="text"
-		autocomplete="off" placeholder="<?php _e( 'MM', 'omise' ); ?>">
-</p>
-<p class="form-row form-row-last omise-required-field">
-	<label for="omise_card_expiration_year"><?php _e( 'Expiration year', 'omise' ); ?></label>
-	<input id="omise_card_expiration_year" class="input-text" type="text"
-		autocomplete="off" placeholder="<?php _e( 'YYYY', 'omise' ); ?>">
-</p>
-<p class="form-row form-row-first omise-required-field">
-	<label for="omise_card_security_code"><?php _e( 'Security code', 'omise' ); ?></label>
-	<input id="omise_card_security_code"
-		class="input-text" type="password" autocomplete="off"
-		placeholder="•••">
-</p>
+	<p class="form-row form-row-wide omise-required-field">
+		<label for="omise_card_name"><?php _e( 'Name on card', 'omise' ); ?></label>
+		<input id="omise_card_name" class="input-text" type="text"
+			maxlength="255" autocomplete="off" placeholder="<?php _e( 'FULL NAME', 'omise' ); ?>">
+	</p>
+	<p class="form-row form-row-first omise-required-field">
+		<label for="omise_card_expiration_month"><?php _e( 'Expiration month', 'omise' ); ?></label>
+		<input id="omise_card_expiration_month" class="input-text" type="text"
+			autocomplete="off" placeholder="<?php _e( 'MM', 'omise' ); ?>">
+	</p>
+	<p class="form-row form-row-last omise-required-field">
+		<label for="omise_card_expiration_year"><?php _e( 'Expiration year', 'omise' ); ?></label>
+		<input id="omise_card_expiration_year" class="input-text" type="text"
+			autocomplete="off" placeholder="<?php _e( 'YYYY', 'omise' ); ?>">
+	</p>
+	<p class="form-row form-row-first omise-required-field">
+		<label for="omise_card_security_code"><?php _e( 'Security code', 'omise' ); ?></label>
+		<input id="omise_card_security_code"
+			class="input-text" type="password" autocomplete="off"
+			placeholder="•••">
+	</p>
+</div>
 <script type="text/javascript">
 
 	/**

--- a/templates/payment/form.php
+++ b/templates/payment/form.php
@@ -23,19 +23,19 @@
 			</label>
 		<?php endif; ?>
 
-		<fieldset id="new_card_form" class="<?php echo $showExistingCards ? 'card-exists' : ''; ?>">
+		<fieldset class="omise-new-card-form <?php echo $showExistingCards ? 'card-exists' : ''; ?>">
 
 			<?php require_once( 'form-creditcard.php' ); ?>
 
 			<div class="clear"></div>
 
 			<?php if ( $viewData['user_logged_in'] ) : ?>
-				<p class="omise-remember-card">
+				<div class="omise-form-child omise-remember-card">
 					<input type="checkbox" name="omise_save_customer_card" id="omise_save_customer_card" />
 					<label for="omise_save_customer_card" class="inline">
 						<?php _e( 'Remember this card', 'omise' ); ?>
 					</label>
-				</p>
+				</div>
 			<?php endif; ?>
 
 			<div class="clear"></div>


### PR DESCRIPTION
#### 1. Objective

Fix the broken remember card  option in CC UIin default theme.

Jira Ticket: [#458](https://opn-ooo.atlassian.net/browse/ENGA3-458)

#### 2. Description of change

Fixed the layout using CSS Flexbox. Added CSS classes and updated some CSS property value.

#### 3. Quality assurance

- Switch to twenty twenty-two theme
- Go to checkout page
- Choose credit card payment

**_Before_**

<img width="1200" alt="Screen Shot 2565-10-21 at 14 53 27" src="https://user-images.githubusercontent.com/101558497/197159676-19fb8166-1273-4fb7-abbd-77a42ef6159a.png">

**_After_**

<img width="1246" alt="Screen Shot 2565-10-21 at 14 52 33" src="https://user-images.githubusercontent.com/101558497/197159745-5550b15b-ea9f-4ee5-8197-b539383d2e3f.png">


**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 4.25.0