### PR TITLE
[ENGA3-553]: Increased the delay to 2 seconds and added a check for OCBC PAO redirect URL.

### DIFF
--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -39,16 +39,20 @@ class Omise_Callback {
 	}
 
 
-	// Sometimes cancelling a transaction does not updates the status on the Omise backend
-	// which causes the status to be pending even thought the transaction was cancelled.
-	// To avoid this random issue of status being 'Pending` when it should have been 'Cancelled',
-	// we are adding a delay of half a second to avoid random
+	/**
+	 * Sometimes cancelling a transaction does not updates the status on the Omise backend
+	 * which causes the status to be pending even thought the transaction was cancelled.
+	 * To avoid this random issue of status being 'Pending` when it should have been 'Cancelled',
+	 * we are adding a delay of half a second to avoid random
+	 *
+	 * @param string $transactionId
+	 */
 	private function fetchCharge($transactionId)
 	{
 		$retryNo = 1;
 		$maxRetry = 5;
 
-		if ($retryNo <= $maxRetry) {
+		do {
 			$charge = OmiseCharge::retrieve($transactionId);
 
 			if('pending' !== $charge['status']) {
@@ -57,7 +61,7 @@ class Omise_Callback {
 
 			$retryNo++;
 			usleep(500000);
-		}
+		} while($retryNo <= $maxRetry);
 
 		return $charge;
 	}

--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -46,7 +46,7 @@ class Omise_Callback {
 			// which causes the status to be pending even thought the transaction was cancelled.
 			// To avoid this random issue of status being 'Pending` when it should have been 'Cancelled',
 			// we are adding a delay of half a second to avoid random
-			usleep(500000);
+			usleep(2000000);
 			$this->charge = OmiseCharge::retrieve( $this->order->get_transaction_id() );
 
 			switch ( strtolower( $this->charge['status'] ) ) {

--- a/includes/gateway/class-omise-payment-ocbc-pao.php
+++ b/includes/gateway/class-omise-payment-ocbc-pao.php
@@ -57,8 +57,6 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 	 */
 	public function charge($order_id, $order)
 	{
-		//Cannot use query parameters for OCBC PAO return URI.
-		$return_uri = home_url('wp-json/omise/ocbc-pao-callback/' . $order_id);
 		$currency = $order->get_currency();
 
 		return OmiseCharge::create([
@@ -69,7 +67,7 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 				'type' => $this->source_type,
 				'platform_type' => Omise_Util::get_platform_type( wc_get_user_agent() ) 
 			],
-			'return_uri' => $return_uri,
+			'return_uri' => $this->getRedirectUrl('omise_ocbc_pao_callback', $order_id, $order),
 			'metadata' => $this->getMetadata($order_id, $order)
 		]);
 	}

--- a/includes/gateway/class-omise-payment-ocbc-pao.php
+++ b/includes/gateway/class-omise-payment-ocbc-pao.php
@@ -80,10 +80,10 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 	 * @see WC_Payment_Gateway::get_icon()
 	 */
 	public function get_icon() {
-		$icon = Omise_Image::get_image( array(
-			    'file' => 'ocbc-pao.png',
-			    'alternate_text' => 'OCBC Pay Anyone',
-		));
+		$icon = Omise_Image::get_image([
+			'file' => 'ocbc-pao.png',
+			'alternate_text' => 'OCBC Pay Anyone',
+		]);
 		return apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
 	}
 }

--- a/includes/libraries/omise-plugin/helpers/request.php
+++ b/includes/libraries/omise-plugin/helpers/request.php
@@ -29,24 +29,8 @@ if (! class_exists('RequestHelper')) {
                 return $token === $order_token;
             }
 
-            // For OCBC PAO as it does not include token in the return URI.
-            if(self::isCallbackOcbcPao()) {
-                return true;
-            }
-
             // For offline payment methods does not include token in the return URI.
             return !self::isUserOriginated();
-        }
-
-        /**
-         * Since OCBC PAO do not suppor query params, we can't add token to it. Plus, HTTP_SEC_FETCH_SITE
-         * is not so reliable. So, we will return true if the callback is of OCBC PAO
-         */
-        private static function isCallbackOcbcPao()
-        {
-            $callback = basename($_SERVER['REQUEST_URI']);
-            $part = explode('?', $callback);
-            return 'omise_ocbc_pao_callback' === $part[0];
         }
     }
 }

--- a/includes/libraries/omise-plugin/helpers/request.php
+++ b/includes/libraries/omise-plugin/helpers/request.php
@@ -29,8 +29,24 @@ if (! class_exists('RequestHelper')) {
                 return $token === $order_token;
             }
 
-            // For offline payment methods and OCBC PAO that does not include token in the return URI.
+            // For OCBC PAO as it does not include token in the return URI.
+            if(self::isCallbackOcbcPao()) {
+                return true;
+            }
+
+            // For offline payment methods does not include token in the return URI.
             return !self::isUserOriginated();
+        }
+
+        /**
+         * Since OCBC PAO do not suppor query params, we can't add token to it. Plus, HTTP_SEC_FETCH_SITE
+         * is not so reliable. So, we will return true if the callback is of OCBC PAO
+         */
+        private static function isCallbackOcbcPao()
+        {
+            $callback = basename($_SERVER['REQUEST_URI']);
+            $part = explode('?', $callback);
+            return 'omise_ocbc_pao_callback' === $part[0];
         }
     }
 }


### PR DESCRIPTION
#### 1. Objective

Increased the delay to 2 seconds.

Jira Ticekt: [#553](https://opn-ooo.atlassian.net/browse/ENGA3-553)

#### 2. Description of change

We observed 0.5 secs was not enough sometimes with RMS payment method while testing with Shopify. To be on safe side, we increase delay to 2 secs. Plus, we added a check for OCBC PAO redirect URL so that plugin won't identity it as user originated request because we can't add query params in OCBC PAO.

#### 3. Quality assurance

- Test with any payment method.

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 4.25.0