### PR TITLE
Preparing release of v4.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### [v4.26.0 _(Nov 1, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.26.0)
+- Metadata keys is_omise_payment_resolved added as protected metadata. (PR [#324](https://github.com/omise/omise-woocommerce/pull/324))
+- Fix the issue of customer getting back to checkout page from OTP page. (PR [#323](https://github.com/omise/omise-woocommerce/pull/323))
+- Fixed the credit card form's UI issue with default theme. (PR [#322](https://github.com/omise/omise-woocommerce/pull/322))
+- Added a delay of 0.5 seconds before calling the charge API in callback class so that we can fetch correct charge status. (PR [#321](https://github.com/omise/omise-woocommerce/pull/321))
+
 ### [v4.25.0 _(Oct 6, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.25.0)
 - Fixed the conflict between Omise and other payment gateway (PR [#317](https://github.com/omise/omise-woocommerce/pull/317))
 - Added Validation on FPX and DuitNow checkout to select the bank (PR [#316](https://github.com/omise/omise-woocommerce/pull/316))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG
 
-### [v4.26.0 _(Nov 1, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.26.0)
+### [v4.26.0 _(Nov 2, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.26.0)
 - Metadata keys is_omise_payment_resolved added as protected metadata. (PR [#324](https://github.com/omise/omise-woocommerce/pull/324))
 - Fix the issue of customer getting back to checkout page from OTP page. (PR [#323](https://github.com/omise/omise-woocommerce/pull/323))
 - Fixed the credit card form's UI issue with default theme. (PR [#322](https://github.com/omise/omise-woocommerce/pull/322))
 - Added a delay of 0.5 seconds before calling the charge API in callback class so that we can fetch correct charge status. (PR [#321](https://github.com/omise/omise-woocommerce/pull/321))
+- Increased the delay to 2 seconds and added a check for OCBC PAO redirect URL. (PR [#327](https://github.com/omise/omise-woocommerce/pull/327))
 
 ### [v4.25.0 _(Oct 6, 2022)_](https://github.com/omise/omise-woocommerce/releases/tag/v4.25.0)
 - Fixed the conflict between Omise and other payment gateway (PR [#317](https://github.com/omise/omise-woocommerce/pull/317))

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -6,7 +6,7 @@
  * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin 
  * designed specifically for WooCommerce. The plugin adds support for 
  * Omise Payment Gateway payment method to WooCommerce.
- * Version:     4.25.0
+ * Version:     4.26.0
  * Author:      Omise and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -24,7 +24,7 @@ class Omise
 	 *
 	 * @var string
 	 */
-	public $version = '4.25.0';
+	public $version = '4.26.0';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,7 @@ From there:
 - Fix the issue of customer getting back to checkout page from OTP page. (PR [#323](https://github.com/omise/omise-woocommerce/pull/323))
 - Fixed the credit card form's UI issue with default theme. (PR [#322](https://github.com/omise/omise-woocommerce/pull/322))
 - Added a delay of 0.5 seconds before calling the charge API in callback class so that we can fetch correct charge status. (PR [#321](https://github.com/omise/omise-woocommerce/pull/321))
+- Increased the delay to 2 seconds and added a check for OCBC PAO redirect URL. (PR [#327](https://github.com/omise/omise-woocommerce/pull/327))
 
 = 4.25.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Omise
 Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 6.0.2
-Stable tag: 4.25.0
+Stable tag: 4.26.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -32,6 +32,13 @@ From there:
 3. Omise Payment Gateway Checkout Form
 
 == Changelog ==
+
+= 4.26.0 =
+
+- Metadata keys is_omise_payment_resolved added as protected metadata. (PR [#324](https://github.com/omise/omise-woocommerce/pull/324))
+- Fix the issue of customer getting back to checkout page from OTP page. (PR [#323](https://github.com/omise/omise-woocommerce/pull/323))
+- Fixed the credit card form's UI issue with default theme. (PR [#322](https://github.com/omise/omise-woocommerce/pull/322))
+- Added a delay of 0.5 seconds before calling the charge API in callback class so that we can fetch correct charge status. (PR [#321](https://github.com/omise/omise-woocommerce/pull/321))
 
 = 4.25.0 =
 


### PR DESCRIPTION
Preparing the release of v4.26.0

### What's changed
- Metadata keys is_omise_payment_resolved added as protected metadata. (PR [#324](https://github.com/omise/omise-woocommerce/pull/324))
- Fix the issue of customer getting back to checkout page from OTP page. (PR [#323](https://github.com/omise/omise-woocommerce/pull/323))
- Fixed the credit card form's UI issue with default theme. (PR [#322](https://github.com/omise/omise-woocommerce/pull/322))
- Added a delay of 0.5 seconds before calling the charge API in callback class so that we can fetch correct charge status. (PR [#321](https://github.com/omise/omise-woocommerce/pull/321))
- Increased the delay to 2 seconds and added a check for OCBC PAO redirect URL. (PR [#327](https://github.com/omise/omise-woocommerce/pull/327))