### PR TITLE
[ENGA3-491]: Metadata keys is_omise_payment_resolved added as protected metadata.

### DIFF
--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -121,7 +121,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	 */
 	public function protectMetadata($protected, $metadataKeys)
 	{
-		if ( in_array( $metadataKeys, [ 'token' ] )) {
+		if ( in_array( $metadataKeys, [ 'token', 'is_omise_payment_resolved' ] )) {
 			return true;
 		}
 


### PR DESCRIPTION
#### 1. Objective

Hide `is_omise_payment_resolved` metadata from order page.

Jira Ticket: [#491](https://opn-ooo.atlassian.net/browse/ENGA3-491)

#### 2. Description of change

Added `is_omise_payment_resolved` as the protected metadata in `includes/gateway/class-omise-payment.php`.

#### 3. Quality assurance

Check the order page. You should not see `is_omise_payment_resolved` under custom fields.

**Before**
<img width="1433" alt="Screen Shot 2565-10-26 at 13 13 34" src="https://user-images.githubusercontent.com/101558497/197962300-e5ef2922-50cc-40b9-908e-3496ab9734d2.png">


**After**
<img width="1410" alt="Screen Shot 2565-10-26 at 13 13 22" src="https://user-images.githubusercontent.com/101558497/197962429-c92118d8-d2c2-4007-a67c-bdfba30f430b.png">


**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 4.25.0