### PR TITLE
[ENGA3-592]: Rebrand Omise to OPN Payments

### DIFF
--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -7,7 +7,8 @@
 			border-left-width: 4px;
 		}
 	</style>
-	<h1><?php echo $title; ?></h1>
+
+	<h1><?= $title; ?></h1>
 
 	<?php $page->display_messages(); ?>
 
@@ -137,7 +138,7 @@
 		<h3><?php _e( 'Payment Methods', 'omise' ); ?></h3>
 		<?php if ($settings['account_country']) : ?>
 			<!--  account_country exists when API key is valid -->
-			<p><?php _e( 'The table below is a list of available payment methods for this omise account that you can enable in your WooCommerce store.', 'omise' ); ?></p>
+			<p><?php _e( 'The table below is a list of available payment methods for this Opn Payments account that you can enable in your WooCommerce store.', 'omise' ); ?></p>
 			<table class="form-table">
 				<tbody>
 					<tr>

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -23,7 +23,7 @@
 		<?php
 		echo sprintf(
 			wp_kses(
-				__( 'All of your keys can be found at your Opn dashboard, check the following links.<br/><a href="%s">Test keys</a> or <a href="%s">Live keys</a> (login required)', 'omise' ),
+				__( 'All of your keys can be found at your Opn Payments dashboard, check the following links.<br/><a href="%s">Test keys</a> or <a href="%s">Live keys</a> (login required)', 'omise' ),
 				array(
 					'br' => array(),
 					'a'  => array( 'href' => array() )
@@ -62,7 +62,7 @@
 						<fieldset>
 							<label for="sandbox">
 								<input name="sandbox" type="checkbox" id="sandbox" value="1" <?php echo 'yes' === $settings['sandbox'] ? 'checked="checked"' : ''; ?>>
-								<?php _e( 'Enabling test mode means that all your transactions will be performed under the Opn test account.', 'omise' ); ?>
+								<?php _e( 'Enabling test mode means that all your transactions will be performed under the Opn Payments test account.', 'omise' ); ?>
 							</label>
 						</fieldset>
 					</td>
@@ -115,7 +115,7 @@
 								<?php
 								echo sprintf(
 									wp_kses(
-										__( 'To enable <a href="%s">WebHooks</a> feature, you must setup an endpoint at <a href="%s"><strong>Omise dashboard</strong></a> by using the above url <em>(HTTPS only)</em>.', 'omise' ),
+										__( 'To enable <a href="%s">WebHooks</a> feature, you must setup an endpoint at <a href="%s"><strong>Opn Payments dashboard</strong></a> by using the above url <em>(HTTPS only)</em>.', 'omise' ),
 										array(
 											'a'       => array( 'href' => array() ),
 											'em'      => array(),

--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -23,7 +23,7 @@
 		<?php
 		echo sprintf(
 			wp_kses(
-				__( 'All of your keys can be found at your Omise dashboard, check the following links.<br/><a href="%s">Test keys</a> or <a href="%s">Live keys</a> (login required)', 'omise' ),
+				__( 'All of your keys can be found at your Opn dashboard, check the following links.<br/><a href="%s">Test keys</a> or <a href="%s">Live keys</a> (login required)', 'omise' ),
 				array(
 					'br' => array(),
 					'a'  => array( 'href' => array() )
@@ -62,7 +62,7 @@
 						<fieldset>
 							<label for="sandbox">
 								<input name="sandbox" type="checkbox" id="sandbox" value="1" <?php echo 'yes' === $settings['sandbox'] ? 'checked="checked"' : ''; ?>>
-								<?php _e( 'Enabling test mode means that all your transactions will be performed under the Omise test account.', 'omise' ); ?>
+								<?php _e( 'Enabling test mode means that all your transactions will be performed under the Opn test account.', 'omise' ); ?>
 							</label>
 						</fieldset>
 					</td>

--- a/includes/class-omise-admin.php
+++ b/includes/class-omise-admin.php
@@ -44,9 +44,7 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		 * Register Omise's custom menu to WordPress admin menus.
 		 */
 		public function wordpress_hook_admin_menu() {
-			add_menu_page( 'Omise', 'Omise', 'manage_options', 'omise', array( $this, 'page_settings') );
-
-			add_submenu_page( 'omise', __( 'Omise Settings', 'omise' ), __( 'Settings', 'omise' ), 'manage_options', 'omise-settings', array( $this, 'page_settings') );
+			add_menu_page( __( 'Opn Settings', 'omise' ), 'Opn', 'manage_options', 'omise', array( $this, 'page_settings') );
 		}
 
 		/**
@@ -79,10 +77,10 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 			$payment_method = version_compare( WC()->version, '3.0.0', '>=' ) ? $theorder->get_payment_method() : $theorder->payment_method;
 
 			if ( $theorder->get_meta( 'is_awaiting_capture' ) === 'yes' ) {
-				$order_actions[ $payment_method . '_charge_capture'] = __( 'Omise: Capture this order', 'omise' );
+				$order_actions[ $payment_method . '_charge_capture'] = __( 'Opn: Capture this order', 'omise' );
 			}
 
-			$order_actions[ $payment_method . '_sync_payment'] = __( 'Omise: Manual sync payment status', 'omise' );
+			$order_actions[ $payment_method . '_sync_payment'] = __( 'Opn: Manual sync payment status', 'omise' );
 
 			return $order_actions;
 		}

--- a/includes/class-omise-admin.php
+++ b/includes/class-omise-admin.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 		 * Register Omise's custom menu to WordPress admin menus.
 		 */
 		public function wordpress_hook_admin_menu() {
-			add_menu_page( __( 'Opn Settings', 'omise' ), 'Opn', 'manage_options', 'omise', array( $this, 'page_settings') );
+			add_menu_page( __( 'Opn Payments Settings', 'omise' ), 'Opn Payments', 'manage_options', 'omise', array( $this, 'page_settings') );
 		}
 
 		/**
@@ -77,10 +77,10 @@ if ( ! class_exists( 'Omise_Admin' ) ) {
 			$payment_method = version_compare( WC()->version, '3.0.0', '>=' ) ? $theorder->get_payment_method() : $theorder->payment_method;
 
 			if ( $theorder->get_meta( 'is_awaiting_capture' ) === 'yes' ) {
-				$order_actions[ $payment_method . '_charge_capture'] = __( 'Opn: Capture this order', 'omise' );
+				$order_actions[ $payment_method . '_charge_capture'] = __( 'Opn Payments: Capture this order', 'omise' );
 			}
 
-			$order_actions[ $payment_method . '_sync_payment'] = __( 'Opn: Manual sync payment status', 'omise' );
+			$order_actions[ $payment_method . '_sync_payment'] = __( 'Opn Payments: Manual sync payment status', 'omise' );
 
 			return $order_actions;
 		}

--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -81,7 +81,7 @@ class Omise_Callback {
 					break;
 
 				default:
-					throw new Exception( __( 'Unrecognized Omise Charge status.', 'omise' ) );
+					throw new Exception( __( 'Unrecognized Opn Charge status.', 'omise' ) );
 					break;
 			}
 		} catch ( Exception $e ) {
@@ -142,7 +142,7 @@ class Omise_Callback {
 		if ( ! $this->charge['capture'] && $this->charge['authorized'] ) {
 			// Card authorized case.
 			$message = __(
-				'Omise: The payment is being processed.<br/>
+				'Opn: The payment is being processed.<br/>
 				An amount %1$s %2$s has been authorized.',
 				'omise'
 			);
@@ -168,9 +168,9 @@ class Omise_Callback {
 
 		// Offsite case.
 		$message = __(
-			'Omise: The payment is being processed.<br/>
+			'Opn: The payment is being processed.<br/>
 			Depending on the payment provider, this may take some time to process.<br/>
-			Please do a manual \'Sync Payment Status\' action from the <strong>Order Actions</strong> panel, or check the payment status directly at the Omise Dashboard later.',
+			Please do a manual \'Sync Payment Status\' action from the <strong>Order Actions</strong> panel, or check the payment status directly at the Opn Dashboard later.',
 			'omise'
 		);
 

--- a/includes/class-omise-callback.php
+++ b/includes/class-omise-callback.php
@@ -81,7 +81,7 @@ class Omise_Callback {
 					break;
 
 				default:
-					throw new Exception( __( 'Unrecognized Opn Charge status.', 'omise' ) );
+					throw new Exception( __( 'Unrecognized Opn Payments Charge status.', 'omise' ) );
 					break;
 			}
 		} catch ( Exception $e ) {
@@ -142,7 +142,7 @@ class Omise_Callback {
 		if ( ! $this->charge['capture'] && $this->charge['authorized'] ) {
 			// Card authorized case.
 			$message = __(
-				'Opn: The payment is being processed.<br/>
+				'Opn Payments: The payment is being processed.<br/>
 				An amount %1$s %2$s has been authorized.',
 				'omise'
 			);
@@ -168,9 +168,9 @@ class Omise_Callback {
 
 		// Offsite case.
 		$message = __(
-			'Opn: The payment is being processed.<br/>
+			'Opn Payments: The payment is being processed.<br/>
 			Depending on the payment provider, this may take some time to process.<br/>
-			Please do a manual \'Sync Payment Status\' action from the <strong>Order Actions</strong> panel, or check the payment status directly at the Opn Dashboard later.',
+			Please do a manual \'Sync Payment Status\' action from the <strong>Order Actions</strong> panel, or check the payment status directly at the Opn Payments Dashboard later.',
 			'omise'
 		);
 

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -43,7 +43,7 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 	 * For on-store capture, it will be handled by Omise_Payment::process_capture.
 	 */
 	public function resolve() {
-		$this->order->add_order_note( __( 'Omise: Received charge.capture webhook event.', 'omise' ) );
+		$this->order->add_order_note( __( 'Opn: Received charge.capture webhook event.', 'omise' ) );
 		$this->order->delete_meta_data( 'is_awaiting_capture');
 		$this->order->save();
 
@@ -53,7 +53,7 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 					return;
 				}
 
-				$message         = __( 'Omise: Payment failed.<br/>%s', 'omise' );
+				$message         = __( 'Opn: Payment failed.<br/>%s', 'omise' );
 				$failure_message = Omise()->translate( $this->data['failure_message'] ) . ' (code: ' . $this->data['failure_code'] . ')';
 				$this->order->add_order_note(
 					sprintf(
@@ -65,7 +65,7 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 				break;
 
 			case 'successful':
-				$message = __( 'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
+				$message = __( 'Opn: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
 
 				$this->order->add_order_note(
 					sprintf(

--- a/includes/events/class-omise-event-charge-capture.php
+++ b/includes/events/class-omise-event-charge-capture.php
@@ -43,7 +43,7 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 	 * For on-store capture, it will be handled by Omise_Payment::process_capture.
 	 */
 	public function resolve() {
-		$this->order->add_order_note( __( 'Opn: Received charge.capture webhook event.', 'omise' ) );
+		$this->order->add_order_note( __( 'Opn Payments: Received charge.capture webhook event.', 'omise' ) );
 		$this->order->delete_meta_data( 'is_awaiting_capture');
 		$this->order->save();
 
@@ -53,7 +53,7 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 					return;
 				}
 
-				$message         = __( 'Opn: Payment failed.<br/>%s', 'omise' );
+				$message         = __( 'Opn Payments: Payment failed.<br/>%s', 'omise' );
 				$failure_message = Omise()->translate( $this->data['failure_message'] ) . ' (code: ' . $this->data['failure_code'] . ')';
 				$this->order->add_order_note(
 					sprintf(
@@ -65,7 +65,7 @@ class Omise_Event_Charge_Capture extends Omise_Event {
 				break;
 
 			case 'successful':
-				$message = __( 'Opn: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
+				$message = __( 'Opn Payments: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
 
 				$this->order->add_order_note(
 					sprintf(

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -75,7 +75,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 	public function resolve() {
 		if ( ! $this->is_resolvable() ) return;
 
-		$this->order->add_order_note( __( 'Omise: Received charge.complete webhook event.', 'omise' ) );
+		$this->order->add_order_note( __( 'Opn: Received charge.complete webhook event.', 'omise' ) );
 
 		switch ( $this->data['status'] ) {
 			case 'failed':
@@ -83,7 +83,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 					return;
 				}
 
-				$message         = __( 'Omise: Payment failed.<br/>%s', 'omise' );
+				$message         = __( 'Opn: Payment failed.<br/>%s', 'omise' );
 				$failure_message = Omise()->translate( $this->data['failure_message'] ) . ' (code: ' . $this->data['failure_code'] . ')';
 				$this->order->add_order_note(
 					sprintf(
@@ -99,7 +99,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 					return;
 				}
 
-				$message = __( 'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
+				$message = __( 'Opn: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
 
 				$this->order->add_order_note(
 					sprintf(

--- a/includes/events/class-omise-event-charge-complete.php
+++ b/includes/events/class-omise-event-charge-complete.php
@@ -75,7 +75,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 	public function resolve() {
 		if ( ! $this->is_resolvable() ) return;
 
-		$this->order->add_order_note( __( 'Opn: Received charge.complete webhook event.', 'omise' ) );
+		$this->order->add_order_note( __( 'Opn Payments: Received charge.complete webhook event.', 'omise' ) );
 
 		switch ( $this->data['status'] ) {
 			case 'failed':
@@ -83,7 +83,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 					return;
 				}
 
-				$message         = __( 'Opn: Payment failed.<br/>%s', 'omise' );
+				$message         = __( 'Opn Payments: Payment failed.<br/>%s', 'omise' );
 				$failure_message = Omise()->translate( $this->data['failure_message'] ) . ' (code: ' . $this->data['failure_code'] . ')';
 				$this->order->add_order_note(
 					sprintf(
@@ -99,7 +99,7 @@ class Omise_Event_Charge_Complete extends Omise_Event {
 					return;
 				}
 
-				$message = __( 'Opn: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
+				$message = __( 'Opn Payments: Payment successful.<br/>An amount %1$s %2$s has been paid', 'omise' );
 
 				$this->order->add_order_note(
 					sprintf(

--- a/includes/gateway/abstract-omise-payment-base-card.php
+++ b/includes/gateway/abstract-omise-payment-base-card.php
@@ -150,7 +150,7 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 		if ( self::STATUS_PENDING === $charge['status'] && ! $charge['authorized'] && ! $charge['paid'] && ! empty( $charge['authorize_uri'] ) ) {
 			$order->add_order_note(
 				sprintf(
-					__( 'Omise: Processing a 3-D Secure payment, redirecting buyer to %s', 'omise' ),
+					__( 'Opn: Processing a 3-D Secure payment, redirecting buyer to %s', 'omise' ),
 					esc_url( $charge['authorize_uri'] )
 				)
 			);
@@ -168,7 +168,7 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 					$order->add_order_note(
 						sprintf(
 							wp_kses(
-								__( 'Omise: Payment processing.<br/>An amount of %1$s %2$s has been authorized', 'omise' ),
+								__( 'Opn: Payment processing.<br/>An amount of %1$s %2$s has been authorized', 'omise' ),
 								array( 'br' => array() )
 							),
 							$order->get_total(),
@@ -187,7 +187,7 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 					$order->add_order_note(
 						sprintf(
 							wp_kses(
-								__( 'Omise: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ),
+								__( 'Opn: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ),
 								array( 'br' => array() )
 							),
 							$order->get_total(),

--- a/includes/gateway/abstract-omise-payment-base-card.php
+++ b/includes/gateway/abstract-omise-payment-base-card.php
@@ -150,7 +150,7 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 		if ( self::STATUS_PENDING === $charge['status'] && ! $charge['authorized'] && ! $charge['paid'] && ! empty( $charge['authorize_uri'] ) ) {
 			$order->add_order_note(
 				sprintf(
-					__( 'Opn: Processing a 3-D Secure payment, redirecting buyer to %s', 'omise' ),
+					__( 'Opn Payments: Processing a 3-D Secure payment, redirecting buyer to %s', 'omise' ),
 					esc_url( $charge['authorize_uri'] )
 				)
 			);
@@ -168,7 +168,7 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 					$order->add_order_note(
 						sprintf(
 							wp_kses(
-								__( 'Opn: Payment processing.<br/>An amount of %1$s %2$s has been authorized', 'omise' ),
+								__( 'Opn Payments: Payment processing.<br/>An amount of %1$s %2$s has been authorized', 'omise' ),
 								array( 'br' => array() )
 							),
 							$order->get_total(),
@@ -187,7 +187,7 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 					$order->add_order_note(
 						sprintf(
 							wp_kses(
-								__( 'Opn: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ),
+								__( 'Opn Payments: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ),
 								array( 'br' => array() )
 							),
 							$order->get_total(),

--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -40,7 +40,7 @@ abstract class Omise_Payment_Offline extends Omise_Payment {
 		}
 
 		if ( self::STATUS_PENDING === $charge['status'] ) {
-			$order->update_status( 'on-hold', sprintf( __( 'Omise: Awaiting %s to be paid.', 'omise' ), $this->title ) );
+			$order->update_status( 'on-hold', sprintf( __( 'Opn: Awaiting %s to be paid.', 'omise' ), $this->title ) );
 			$order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
 			$order->save();
 

--- a/includes/gateway/abstract-omise-payment-offline.php
+++ b/includes/gateway/abstract-omise-payment-offline.php
@@ -40,7 +40,7 @@ abstract class Omise_Payment_Offline extends Omise_Payment {
 		}
 
 		if ( self::STATUS_PENDING === $charge['status'] ) {
-			$order->update_status( 'on-hold', sprintf( __( 'Opn: Awaiting %s to be paid.', 'omise' ), $this->title ) );
+			$order->update_status( 'on-hold', sprintf( __( 'Opn Payments: Awaiting %s to be paid.', 'omise' ), $this->title ) );
 			$order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
 			$order->save();
 

--- a/includes/gateway/abstract-omise-payment-offsite.php
+++ b/includes/gateway/abstract-omise-payment-offsite.php
@@ -18,7 +18,7 @@ abstract class Omise_Payment_Offsite extends Omise_Payment
 		}
 
 		if (self::STATUS_PENDING === $charge['status']) {
-			$order->add_order_note(sprintf(__('Omise: Redirecting buyer to %s', 'omise'), esc_url($charge['authorize_uri'])));
+			$order->add_order_note(sprintf(__('Opn: Redirecting buyer to %s', 'omise'), esc_url($charge['authorize_uri'])));
 
 			return array(
 				'result'   => 'success',

--- a/includes/gateway/abstract-omise-payment-offsite.php
+++ b/includes/gateway/abstract-omise-payment-offsite.php
@@ -18,7 +18,7 @@ abstract class Omise_Payment_Offsite extends Omise_Payment
 		}
 
 		if (self::STATUS_PENDING === $charge['status']) {
-			$order->add_order_note(sprintf(__('Opn: Redirecting buyer to %s', 'omise'), esc_url($charge['authorize_uri'])));
+			$order->add_order_note(sprintf(__('Opn Payments: Redirecting buyer to %s', 'omise'), esc_url($charge['authorize_uri'])));
 
 			return array(
 				'result'   => 'success',

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -7,7 +7,7 @@ class Omise_Payment_Alipay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_alipay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise Alipay', 'omise' );
+		$this->method_title       = __( 'Opn Alipay', 'omise' );
 		$this->method_description = __( 'Accept payment through Alipay', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
@@ -33,7 +33,7 @@ class Omise_Payment_Alipay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Alipay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  Alipay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -33,7 +33,7 @@ class Omise_Payment_Alipay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Alipay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Alipay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -7,7 +7,7 @@ class Omise_Payment_Alipay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_alipay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn Alipay', 'omise' );
+		$this->method_title       = __( 'Opn Payments Alipay', 'omise' );
 		$this->method_description = __( 'Accept payment through Alipay', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
@@ -33,7 +33,7 @@ class Omise_Payment_Alipay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Alipay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Alipay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-alipayplus.php
+++ b/includes/gateway/class-omise-payment-alipayplus.php
@@ -52,7 +52,7 @@ abstract class Omise_Payment_Alipayplus extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  ' . $this->wallet_title . ' Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments ' . $this->wallet_title . ' Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-alipayplus.php
+++ b/includes/gateway/class-omise-payment-alipayplus.php
@@ -24,9 +24,9 @@ abstract class Omise_Payment_Alipayplus extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_' . $wallet_source;
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn ' . $wallet_title, 'omise' );
+		$this->method_title       = __( 'Opn Payments ' . $wallet_title, 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>' . $wallet_title . '</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>' . $wallet_title . '</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 		$this->supports           = array( 'products', 'refunds' );
@@ -52,7 +52,7 @@ abstract class Omise_Payment_Alipayplus extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  ' . $this->wallet_title . ' Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  ' . $this->wallet_title . ' Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-alipayplus.php
+++ b/includes/gateway/class-omise-payment-alipayplus.php
@@ -24,9 +24,9 @@ abstract class Omise_Payment_Alipayplus extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_' . $wallet_source;
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise ' . $wallet_title, 'omise' );
+		$this->method_title       = __( 'Opn ' . $wallet_title, 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>' . $wallet_title . '</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>' . $wallet_title . '</strong> via Opn payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 		$this->supports           = array( 'products', 'refunds' );
@@ -52,7 +52,7 @@ abstract class Omise_Payment_Alipayplus extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise ' . $this->wallet_title . ' Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  ' . $this->wallet_title . ' Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -10,9 +10,9 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_billpayment_tesco';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise Bill Payment: Tesco', 'omise' );
+		$this->method_title       = __( 'Opn Bill Payment: Tesco', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>Tesco Bill Payment</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>Tesco Bill Payment</strong> via Opn payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -40,7 +40,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Tesco Bill Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  Tesco Bill Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -40,7 +40,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Tesco Bill Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Tesco Bill Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -10,9 +10,9 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_billpayment_tesco';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn Bill Payment: Tesco', 'omise' );
+		$this->method_title       = __( 'Opn Payments Bill Payment: Tesco', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>Tesco Bill Payment</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>Tesco Bill Payment</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -40,7 +40,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Tesco Bill Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Tesco Bill Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-boost.php
+++ b/includes/gateway/class-omise-payment-boost.php
@@ -33,7 +33,7 @@ class Omise_Payment_Boost extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Boost Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Boost Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-boost.php
+++ b/includes/gateway/class-omise-payment-boost.php
@@ -7,8 +7,8 @@ class Omise_Payment_Boost extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_boost';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn Boost', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>Boost</strong> via Opn payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Payments Boost', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>Boost</strong> via Opn Payments payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_Boost extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Boost Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Boost Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-boost.php
+++ b/includes/gateway/class-omise-payment-boost.php
@@ -7,8 +7,8 @@ class Omise_Payment_Boost extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_boost';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise Boost', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>Boost</strong> via Omise payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Boost', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>Boost</strong> via Opn payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_Boost extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Boost Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  Boost Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -10,9 +10,9 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 		// version 2017-2014
 		$this->source_type        = 'credit_card';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Opn Credit / Debit Card', 'omise' );
+		$this->method_title       = __( 'Opn Payments Credit / Debit Card', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payment through <strong>Credit / Debit Card</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept payment through <strong>Credit / Debit Card</strong> via Opn Payments payment gateway.', 'omise' ),
 			array(
 				'strong' => array()
 			)
@@ -47,7 +47,7 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 				'enabled' => array(
 					'title'   => __( 'Enable/Disable', 'omise' ),
 					'type'    => 'checkbox',
-					'label'   => __( 'Enable Opn  Credit / Debit Card Payment', 'omise' ),
+					'label'   => __( 'Enable Opn Payments  Credit / Debit Card Payment', 'omise' ),
 					'default' => 'no'
 				),
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -10,9 +10,9 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 		// version 2017-2014
 		$this->source_type        = 'credit_card';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Omise Credit / Debit Card', 'omise' );
+		$this->method_title       = __( 'Opn Credit / Debit Card', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payment through <strong>Credit / Debit Card</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept payment through <strong>Credit / Debit Card</strong> via Opn payment gateway.', 'omise' ),
 			array(
 				'strong' => array()
 			)
@@ -47,7 +47,7 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 				'enabled' => array(
 					'title'   => __( 'Enable/Disable', 'omise' ),
 					'type'    => 'checkbox',
-					'label'   => __( 'Enable Omise Credit / Debit Card Payment', 'omise' ),
+					'label'   => __( 'Enable Opn  Credit / Debit Card Payment', 'omise' ),
 					'default' => 'no'
 				),
 

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -47,7 +47,7 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 				'enabled' => array(
 					'title'   => __( 'Enable/Disable', 'omise' ),
 					'type'    => 'checkbox',
-					'label'   => __( 'Enable Opn Payments  Credit / Debit Card Payment', 'omise' ),
+					'label'   => __( 'Enable Opn Payments Credit / Debit Card Payment', 'omise' ),
 					'default' => 'no'
 				),
 

--- a/includes/gateway/class-omise-payment-duitnow-obw.php
+++ b/includes/gateway/class-omise-payment-duitnow-obw.php
@@ -9,8 +9,8 @@ class Omise_Payment_DuitNow_OBW extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_duitnow_obw';
 		$this->has_fields         = true;
-		$this->method_title       = __('Omise DuitNow Online Banking/Wallets', 'omise');
-		$this->method_description = __('Accept payment through <strong>DuitNow Online Banking/Wallets</strong> via Omise payment gateway.', 'omise');
+		$this->method_title       = __('Opn DuitNow Online Banking/Wallets', 'omise');
+		$this->method_description = __('Accept payment through <strong>DuitNow Online Banking/Wallets</strong> via Opn payment gateway.', 'omise');
 		$this->supports           = array('products', 'refunds');
 
 		$this->init_form_fields();
@@ -37,7 +37,7 @@ class Omise_Payment_DuitNow_OBW extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __('Enable/Disable', 'omise'),
 				'type'    => 'checkbox',
-				'label'   => __('Enable Omise DuitNow Online Banking/Wallets Payment', 'omise'),
+				'label'   => __('Enable Opn  DuitNow Online Banking/Wallets Payment', 'omise'),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-duitnow-obw.php
+++ b/includes/gateway/class-omise-payment-duitnow-obw.php
@@ -9,8 +9,8 @@ class Omise_Payment_DuitNow_OBW extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_duitnow_obw';
 		$this->has_fields         = true;
-		$this->method_title       = __('Opn DuitNow Online Banking/Wallets', 'omise');
-		$this->method_description = __('Accept payment through <strong>DuitNow Online Banking/Wallets</strong> via Opn payment gateway.', 'omise');
+		$this->method_title       = __('Opn Payments DuitNow Online Banking/Wallets', 'omise');
+		$this->method_description = __('Accept payment through <strong>DuitNow Online Banking/Wallets</strong> via Opn Payments payment gateway.', 'omise');
 		$this->supports           = array('products', 'refunds');
 
 		$this->init_form_fields();
@@ -37,7 +37,7 @@ class Omise_Payment_DuitNow_OBW extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __('Enable/Disable', 'omise'),
 				'type'    => 'checkbox',
-				'label'   => __('Enable Opn  DuitNow Online Banking/Wallets Payment', 'omise'),
+				'label'   => __('Enable Opn Payments  DuitNow Online Banking/Wallets Payment', 'omise'),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-duitnow-obw.php
+++ b/includes/gateway/class-omise-payment-duitnow-obw.php
@@ -37,7 +37,7 @@ class Omise_Payment_DuitNow_OBW extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __('Enable/Disable', 'omise'),
 				'type'    => 'checkbox',
-				'label'   => __('Enable Opn Payments  DuitNow Online Banking/Wallets Payment', 'omise'),
+				'label'   => __('Enable Opn Payments DuitNow Online Banking/Wallets Payment', 'omise'),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-duitnow-qr.php
+++ b/includes/gateway/class-omise-payment-duitnow-qr.php
@@ -33,7 +33,7 @@ class Omise_Payment_DuitNow_QR extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  DuitNow QR Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments DuitNow QR Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-duitnow-qr.php
+++ b/includes/gateway/class-omise-payment-duitnow-qr.php
@@ -7,8 +7,8 @@ class Omise_Payment_DuitNow_QR extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_duitnow_qr';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn DuitNow QR', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>DuitNow QR</strong> via Opn payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Payments DuitNow QR', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>DuitNow QR</strong> via Opn Payments payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_DuitNow_QR extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  DuitNow QR Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  DuitNow QR Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-duitnow-qr.php
+++ b/includes/gateway/class-omise-payment-duitnow-qr.php
@@ -7,8 +7,8 @@ class Omise_Payment_DuitNow_QR extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_duitnow_qr';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise DuitNow QR', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>DuitNow QR</strong> via Omise payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn DuitNow QR', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>DuitNow QR</strong> via Opn payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_DuitNow_QR extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise DuitNow QR Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  DuitNow QR Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -39,7 +39,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __('Enable/Disable', 'omise'),
 				'type'    => 'checkbox',
-				'label'   => __('Enable Opn Payments  FPX Payment', 'omise'),
+				'label'   => __('Enable Opn Payments FPX Payment', 'omise'),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -10,7 +10,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_fpx';
 		$this->has_fields         = true;
-		$this->method_title       = __('Omise FPX', 'omise');
+		$this->method_title       = __('Opn FPX', 'omise');
 		$this->method_description = __('Accept payment through FPX', 'omise');
 		$this->supports           = array('products', 'refunds');
 
@@ -39,7 +39,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __('Enable/Disable', 'omise'),
 				'type'    => 'checkbox',
-				'label'   => __('Enable Omise FPX Payment', 'omise'),
+				'label'   => __('Enable Opn  FPX Payment', 'omise'),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-fpx.php
+++ b/includes/gateway/class-omise-payment-fpx.php
@@ -10,7 +10,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_fpx';
 		$this->has_fields         = true;
-		$this->method_title       = __('Opn FPX', 'omise');
+		$this->method_title       = __('Opn Payments FPX', 'omise');
 		$this->method_description = __('Accept payment through FPX', 'omise');
 		$this->supports           = array('products', 'refunds');
 
@@ -39,7 +39,7 @@ class Omise_Payment_FPX extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __('Enable/Disable', 'omise'),
 				'type'    => 'checkbox',
-				'label'   => __('Enable Opn  FPX Payment', 'omise'),
+				'label'   => __('Enable Opn Payments  FPX Payment', 'omise'),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-googlepay.php
+++ b/includes/gateway/class-omise-payment-googlepay.php
@@ -7,9 +7,9 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
 
         $this->id = 'omise_googlepay';
         $this->has_fields = true;
-        $this->method_title = __('Opn Google Pay', 'omise');
+        $this->method_title = __('Opn Payments Google Pay', 'omise');
         $this->method_description = wp_kses(
-            __('Accept payments through <strong>Google Pay</strong> via Opn payment gateway.', 'omise'),
+            __('Accept payments through <strong>Google Pay</strong> via Opn Payments payment gateway.', 'omise'),
             array('strong' => array())
         );
 
@@ -42,7 +42,7 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
                 'enabled' => array(
                     'title' => __('Enable/Disable', 'omise'),
                     'type' => 'checkbox',
-                    'label' => __('Enable Opn Google Pay Payment', 'omise'),
+                    'label' => __('Enable Opn Payments Google Pay Payment', 'omise'),
                     'default' => 'no'
                 ),
 
@@ -122,7 +122,7 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
                     'default'     => Omise_Card_Image::get_amex_default_display(),
                     'description' => wp_kses(
                         __('This only controls the allowed card networks GooglePay will allow the customer to select.
-                        <br />It is not related to card processing on Opn payment gateway.
+                        <br />It is not related to card processing on Opn Payments payment gateway.
                         <br />Note: This payment method will not be available on the checkout page if no card network is selected.', 'omise'),
                         array('br' => array())
                     )

--- a/includes/gateway/class-omise-payment-googlepay.php
+++ b/includes/gateway/class-omise-payment-googlepay.php
@@ -7,9 +7,9 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
 
         $this->id = 'omise_googlepay';
         $this->has_fields = true;
-        $this->method_title = __('Omise Google Pay', 'omise');
+        $this->method_title = __('Opn Google Pay', 'omise');
         $this->method_description = wp_kses(
-            __('Accept payments through <strong>Google Pay</strong> via Omise payment gateway.', 'omise'),
+            __('Accept payments through <strong>Google Pay</strong> via Opn payment gateway.', 'omise'),
             array('strong' => array())
         );
 
@@ -42,7 +42,7 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
                 'enabled' => array(
                     'title' => __('Enable/Disable', 'omise'),
                     'type' => 'checkbox',
-                    'label' => __('Enable Omise Google Pay Payment', 'omise'),
+                    'label' => __('Enable Opn Google Pay Payment', 'omise'),
                     'default' => 'no'
                 ),
 
@@ -122,7 +122,7 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
                     'default'     => Omise_Card_Image::get_amex_default_display(),
                     'description' => wp_kses(
                         __('This only controls the allowed card networks GooglePay will allow the customer to select.
-                        <br />It is not related to card processing on Omise payment gateway.
+                        <br />It is not related to card processing on Opn payment gateway.
                         <br />Note: This payment method will not be available on the checkout page if no card network is selected.', 'omise'),
                         array('br' => array())
                     )

--- a/includes/gateway/class-omise-payment-grabpay.php
+++ b/includes/gateway/class-omise-payment-grabpay.php
@@ -7,7 +7,7 @@ class Omise_Payment_GrabPay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_grabpay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise GrabPay', 'omise' );
+		$this->method_title       = __( 'Opn GrabPay', 'omise' );
 		$this->method_description = __( 'Accept payment through GrabPay', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
@@ -33,7 +33,7 @@ class Omise_Payment_GrabPay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise GrabPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  GrabPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-grabpay.php
+++ b/includes/gateway/class-omise-payment-grabpay.php
@@ -7,7 +7,7 @@ class Omise_Payment_GrabPay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_grabpay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn GrabPay', 'omise' );
+		$this->method_title       = __( 'Opn Payments GrabPay', 'omise' );
 		$this->method_description = __( 'Accept payment through GrabPay', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
@@ -33,7 +33,7 @@ class Omise_Payment_GrabPay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  GrabPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  GrabPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-grabpay.php
+++ b/includes/gateway/class-omise-payment-grabpay.php
@@ -33,7 +33,7 @@ class Omise_Payment_GrabPay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  GrabPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments GrabPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -10,9 +10,9 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_installment';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Omise Installments', 'omise' );
+		$this->method_title       = __( 'Opn Installments', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept <strong>installment payments</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept <strong>installment payments</strong> via Opn payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 		$this->supports           = array( 'products', 'refunds' );
@@ -40,7 +40,7 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Installment Payments', 'omise' ),
+				'label'   => __( 'Enable Opn  Installment Payments', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -40,7 +40,7 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Installment Payments', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Installment Payments', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -10,9 +10,9 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_installment';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Opn Installments', 'omise' );
+		$this->method_title       = __( 'Opn Payments Installments', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept <strong>installment payments</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept <strong>installment payments</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 		$this->supports           = array( 'products', 'refunds' );
@@ -40,7 +40,7 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Installment Payments', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Installment Payments', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -36,7 +36,7 @@ class Omise_Payment_Internetbanking extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Internet Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Internet Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -7,9 +7,9 @@ class Omise_Payment_Internetbanking extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_internetbanking';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Opn Internet Banking', 'omise' );
+		$this->method_title       = __( 'Opn Payments Internet Banking', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payment through <strong>Internet Banking</strong> via Opn payment gateway (only available in Thailand).', 'omise' ),
+			__( 'Accept payment through <strong>Internet Banking</strong> via Opn Payments payment gateway (only available in Thailand).', 'omise' ),
 			array(
 				'strong' => array()
 			)
@@ -36,7 +36,7 @@ class Omise_Payment_Internetbanking extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Internet Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Internet Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-internetbanking.php
+++ b/includes/gateway/class-omise-payment-internetbanking.php
@@ -7,9 +7,9 @@ class Omise_Payment_Internetbanking extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_internetbanking';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Omise Internet Banking', 'omise' );
+		$this->method_title       = __( 'Opn Internet Banking', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payment through <strong>Internet Banking</strong> via Omise payment gateway (only available in Thailand).', 'omise' ),
+			__( 'Accept payment through <strong>Internet Banking</strong> via Opn payment gateway (only available in Thailand).', 'omise' ),
 			array(
 				'strong' => array()
 			)
@@ -36,7 +36,7 @@ class Omise_Payment_Internetbanking extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Internet Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  Internet Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-konbini.php
+++ b/includes/gateway/class-omise-payment-konbini.php
@@ -40,7 +40,7 @@ class Omise_Payment_Konbini extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Convenience Store / Pay-easy / Online Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Convenience Store / Pay-easy / Online Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-konbini.php
+++ b/includes/gateway/class-omise-payment-konbini.php
@@ -13,7 +13,7 @@ class Omise_Payment_Konbini extends Omise_Payment_Offline {
 		$this->has_fields         = true;
 		$this->method_title       = __( 'Convenience Store / Pay-easy / Online Banking', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>Convenience Store</strong> / <strong>Pay-easy</strong> / <strong>Online Banking</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>Convenience Store</strong> / <strong>Pay-easy</strong> / <strong>Online Banking</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -40,7 +40,7 @@ class Omise_Payment_Konbini extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Convenience Store / Pay-easy / Online Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Convenience Store / Pay-easy / Online Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-konbini.php
+++ b/includes/gateway/class-omise-payment-konbini.php
@@ -13,7 +13,7 @@ class Omise_Payment_Konbini extends Omise_Payment_Offline {
 		$this->has_fields         = true;
 		$this->method_title       = __( 'Convenience Store / Pay-easy / Online Banking', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>Convenience Store</strong> / <strong>Pay-easy</strong> / <strong>Online Banking</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>Convenience Store</strong> / <strong>Pay-easy</strong> / <strong>Online Banking</strong> via Opn payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -40,7 +40,7 @@ class Omise_Payment_Konbini extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Convenience Store / Pay-easy / Online Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  Convenience Store / Pay-easy / Online Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-maybank-qr.php
+++ b/includes/gateway/class-omise-payment-maybank-qr.php
@@ -7,8 +7,8 @@ class Omise_Payment_Maybank_QR extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_maybank_qr';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn Maybank QRPay', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>Maybank QRPay</strong> via Opn payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Payments Maybank QRPay', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>Maybank QRPay</strong> via Opn Payments payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_Maybank_QR extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Maybank QRPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Maybank QRPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-maybank-qr.php
+++ b/includes/gateway/class-omise-payment-maybank-qr.php
@@ -33,7 +33,7 @@ class Omise_Payment_Maybank_QR extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Maybank QRPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Maybank QRPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-maybank-qr.php
+++ b/includes/gateway/class-omise-payment-maybank-qr.php
@@ -7,8 +7,8 @@ class Omise_Payment_Maybank_QR extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_maybank_qr';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise Maybank QRPay', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>Maybank QRPay</strong> via Omise payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Maybank QRPay', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>Maybank QRPay</strong> via Opn payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_Maybank_QR extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Maybank QRPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  Maybank QRPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-mobilebanking.php
+++ b/includes/gateway/class-omise-payment-mobilebanking.php
@@ -9,9 +9,9 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_mobilebanking';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Omise Mobile Banking', 'omise' );
+		$this->method_title       = __( 'Opn Mobile Banking', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payment through <strong>Mobile Banking</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept payment through <strong>Mobile Banking</strong> via Opn payment gateway.', 'omise' ),
 			array(
 				'strong' => array()
 			)
@@ -41,7 +41,7 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise Mobile Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  Mobile Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-mobilebanking.php
+++ b/includes/gateway/class-omise-payment-mobilebanking.php
@@ -41,7 +41,7 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  Mobile Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Mobile Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-mobilebanking.php
+++ b/includes/gateway/class-omise-payment-mobilebanking.php
@@ -9,9 +9,9 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_mobilebanking';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Opn Mobile Banking', 'omise' );
+		$this->method_title       = __( 'Opn Payments Mobile Banking', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payment through <strong>Mobile Banking</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept payment through <strong>Mobile Banking</strong> via Opn Payments payment gateway.', 'omise' ),
 			array(
 				'strong' => array()
 			)
@@ -41,7 +41,7 @@ class Omise_Payment_Mobilebanking extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  Mobile Banking Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  Mobile Banking Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-ocbc-pao.php
+++ b/includes/gateway/class-omise-payment-ocbc-pao.php
@@ -7,8 +7,8 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_ocbc_pao';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn OCBC Pay Anyone', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>OCBC Pay Anyone</strong> via Opn payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Payments OCBC Pay Anyone', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>OCBC Pay Anyone</strong> via Opn Payments payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  OCBC Pay Anyone Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  OCBC Pay Anyone Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-ocbc-pao.php
+++ b/includes/gateway/class-omise-payment-ocbc-pao.php
@@ -7,8 +7,8 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_ocbc_pao';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise OCBC Pay Anyone', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>OCBC Pay Anyone</strong> via Omise payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn OCBC Pay Anyone', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>OCBC Pay Anyone</strong> via Opn payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise OCBC Pay Anyone Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  OCBC Pay Anyone Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-ocbc-pao.php
+++ b/includes/gateway/class-omise-payment-ocbc-pao.php
@@ -33,7 +33,7 @@ class Omise_Payment_OCBC_PAO extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  OCBC Pay Anyone Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments OCBC Pay Anyone Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -39,7 +39,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  PayNow Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments PayNow Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -10,9 +10,9 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_paynow';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn PayNow', 'omise' );
+		$this->method_title       = __( 'Opn Payments PayNow', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>PayNow</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>PayNow</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 		$this->supports           = array( 'products', 'refunds' );
@@ -39,7 +39,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  PayNow Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  PayNow Payment', 'omise' ),
 				'default' => 'no'
 			),
 
@@ -100,7 +100,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 					<?php echo __( 'Scan the QR code to pay', 'omise' ); ?>
 				</p>
 				<div class="omise omise-paynow-qrcode">
-					<img src="<?php echo $qrcode; ?>" alt="Opn QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
+					<img src="<?php echo $qrcode; ?>" alt="Opn Payments QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
 				</div>
 				<div class="omise-paynow-payment-status">
 					<div class="pending">

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -10,9 +10,9 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_paynow';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise PayNow', 'omise' );
+		$this->method_title       = __( 'Opn PayNow', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>PayNow</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>PayNow</strong> via Opn payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 		$this->supports           = array( 'products', 'refunds' );
@@ -39,7 +39,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise PayNow Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  PayNow Payment', 'omise' ),
 				'default' => 'no'
 			),
 
@@ -100,7 +100,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 					<?php echo __( 'Scan the QR code to pay', 'omise' ); ?>
 				</p>
 				<div class="omise omise-paynow-qrcode">
-					<img src="<?php echo $qrcode; ?>" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
+					<img src="<?php echo $qrcode; ?>" alt="Opn QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
 				</div>
 				<div class="omise-paynow-payment-status">
 					<div class="pending">

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -11,9 +11,9 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_promptpay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise PromptPay', 'omise' );
+		$this->method_title       = __( 'Opn PromptPay', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>PromptPay</strong> via Omise payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>PromptPay</strong> via Opn payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -55,7 +55,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise PromptPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  PromptPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 
@@ -133,7 +133,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 		if ( 'view' === $context ) : ?>
 			<div id="omise-offline-additional-details" class="omise omise-additional-payment-details-box omise-promptpay-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
 				<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
-				<div class="omise omise-promptpay-qrcode" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
+				<div class="omise omise-promptpay-qrcode" alt="Opn QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
 					<?php $this->load_qr_svg_to_DOM($qrcode, 'omise-promptpay-qrcode-svg') ?>
 				</div>
 				<a id="omise-download-promptpay-qr" class="omise-download-promptpay-qr" href="<?php echo $qrcode ?>" download="qr_code.svg">Download QR</a>

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -55,7 +55,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  PromptPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments PromptPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -11,9 +11,9 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_promptpay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn PromptPay', 'omise' );
+		$this->method_title       = __( 'Opn Payments PromptPay', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>PromptPay</strong> via Opn payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>PromptPay</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -55,7 +55,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  PromptPay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  PromptPay Payment', 'omise' ),
 				'default' => 'no'
 			),
 
@@ -133,7 +133,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 		if ( 'view' === $context ) : ?>
 			<div id="omise-offline-additional-details" class="omise omise-additional-payment-details-box omise-promptpay-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
 				<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
-				<div class="omise omise-promptpay-qrcode" alt="Opn QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
+				<div class="omise omise-promptpay-qrcode" alt="Opn Payments QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
 					<?php $this->load_qr_svg_to_DOM($qrcode, 'omise-promptpay-qrcode-svg') ?>
 				</div>
 				<a id="omise-download-promptpay-qr" class="omise-download-promptpay-qr" href="<?php echo $qrcode ?>" download="qr_code.svg">Download QR</a>

--- a/includes/gateway/class-omise-payment-rabbit-linepay.php
+++ b/includes/gateway/class-omise-payment-rabbit-linepay.php
@@ -39,7 +39,7 @@ class Omise_Payment_RabbitLinePay extends Omise_Payment_Offsite {
 				'enabled' => array(
 					'title'   => __( 'Enable/Disable', 'omise' ),
 					'type'    => 'checkbox',
-					'label'   => __( 'Enable Opn Payments  Rabbit LINE Pay Payment', 'omise' ),
+					'label'   => __( 'Enable Opn Payments Rabbit LINE Pay Payment', 'omise' ),
 					'default' => 'no'
 				),
 

--- a/includes/gateway/class-omise-payment-rabbit-linepay.php
+++ b/includes/gateway/class-omise-payment-rabbit-linepay.php
@@ -10,7 +10,7 @@ class Omise_Payment_RabbitLinePay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_rabbit_linepay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn Rabbit LINE Pay', 'omise' );
+		$this->method_title       = __( 'Opn Payments Rabbit LINE Pay', 'omise' );
 		$this->method_description = __( 'Accept payment through Rabbit LINE Pay', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
@@ -39,7 +39,7 @@ class Omise_Payment_RabbitLinePay extends Omise_Payment_Offsite {
 				'enabled' => array(
 					'title'   => __( 'Enable/Disable', 'omise' ),
 					'type'    => 'checkbox',
-					'label'   => __( 'Enable Opn  Rabbit LINE Pay Payment', 'omise' ),
+					'label'   => __( 'Enable Opn Payments  Rabbit LINE Pay Payment', 'omise' ),
 					'default' => 'no'
 				),
 

--- a/includes/gateway/class-omise-payment-rabbit-linepay.php
+++ b/includes/gateway/class-omise-payment-rabbit-linepay.php
@@ -10,7 +10,7 @@ class Omise_Payment_RabbitLinePay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_rabbit_linepay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise Rabbit LINE Pay', 'omise' );
+		$this->method_title       = __( 'Opn Rabbit LINE Pay', 'omise' );
 		$this->method_description = __( 'Accept payment through Rabbit LINE Pay', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
@@ -39,7 +39,7 @@ class Omise_Payment_RabbitLinePay extends Omise_Payment_Offsite {
 				'enabled' => array(
 					'title'   => __( 'Enable/Disable', 'omise' ),
 					'type'    => 'checkbox',
-					'label'   => __( 'Enable Omise Rabbit LINE Pay Payment', 'omise' ),
+					'label'   => __( 'Enable Opn  Rabbit LINE Pay Payment', 'omise' ),
 					'default' => 'no'
 				),
 

--- a/includes/gateway/class-omise-payment-shopeepay.php
+++ b/includes/gateway/class-omise-payment-shopeepay.php
@@ -7,8 +7,8 @@ class Omise_Payment_ShopeePay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_shopeepay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise ShopeePay', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>ShopeePay</strong> via Omise payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn ShopeePay', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>ShopeePay</strong> via Opn payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_ShopeePay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise ShopeePay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  ShopeePay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-shopeepay.php
+++ b/includes/gateway/class-omise-payment-shopeepay.php
@@ -7,8 +7,8 @@ class Omise_Payment_ShopeePay extends Omise_Payment_Offsite {
 
 		$this->id                 = 'omise_shopeepay';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn ShopeePay', 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>ShopeePay</strong> via Opn payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Payments ShopeePay', 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>ShopeePay</strong> via Opn Payments payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -33,7 +33,7 @@ class Omise_Payment_ShopeePay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  ShopeePay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  ShopeePay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-shopeepay.php
+++ b/includes/gateway/class-omise-payment-shopeepay.php
@@ -33,7 +33,7 @@ class Omise_Payment_ShopeePay extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  ShopeePay Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments ShopeePay Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-touch-n-go.php
+++ b/includes/gateway/class-omise-payment-touch-n-go.php
@@ -9,8 +9,8 @@ class Omise_Payment_TouchNGo extends Omise_Payment_Offsite {
 		$this->provider           = $this->get_provider();
 		$this->id                 = 'omise_touch_n_go';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Omise ' . $this->GetMethodTitle(), 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>' . $this->GetMethodTitle() . '</strong> via Omise payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn ' . $this->GetMethodTitle(), 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>' . $this->GetMethodTitle() . '</strong> via Opn payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -42,7 +42,7 @@ class Omise_Payment_TouchNGo extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise ' . $method_title . ' Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  ' . $method_title . ' Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-touch-n-go.php
+++ b/includes/gateway/class-omise-payment-touch-n-go.php
@@ -9,8 +9,8 @@ class Omise_Payment_TouchNGo extends Omise_Payment_Offsite {
 		$this->provider           = $this->get_provider();
 		$this->id                 = 'omise_touch_n_go';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn ' . $this->GetMethodTitle(), 'omise' );
-		$this->method_description = __( 'Accept payment through <strong>' . $this->GetMethodTitle() . '</strong> via Opn payment gateway.', 'omise' );
+		$this->method_title       = __( 'Opn Payments ' . $this->GetMethodTitle(), 'omise' );
+		$this->method_description = __( 'Accept payment through <strong>' . $this->GetMethodTitle() . '</strong> via Opn Payments payment gateway.', 'omise' );
 		$this->supports           = array( 'products', 'refunds' );
 
 		$this->init_form_fields();
@@ -42,7 +42,7 @@ class Omise_Payment_TouchNGo extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  ' . $method_title . ' Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  ' . $method_title . ' Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-touch-n-go.php
+++ b/includes/gateway/class-omise-payment-touch-n-go.php
@@ -42,7 +42,7 @@ class Omise_Payment_TouchNGo extends Omise_Payment_Offsite {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  ' . $method_title . ' Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments ' . $method_title . ' Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -12,9 +12,9 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_truemoney';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Opn TrueMoney Wallet', 'omise' );
+		$this->method_title       = __( 'Opn Payments TrueMoney Wallet', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>TrueMoney Wallet</strong> via Opn payment gateway (only available in Thailand).', 'omise' ),
+			__( 'Accept payments through <strong>TrueMoney Wallet</strong> via Opn Payments payment gateway (only available in Thailand).', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -43,7 +43,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn  TrueMoney Wallet Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments  TrueMoney Wallet Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -43,7 +43,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments  TrueMoney Wallet Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments TrueMoney Wallet Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -12,9 +12,9 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 
 		$this->id                 = 'omise_truemoney';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Omise TrueMoney Wallet', 'omise' );
+		$this->method_title       = __( 'Opn TrueMoney Wallet', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>TrueMoney Wallet</strong> via Omise payment gateway (only available in Thailand).', 'omise' ),
+			__( 'Accept payments through <strong>TrueMoney Wallet</strong> via Opn payment gateway (only available in Thailand).', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -43,7 +43,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Omise TrueMoney Wallet Payment', 'omise' ),
+				'label'   => __( 'Enable Opn  TrueMoney Wallet Payment', 'omise' ),
 				'default' => 'no'
 			),
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -266,7 +266,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			return $this->invalid_order( $order_id );
 		}
 
-		$this->order->add_order_note( sprintf( __( 'Opn: Processing a payment with %s', 'omise' ), $this->method_title ) );
+		$this->order->add_order_note( sprintf( __( 'Opn Payments: Processing a payment with %s', 'omise' ), $this->method_title ) );
 		$this->order->add_meta_data( 'is_omise_payment_resolved', 'no', true );
 		$this->order->save();
 
@@ -276,7 +276,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			return $this->payment_failed( $e->getMessage() );
 		}
 
-		$this->order->add_order_note( sprintf( __( 'Opn: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
+		$this->order->add_order_note( sprintf( __( 'Opn Payments: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
 		$this->set_order_transaction_id( $charge['id'] );
 
 		return $this->result( $order_id, $this->order, $charge );
@@ -331,7 +331,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$this->order()->add_order_note(
 				sprintf(
 					wp_kses(
-						__( 'Opn: Payment successful (manual capture).<br/>An amount of %1$s %2$s has been paid', 'omise' ),
+						__( 'Opn Payments: Payment successful (manual capture).<br/>An amount of %1$s %2$s has been paid', 'omise' ),
 						array( 'br' => array() )
 					),
 
@@ -345,7 +345,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$omiseError = $e->getOmiseError();
 			$this->order()->add_order_note(
 				sprintf(
-					wp_kses( __( 'Opn: Capture failed (manual capture).<br/>%s', 'omise' ), array( 'br' => array() ) ),
+					wp_kses( __( 'Opn Payments: Capture failed (manual capture).<br/>%s', 'omise' ), array( 'br' => array() ) ),
 					$e->getMessage()
 				)
 			);
@@ -392,7 +392,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			if ( $refund['voided'] ) {
 				$message = sprintf(
 					wp_kses(
-						__( 'Opn: Voided an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
+						__( 'Opn Payments: Voided an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
 						array( 'br' => array() )
 					),
 					$amount,
@@ -402,7 +402,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			} else {
 				$message = sprintf(
 					wp_kses(
-						__( 'Opn: Refunded an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
+						__( 'Opn Payments: Refunded an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
 						array( 'br' => array() )
 					),
 					$amount,
@@ -456,13 +456,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 						}
 
 						$message = wp_kses( __(
-							'Opn: Payment refunded.<br/>An amount %1$s %2$s has been refunded (manual sync).', 'omise' ),
+							'Opn Payments: Payment refunded.<br/>An amount %1$s %2$s has been refunded (manual sync).', 'omise' ),
 							array( 'br' => array() )
 						);
 						$this->order()->add_order_note( sprintf( $message, $this->order()->get_total(), $this->order()->get_currency() ) );
 					} else {
 						$message = wp_kses( __(
-							'Opn: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync).', 'omise' ),
+							'Opn Payments: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync).', 'omise' ),
 							array( 'br' => array() )
 						);
 						$this->order()->add_order_note( sprintf( $message, $this->order()->get_total(), $this->order()->get_currency() ) );
@@ -477,7 +477,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 					$this->delete_capture_metadata();
 
 					$message = wp_kses(
-						__( 'Opn: Payment failed.<br/>%s (code: %s) (manual sync).', 'omise' ),
+						__( 'Opn Payments: Payment failed.<br/>%s (code: %s) (manual sync).', 'omise' ),
 						array( 'br' => array() )
 					);
 					$this->order()->add_order_note( sprintf( $message, Omise()->translate( $charge['failure_message'] ), $charge['failure_code'] ) );
@@ -489,8 +489,8 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 
 				case self::STATUS_PENDING:
 					$message = wp_kses( __(
-						'Opn: Payment is still in progress.<br/>
-						You might wait for a moment before click sync the status again or contact Opn support team at support@omise.co if you have any questions (manual sync).',
+						'Opn Payments: Payment is still in progress.<br/>
+						You might wait for a moment before click sync the status again or contact Opn Payments support team at support@omise.co if you have any questions (manual sync).',
 						'omise'
 					), array( 'br' => array() ) );
 
@@ -500,7 +500,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 				case self::STATUS_EXPIRED:
 					$this->delete_capture_metadata();
 
-					$message = wp_kses( __( 'Opn: Payment expired. (manual sync).', 'omise' ), array( 'br' => array() ) );
+					$message = wp_kses( __( 'Opn Payments: Payment expired. (manual sync).', 'omise' ), array( 'br' => array() ) );
 					$this->order()->add_order_note( $message );
 
 					if ( ! $this->order()->has_status( self::STATUS_CANCELLED ) ) {
@@ -511,7 +511,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 				case self::STATUS_REVERSED:
 					$this->delete_capture_metadata();
 
-					$message = wp_kses( __( 'Opn: Payment reversed. (manual sync).', 'omise' ), array( 'br' => array() ) );
+					$message = wp_kses( __( 'Opn Payments: Payment reversed. (manual sync).', 'omise' ), array( 'br' => array() ) );
 					$this->order()->add_order_note( $message );
 
 					if ( ! $this->order()->has_status( self::STATUS_CANCELLED ) ) {
@@ -521,13 +521,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 
 				default:
 					throw new Exception(
-						__( 'Cannot read the payment status. Please try sync again or contact Opn support team at support@omise.co if you have any questions.', 'omise' )
+						__( 'Cannot read the payment status. Please try sync again or contact Opn Payments support team at support@omise.co if you have any questions.', 'omise' )
 					);
 					break;
 			}
 		} catch ( Exception $e ) {
 			$message = wp_kses(
-				__( 'Opn: Sync failed (manual sync).<br/>%s.', 'omise' ),
+				__( 'Opn Payments: Sync failed (manual sync).<br/>%s.', 'omise' ),
 				array( 'br' => array() )
 			);
 
@@ -572,7 +572,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		$message = __( "It seems we've been unable to process your payment properly:<br/>%s", 'omise' );
 
 		if ( $this->order() ) {
-			$this->order()->add_order_note( sprintf( __( 'Opn: Payment failed, %s', 'omise' ), $reason ) );
+			$this->order()->add_order_note( sprintf( __( 'Opn Payments: Payment failed, %s', 'omise' ), $reason ) );
 			$this->order()->update_status( 'failed' );
 		}
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -266,7 +266,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			return $this->invalid_order( $order_id );
 		}
 
-		$this->order->add_order_note( sprintf( __( 'Omise: Processing a payment with %s', 'omise' ), $this->method_title ) );
+		$this->order->add_order_note( sprintf( __( 'Opn: Processing a payment with %s', 'omise' ), $this->method_title ) );
 		$this->order->add_meta_data( 'is_omise_payment_resolved', 'no', true );
 		$this->order->save();
 
@@ -276,7 +276,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			return $this->payment_failed( $e->getMessage() );
 		}
 
-		$this->order->add_order_note( sprintf( __( 'Omise: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
+		$this->order->add_order_note( sprintf( __( 'Opn: Charge (ID: %s) has been created', 'omise' ), $charge['id'] ) );
 		$this->set_order_transaction_id( $charge['id'] );
 
 		return $this->result( $order_id, $this->order, $charge );
@@ -331,7 +331,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$this->order()->add_order_note(
 				sprintf(
 					wp_kses(
-						__( 'Omise: Payment successful (manual capture).<br/>An amount of %1$s %2$s has been paid', 'omise' ),
+						__( 'Opn: Payment successful (manual capture).<br/>An amount of %1$s %2$s has been paid', 'omise' ),
 						array( 'br' => array() )
 					),
 
@@ -345,7 +345,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			$omiseError = $e->getOmiseError();
 			$this->order()->add_order_note(
 				sprintf(
-					wp_kses( __( 'Omise: Capture failed (manual capture).<br/>%s', 'omise' ), array( 'br' => array() ) ),
+					wp_kses( __( 'Opn: Capture failed (manual capture).<br/>%s', 'omise' ), array( 'br' => array() ) ),
 					$e->getMessage()
 				)
 			);
@@ -392,7 +392,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			if ( $refund['voided'] ) {
 				$message = sprintf(
 					wp_kses(
-						__( 'Omise: Voided an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
+						__( 'Opn: Voided an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
 						array( 'br' => array() )
 					),
 					$amount,
@@ -402,7 +402,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 			} else {
 				$message = sprintf(
 					wp_kses(
-						__( 'Omise: Refunded an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
+						__( 'Opn: Refunded an amount of %1$s %2$s.<br/>Refund id is %3$s', 'omise' ),
 						array( 'br' => array() )
 					),
 					$amount,
@@ -456,13 +456,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 						}
 
 						$message = wp_kses( __(
-							'Omise: Payment refunded.<br/>An amount %1$s %2$s has been refunded (manual sync).', 'omise' ),
+							'Opn: Payment refunded.<br/>An amount %1$s %2$s has been refunded (manual sync).', 'omise' ),
 							array( 'br' => array() )
 						);
 						$this->order()->add_order_note( sprintf( $message, $this->order()->get_total(), $this->order()->get_currency() ) );
 					} else {
 						$message = wp_kses( __(
-							'Omise: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync).', 'omise' ),
+							'Opn: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync).', 'omise' ),
 							array( 'br' => array() )
 						);
 						$this->order()->add_order_note( sprintf( $message, $this->order()->get_total(), $this->order()->get_currency() ) );
@@ -477,7 +477,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 					$this->delete_capture_metadata();
 
 					$message = wp_kses(
-						__( 'Omise: Payment failed.<br/>%s (code: %s) (manual sync).', 'omise' ),
+						__( 'Opn: Payment failed.<br/>%s (code: %s) (manual sync).', 'omise' ),
 						array( 'br' => array() )
 					);
 					$this->order()->add_order_note( sprintf( $message, Omise()->translate( $charge['failure_message'] ), $charge['failure_code'] ) );
@@ -489,8 +489,8 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 
 				case self::STATUS_PENDING:
 					$message = wp_kses( __(
-						'Omise: Payment is still in progress.<br/>
-						You might wait for a moment before click sync the status again or contact Omise support team at support@omise.co if you have any questions (manual sync).',
+						'Opn: Payment is still in progress.<br/>
+						You might wait for a moment before click sync the status again or contact Opn support team at support@omise.co if you have any questions (manual sync).',
 						'omise'
 					), array( 'br' => array() ) );
 
@@ -500,7 +500,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 				case self::STATUS_EXPIRED:
 					$this->delete_capture_metadata();
 
-					$message = wp_kses( __( 'Omise: Payment expired. (manual sync).', 'omise' ), array( 'br' => array() ) );
+					$message = wp_kses( __( 'Opn: Payment expired. (manual sync).', 'omise' ), array( 'br' => array() ) );
 					$this->order()->add_order_note( $message );
 
 					if ( ! $this->order()->has_status( self::STATUS_CANCELLED ) ) {
@@ -511,7 +511,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 				case self::STATUS_REVERSED:
 					$this->delete_capture_metadata();
 
-					$message = wp_kses( __( 'Omise: Payment reversed. (manual sync).', 'omise' ), array( 'br' => array() ) );
+					$message = wp_kses( __( 'Opn: Payment reversed. (manual sync).', 'omise' ), array( 'br' => array() ) );
 					$this->order()->add_order_note( $message );
 
 					if ( ! $this->order()->has_status( self::STATUS_CANCELLED ) ) {
@@ -521,13 +521,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 
 				default:
 					throw new Exception(
-						__( 'Cannot read the payment status. Please try sync again or contact Omise support team at support@omise.co if you have any questions.', 'omise' )
+						__( 'Cannot read the payment status. Please try sync again or contact Opn support team at support@omise.co if you have any questions.', 'omise' )
 					);
 					break;
 			}
 		} catch ( Exception $e ) {
 			$message = wp_kses(
-				__( 'Omise: Sync failed (manual sync).<br/>%s.', 'omise' ),
+				__( 'Opn: Sync failed (manual sync).<br/>%s.', 'omise' ),
 				array( 'br' => array() )
 			);
 
@@ -572,7 +572,7 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 		$message = __( "It seems we've been unable to process your payment properly:<br/>%s", 'omise' );
 
 		if ( $this->order() ) {
-			$this->order()->add_order_note( sprintf( __( 'Omise: Payment failed, %s', 'omise' ), $reason ) );
+			$this->order()->add_order_note( sprintf( __( 'Opn: Payment failed, %s', 'omise' ), $reason ) );
 			$this->order()->update_status( 'failed' );
 		}
 

--- a/languages/omise-ja.po
+++ b/languages/omise-ja.po
@@ -1,4 +1,4 @@
-# This file is distributed under the same license as the Opn package.
+# This file is distributed under the same license as the Opn Payments package.
 msgid ""
 msgstr ""
 "Project-Id-Version: Omise Payment Gateway v3.2\n"
@@ -18,12 +18,12 @@ msgstr ""
 "Language: ja\n"
 
 #: includes/gateway/class-omise-payment-alipay.php:21
-msgid "Opn Alipay"
-msgstr "Opn アリペイ"
+msgid "Opn Payments Alipay"
+msgstr "Opn Payments アリペイ"
 
 #: includes/gateway/class-omise-payment-alipay.php:22
 msgid "Accept payment through Alipay"
-msgstr "Opnを通してアリペイ決済を提供します。"
+msgstr "Opn Paymentsを通してアリペイ決済を提供します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:42 includes/gateway/class-omise-payment-creditcard.php:56
 #: includes/gateway/class-omise-payment-internetbanking.php:48
@@ -31,8 +31,8 @@ msgid "Enable/Disable"
 msgstr "有効/無効"
 
 #: includes/gateway/class-omise-payment-alipay.php:44
-msgid "Enable Opn  Alipay Payment"
-msgstr "Opnのアリペイ決済を有効化します。"
+msgid "Enable Opn Payments  Alipay Payment"
+msgstr "Opn Paymentsのアリペイ決済を有効化します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:49 includes/gateway/class-omise-payment-creditcard.php:63
 #: includes/gateway/class-omise-payment-internetbanking.php:55
@@ -67,17 +67,17 @@ msgid "try submit your order again or report our support team that you have foun
 msgstr "ていただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-alipay.php:88
-msgid "Opn: Processing a payment with Alipay solution."
-msgstr "Opn: アリペイソリューションで決済処理."
+msgid "Opn Payments: Processing a payment with Alipay solution."
+msgstr "Opn Payments: アリペイソリューションで決済処理."
 
 #: includes/gateway/class-omise-payment-alipay.php:99 includes/gateway/class-omise-payment-creditcard.php:289
 #: includes/gateway/class-omise-payment-internetbanking.php:115
-msgid "Opn: Charge (ID: %s) has been created"
-msgstr "Opn: 課金（ID：%s）が作成されました。"
+msgid "Opn Payments: Charge (ID: %s) has been created"
+msgstr "Opn Payments: 課金（ID：%s）が作成されました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:106 includes/gateway/class-omise-payment-internetbanking.php:122
-msgid "Opn: Redirecting buyer out to %s"
-msgstr "Opn: 購入者を %s にリダイレクトします。"
+msgid "Opn Payments: Redirecting buyer out to %s"
+msgstr "Opn Payments: 購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-alipay.php:122 includes/gateway/class-omise-payment-internetbanking.php:138
 msgid "Please feel free to try submit your order again or contact our support team if you have any questions (Your temporary order id is '%s')"
@@ -91,8 +91,8 @@ msgstr "お客様の決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:142 includes/gateway/class-omise-payment-creditcard.php:385
 #: includes/gateway/class-omise-payment-internetbanking.php:158
-msgid "Opn: Payment failed, %s"
-msgstr "Opn: 決済が完了できませんでした。%s"
+msgid "Opn Payments: Payment failed, %s"
+msgstr "Opn Payments: 決済が完了できませんでした。%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:158 includes/gateway/class-omise-payment-creditcard.php:492
 #: includes/gateway/class-omise-payment-internetbanking.php:174
@@ -101,38 +101,38 @@ msgstr "お客様の決済結果を確認できませんでした。<br/>すで�
 
 #: includes/gateway/class-omise-payment-alipay.php:168 includes/gateway/class-omise-payment-creditcard.php:502
 #: includes/gateway/class-omise-payment-internetbanking.php:184
-msgid "Opn: Validating the payment result.."
-msgstr "Opn: 決済処理の結果を返します。"
+msgid "Opn Payments: Validating the payment result.."
+msgstr "Opn Payments: 決済処理の結果を返します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:180
-msgid "Opn: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
-msgstr "Opn: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
+msgid "Opn Payments: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn Payments dashboard again later"
+msgstr "Opn Payments: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOpn Paymentsダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:196 includes/gateway/class-omise-payment-creditcard.php:338
 #: includes/gateway/class-omise-payment-creditcard.php:532 includes/gateway/class-omise-payment-internetbanking.php:212
-msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid"
-msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
+msgid "Opn Payments: Payment successful.<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn Payments: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:212 includes/gateway/class-omise-payment-creditcard.php:361
 msgid "Note that your payment might already has been processed. Please contact our support team if you have any questions."
-msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Opnサポートチームまでお問い合わせください。"
+msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Opn Paymentsサポートチームまでお問い合わせください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:228 includes/gateway/class-omise-payment-creditcard.php:577
 #: includes/gateway/class-omise-payment-internetbanking.php:244
-msgid "Opn: Payment failed.<br/>%s"
-msgstr "Opn: 決済を完了できませんでした。<br/>%s"
+msgid "Opn Payments: Payment failed.<br/>%s"
+msgstr "Opn Payments: 決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-creditcard.php:21
-msgid "Opn Credit / Debit Card"
-msgstr "Opn クレジットカード ／ デビットカード"
+msgid "Opn Payments Credit / Debit Card"
+msgstr "Opn Payments クレジットカード ／ デビットカード"
 
 #: includes/gateway/class-omise-payment-creditcard.php:23
-msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn payment gateway."
-msgstr "Opn決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
+msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn Payments payment gateway."
+msgstr "Opn Payments決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:58
-msgid "Enable Opn  Credit / Debit Card Payment"
-msgstr "Opnのクレジットカード／デビットカード決済システムを有効化します。"
+msgid "Enable Opn Payments  Credit / Debit Card Payment"
+msgstr "Opn Paymentsのクレジットカード／デビットカード決済システムを有効化します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:66
 msgid "Credit / Debit Card"
@@ -167,20 +167,20 @@ msgid "Enabling 3-D Secure payment means that buyer will be redirected to the 3-
 msgstr "3-Dセキュア決済を有効にすると、購入者は決済処理中に3-Dセキュアの認証ページにリダイレクトされます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:98
-msgid "Please be informed that you must contact Opn support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
-msgstr "本オプションのご利用を希望される方は、Opnサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
+msgid "Please be informed that you must contact Opn Payments support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
+msgstr "本オプションのご利用を希望される方は、Opn Paymentsサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:104
 msgid "Supported card icons"
 msgstr "ご利用可能ブランド"
 
 #: includes/gateway/class-omise-payment-creditcard.php:134
-msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Opn payment gateway."
+msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Opn Payments payment gateway."
 msgstr "ご提供可能なカードブランドのアイコンを決済画面に表示できます。<br/>本項目の選択内容は、カード処理システムには影響いたしません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:191
-msgid "Opn: Processing a payment with Credit Card solution.."
-msgstr "Opn: クレジットカード決済"
+msgid "Opn Payments: Processing a payment with Credit Card solution.."
+msgstr "Opn Payments: クレジットカード決済"
 
 #: includes/gateway/class-omise-payment-creditcard.php:198
 msgid "Please select an existing card or enter a new card information."
@@ -192,75 +192,75 @@ msgstr "ご使用のカードでは決済処理ができません。カード情
 
 #: includes/gateway/class-omise-payment-creditcard.php:250
 msgid "Note that nothing wrong by you, this might be from our store issue.<br/><br/>Please feel free to try submit your order again or report our support team that you have found this problem (Your temporary order id is '%s')"
-msgstr "お客様側ではなく、Opnサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
+msgstr "お客様側ではなく、Opn Paymentsサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-creditcard.php:303
-msgid "Opn: Processing with a 3-D Secure payment, redirecting buyer out to %s"
-msgstr "Opn: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
+msgid "Opn Payments: Processing with a 3-D Secure payment, redirecting buyer out to %s"
+msgstr "Opn Payments: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:320 includes/gateway/class-omise-payment-creditcard.php:514
-msgid "Opn: Payment processing.<br/>An amount %1$s %2$s has been authorized"
-msgstr "Opn: 決済処理 <br/> %1$s %2$s が認証されました。"
+msgid "Opn Payments: Payment processing.<br/>An amount %1$s %2$s has been authorized"
+msgstr "Opn Payments: 決済処理 <br/> %1$s %2$s が認証されました。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:411
 msgid "We cannot process your refund.<br/>Note that nothing wrong by you, this might be from the store issue.<br/><br/>Please feel try to create a refund again or report our support team that you have found this problem"
-msgstr "返金処理ができません。<br/>お客様側ではなく、Opnサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
+msgstr "返金処理ができません。<br/>お客様側ではなく、Opn Paymentsサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:423
-msgid "Opn: Refunding a payment with an amount %1$s %2$s"
-msgstr "Opn: %1$s %2$sを返金します。"
+msgid "Opn Payments: Refunding a payment with an amount %1$s %2$s"
+msgstr "Opn Payments: %1$s %2$sを返金します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:439
-msgid "Opn: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Opn: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
+msgid "Opn Payments: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn Payments: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:451
-msgid "Opn: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Opn: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
+msgid "Opn Payments: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn Payments: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:466 includes/gateway/class-omise-payment-creditcard.php:477
-msgid "Opn: Refund failed.<br/>%s"
-msgstr "Opn: 返金が完了できませんでした。"
+msgid "Opn Payments: Refund failed.<br/>%s"
+msgstr "Opn Payments: 返金が完了できませんでした。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:21
-msgid "Opn Internet Banking"
-msgstr "Opn インターネットバンキング"
+msgid "Opn Payments Internet Banking"
+msgstr "Opn Payments インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:23
-msgid "Accept payment through <strong>Internet Banking</strong> via Opn payment gateway (only available in Thailand)."
-msgstr "Opn決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
+msgid "Accept payment through <strong>Internet Banking</strong> via Opn Payments payment gateway (only available in Thailand)."
+msgstr "Opn Payments決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:50
-msgid "Enable Opn  Internet Banking Payment"
-msgstr "Opnのインターネットバンキングを有効化にします。"
+msgid "Enable Opn Payments  Internet Banking Payment"
+msgstr "Opn Paymentsのインターネットバンキングを有効化にします。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:58
 msgid "Internet Banking"
 msgstr "インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:104
-msgid "Opn: Processing a payment with Internet Banking solution.."
-msgstr "Opn: インターネットバンキングで決済を行います。"
+msgid "Opn Payments: Processing a payment with Internet Banking solution.."
+msgstr "Opn Payments: インターネットバンキングで決済を行います。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:196
-msgid "Opn: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
-msgstr "Opn: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
+msgid "Opn Payments: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn Payments dashboard again later"
+msgstr "Opn Payments: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOpn Paymentsダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment.php:57
 msgid "Payment Settings"
 msgstr "設定"
 
 #: includes/gateway/class-omise-payment.php:61
-msgid "All of your keys can be found at your Opn dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
-msgstr "加盟店毎に付与されるAPIキーはOpnダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
+msgid "All of your keys can be found at your Opn Payments dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
+msgstr "加盟店毎に付与されるAPIキーはOpn Paymentsダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
 
 #: includes/gateway/class-omise-payment.php:73
 msgid "Test mode"
 msgstr "テストモード"
 
 #: includes/gateway/class-omise-payment.php:75
-msgid "Enabling test mode means that all your transactions will be performed under the Opn test account."
-msgstr "テストモードを有効化すると、全取引がOpnテストアカウント下で実行されます。"
+msgid "Enabling test mode means that all your transactions will be performed under the Opn Payments test account."
+msgstr "テストモードを有効化すると、全取引がOpn Paymentsテストアカウント下で実行されます。"
 
 #: includes/gateway/class-omise-payment.php:80
 msgid "Public key for test"
@@ -279,40 +279,40 @@ msgid "Secret key for live"
 msgstr "ライブモード用シークレットキー"
 
 #: includes/gateway/class-omise-payment.php:261
-msgid "Opn: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
-msgstr "Opn: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
+msgid "Opn Payments: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn Payments: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
 
 #: includes/gateway/class-omise-payment.php:273
-msgid "Opn: Payment failed (manual capture).<br/>%s"
-msgstr "Opn: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
+msgid "Opn Payments: Payment failed (manual capture).<br/>%s"
+msgstr "Opn Payments: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
 
 #: includes/gateway/class-omise-payment.php:312
-msgid "Opn: Payment failed.<br/>%s (code: %s) (manual sync)."
-msgstr "Opn: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
+msgid "Opn Payments: Payment failed.<br/>%s (code: %s) (manual sync)."
+msgstr "Opn Payments: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
 
 #: includes/gateway/class-omise-payment.php:326
-msgid "Opn: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Opn support team at support@omise.co if you have any questions (manual sync)."
-msgstr "Opn: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
+msgid "Opn Payments: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Opn Payments support team at support@omise.co if you have any questions (manual sync)."
+msgstr "Opn Payments: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOpn Paymentsサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:337
-msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
-msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
+msgid "Opn Payments: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
+msgstr "Opn Payments: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:353
-msgid "Cannot read the payment status. Please try sync again or contact Opn support team at support@omise.co if you have any questions."
-msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください。"
+msgid "Cannot read the payment status. Please try sync again or contact Opn Payments support team at support@omise.co if you have any questions."
+msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOpn Paymentsサポートチーム（support@omise.co）にお問い合わせください。"
 
 #: includes/gateway/class-omise-payment.php:359
-msgid "Opn: Sync failed (manual sync).<br/>%s (manual sync)."
-msgstr "Opn: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
+msgid "Opn Payments: Sync failed (manual sync).<br/>%s (manual sync)."
+msgstr "Opn Payments: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
 
 #: omise-woocommerce.php:111
-msgid "Opn: Capture this order"
-msgstr "Opn: 注文のキャプチャ"
+msgid "Opn Payments: Capture this order"
+msgstr "Opn Payments: 注文のキャプチャ"
 
 #: omise-woocommerce.php:114
-msgid "Opn: Manual sync payment status"
-msgstr "Opn: マニュアル同期での決済状況"
+msgid "Opn Payments: Manual sync payment status"
+msgstr "Opn Payments: マニュアル同期での決済状況"
 
 #: templates/payment/form-creditcard.php:2
 msgid "Card number"
@@ -439,20 +439,20 @@ msgid "Remember this card"
 msgstr "カード情報を保存する"
 
 #: Plugin Name of the plugin/theme
-msgid "Opn Payment Gateway"
-msgstr "Opn 決済ゲートウェイ"
+msgid "Opn Payments Payment Gateway"
+msgstr "Opn Payments 決済ゲートウェイ"
 
 #: Plugin URI of the plugin/theme
 msgid "https://www.omise.co/woocommerce"
 msgstr "https://www.omise.co/ja/woocommerce-plugin/japan"
 
 #: Description of the plugin/theme
-msgid "Opn WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payment Gateway payment method to WooCommerce."
-msgstr " Opn WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOpn 決済ゲートウェイのサポートをWooCommerceに追加します。"
+msgid "Opn Payments WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payments Payment Gateway payment method to WooCommerce."
+msgstr " Opn Payments WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOpn Payments 決済ゲートウェイのサポートをWooCommerceに追加します。"
 
 #: Author of the plugin/theme
-msgid "Opn"
-msgstr "Opn "
+msgid "Opn Payments"
+msgstr "Opn Payments "
 
 #: Author URI of the plugin/theme
 msgid "https://www.omise.co"

--- a/languages/omise-ja.po
+++ b/languages/omise-ja.po
@@ -1,4 +1,4 @@
-# This file is distributed under the same license as the Omise package.
+# This file is distributed under the same license as the Opn package.
 msgid ""
 msgstr ""
 "Project-Id-Version: Omise Payment Gateway v3.2\n"
@@ -18,12 +18,12 @@ msgstr ""
 "Language: ja\n"
 
 #: includes/gateway/class-omise-payment-alipay.php:21
-msgid "Omise Alipay"
-msgstr "Omise アリペイ"
+msgid "Opn Alipay"
+msgstr "Opn アリペイ"
 
 #: includes/gateway/class-omise-payment-alipay.php:22
 msgid "Accept payment through Alipay"
-msgstr "Omiseを通してアリペイ決済を提供します。"
+msgstr "Opnを通してアリペイ決済を提供します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:42 includes/gateway/class-omise-payment-creditcard.php:56
 #: includes/gateway/class-omise-payment-internetbanking.php:48
@@ -31,8 +31,8 @@ msgid "Enable/Disable"
 msgstr "有効/無効"
 
 #: includes/gateway/class-omise-payment-alipay.php:44
-msgid "Enable Omise Alipay Payment"
-msgstr "Omiseのアリペイ決済を有効化します。"
+msgid "Enable Opn  Alipay Payment"
+msgstr "Opnのアリペイ決済を有効化します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:49 includes/gateway/class-omise-payment-creditcard.php:63
 #: includes/gateway/class-omise-payment-internetbanking.php:55
@@ -67,17 +67,17 @@ msgid "try submit your order again or report our support team that you have foun
 msgstr "ていただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-alipay.php:88
-msgid "Omise: Processing a payment with Alipay solution."
-msgstr "Omise: アリペイソリューションで決済処理."
+msgid "Opn: Processing a payment with Alipay solution."
+msgstr "Opn: アリペイソリューションで決済処理."
 
 #: includes/gateway/class-omise-payment-alipay.php:99 includes/gateway/class-omise-payment-creditcard.php:289
 #: includes/gateway/class-omise-payment-internetbanking.php:115
-msgid "Omise: Charge (ID: %s) has been created"
-msgstr "Omise: 課金（ID：%s）が作成されました。"
+msgid "Opn: Charge (ID: %s) has been created"
+msgstr "Opn: 課金（ID：%s）が作成されました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:106 includes/gateway/class-omise-payment-internetbanking.php:122
-msgid "Omise: Redirecting buyer out to %s"
-msgstr "Omise: 購入者を %s にリダイレクトします。"
+msgid "Opn: Redirecting buyer out to %s"
+msgstr "Opn: 購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-alipay.php:122 includes/gateway/class-omise-payment-internetbanking.php:138
 msgid "Please feel free to try submit your order again or contact our support team if you have any questions (Your temporary order id is '%s')"
@@ -91,8 +91,8 @@ msgstr "お客様の決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:142 includes/gateway/class-omise-payment-creditcard.php:385
 #: includes/gateway/class-omise-payment-internetbanking.php:158
-msgid "Omise: Payment failed, %s"
-msgstr "Omise: 決済が完了できませんでした。%s"
+msgid "Opn: Payment failed, %s"
+msgstr "Opn: 決済が完了できませんでした。%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:158 includes/gateway/class-omise-payment-creditcard.php:492
 #: includes/gateway/class-omise-payment-internetbanking.php:174
@@ -101,38 +101,38 @@ msgstr "お客様の決済結果を確認できませんでした。<br/>すで�
 
 #: includes/gateway/class-omise-payment-alipay.php:168 includes/gateway/class-omise-payment-creditcard.php:502
 #: includes/gateway/class-omise-payment-internetbanking.php:184
-msgid "Omise: Validating the payment result.."
-msgstr "Omise: 決済処理の結果を返します。"
+msgid "Opn: Validating the payment result.."
+msgstr "Opn: 決済処理の結果を返します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:180
-msgid "Omise: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Omise dashboard again later"
-msgstr "Omise: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOmiseダッシュボードにてご確認ください。"
+msgid "Opn: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
+msgstr "Opn: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:196 includes/gateway/class-omise-payment-creditcard.php:338
 #: includes/gateway/class-omise-payment-creditcard.php:532 includes/gateway/class-omise-payment-internetbanking.php:212
-msgid "Omise: Payment successful.<br/>An amount %1$s %2$s has been paid"
-msgstr "Omise: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
+msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:212 includes/gateway/class-omise-payment-creditcard.php:361
 msgid "Note that your payment might already has been processed. Please contact our support team if you have any questions."
-msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Omiseサポートチームまでお問い合わせください。"
+msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Opnサポートチームまでお問い合わせください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:228 includes/gateway/class-omise-payment-creditcard.php:577
 #: includes/gateway/class-omise-payment-internetbanking.php:244
-msgid "Omise: Payment failed.<br/>%s"
-msgstr "Omise: 決済を完了できませんでした。<br/>%s"
+msgid "Opn: Payment failed.<br/>%s"
+msgstr "Opn: 決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-creditcard.php:21
-msgid "Omise Credit / Debit Card"
-msgstr "Omise クレジットカード ／ デビットカード"
+msgid "Opn Credit / Debit Card"
+msgstr "Opn クレジットカード ／ デビットカード"
 
 #: includes/gateway/class-omise-payment-creditcard.php:23
-msgid "Accept payment through <strong>Credit / Debit Card</strong> via Omise payment gateway."
-msgstr "Omise決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
+msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn payment gateway."
+msgstr "Opn決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:58
-msgid "Enable Omise Credit / Debit Card Payment"
-msgstr "Omiseのクレジットカード／デビットカード決済システムを有効化します。"
+msgid "Enable Opn  Credit / Debit Card Payment"
+msgstr "Opnのクレジットカード／デビットカード決済システムを有効化します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:66
 msgid "Credit / Debit Card"
@@ -167,20 +167,20 @@ msgid "Enabling 3-D Secure payment means that buyer will be redirected to the 3-
 msgstr "3-Dセキュア決済を有効にすると、購入者は決済処理中に3-Dセキュアの認証ページにリダイレクトされます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:98
-msgid "Please be informed that you must contact Omise support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
-msgstr "本オプションのご利用を希望される方は、Omiseサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
+msgid "Please be informed that you must contact Opn support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
+msgstr "本オプションのご利用を希望される方は、Opnサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:104
 msgid "Supported card icons"
 msgstr "ご利用可能ブランド"
 
 #: includes/gateway/class-omise-payment-creditcard.php:134
-msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway."
+msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Opn payment gateway."
 msgstr "ご提供可能なカードブランドのアイコンを決済画面に表示できます。<br/>本項目の選択内容は、カード処理システムには影響いたしません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:191
-msgid "Omise: Processing a payment with Credit Card solution.."
-msgstr "Omise: クレジットカード決済"
+msgid "Opn: Processing a payment with Credit Card solution.."
+msgstr "Opn: クレジットカード決済"
 
 #: includes/gateway/class-omise-payment-creditcard.php:198
 msgid "Please select an existing card or enter a new card information."
@@ -192,75 +192,75 @@ msgstr "ご使用のカードでは決済処理ができません。カード情
 
 #: includes/gateway/class-omise-payment-creditcard.php:250
 msgid "Note that nothing wrong by you, this might be from our store issue.<br/><br/>Please feel free to try submit your order again or report our support team that you have found this problem (Your temporary order id is '%s')"
-msgstr "お客様側ではなく、Omiseサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
+msgstr "お客様側ではなく、Opnサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-creditcard.php:303
-msgid "Omise: Processing with a 3-D Secure payment, redirecting buyer out to %s"
-msgstr "Omise: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
+msgid "Opn: Processing with a 3-D Secure payment, redirecting buyer out to %s"
+msgstr "Opn: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:320 includes/gateway/class-omise-payment-creditcard.php:514
-msgid "Omise: Payment processing.<br/>An amount %1$s %2$s has been authorized"
-msgstr "Omise: 決済処理 <br/> %1$s %2$s が認証されました。"
+msgid "Opn: Payment processing.<br/>An amount %1$s %2$s has been authorized"
+msgstr "Opn: 決済処理 <br/> %1$s %2$s が認証されました。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:411
 msgid "We cannot process your refund.<br/>Note that nothing wrong by you, this might be from the store issue.<br/><br/>Please feel try to create a refund again or report our support team that you have found this problem"
-msgstr "返金処理ができません。<br/>お客様側ではなく、Omiseサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
+msgstr "返金処理ができません。<br/>お客様側ではなく、Opnサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:423
-msgid "Omise: Refunding a payment with an amount %1$s %2$s"
-msgstr "Omise: %1$s %2$sを返金します。"
+msgid "Opn: Refunding a payment with an amount %1$s %2$s"
+msgstr "Opn: %1$s %2$sを返金します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:439
-msgid "Omise: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Omise: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
+msgid "Opn: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:451
-msgid "Omise: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Omise: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
+msgid "Opn: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:466 includes/gateway/class-omise-payment-creditcard.php:477
-msgid "Omise: Refund failed.<br/>%s"
-msgstr "Omise: 返金が完了できませんでした。"
+msgid "Opn: Refund failed.<br/>%s"
+msgstr "Opn: 返金が完了できませんでした。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:21
-msgid "Omise Internet Banking"
-msgstr "Omise インターネットバンキング"
+msgid "Opn Internet Banking"
+msgstr "Opn インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:23
-msgid "Accept payment through <strong>Internet Banking</strong> via Omise payment gateway (only available in Thailand)."
-msgstr "Omise決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
+msgid "Accept payment through <strong>Internet Banking</strong> via Opn payment gateway (only available in Thailand)."
+msgstr "Opn決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:50
-msgid "Enable Omise Internet Banking Payment"
-msgstr "Omiseのインターネットバンキングを有効化にします。"
+msgid "Enable Opn  Internet Banking Payment"
+msgstr "Opnのインターネットバンキングを有効化にします。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:58
 msgid "Internet Banking"
 msgstr "インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:104
-msgid "Omise: Processing a payment with Internet Banking solution.."
-msgstr "Omise: インターネットバンキングで決済を行います。"
+msgid "Opn: Processing a payment with Internet Banking solution.."
+msgstr "Opn: インターネットバンキングで決済を行います。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:196
-msgid "Omise: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Omise dashboard again later"
-msgstr "Omise: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOmiseダッシュボードにてご確認ください。"
+msgid "Opn: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
+msgstr "Opn: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment.php:57
 msgid "Payment Settings"
 msgstr "設定"
 
 #: includes/gateway/class-omise-payment.php:61
-msgid "All of your keys can be found at your Omise dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
-msgstr "加盟店毎に付与されるAPIキーはOmiseダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
+msgid "All of your keys can be found at your Opn dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
+msgstr "加盟店毎に付与されるAPIキーはOpnダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
 
 #: includes/gateway/class-omise-payment.php:73
 msgid "Test mode"
 msgstr "テストモード"
 
 #: includes/gateway/class-omise-payment.php:75
-msgid "Enabling test mode means that all your transactions will be performed under the Omise test account."
-msgstr "テストモードを有効化すると、全取引がOmiseテストアカウント下で実行されます。"
+msgid "Enabling test mode means that all your transactions will be performed under the Opn test account."
+msgstr "テストモードを有効化すると、全取引がOpnテストアカウント下で実行されます。"
 
 #: includes/gateway/class-omise-payment.php:80
 msgid "Public key for test"
@@ -279,40 +279,40 @@ msgid "Secret key for live"
 msgstr "ライブモード用シークレットキー"
 
 #: includes/gateway/class-omise-payment.php:261
-msgid "Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
-msgstr "Omise: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
+msgid "Opn: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
 
 #: includes/gateway/class-omise-payment.php:273
-msgid "Omise: Payment failed (manual capture).<br/>%s"
-msgstr "Omise: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
+msgid "Opn: Payment failed (manual capture).<br/>%s"
+msgstr "Opn: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
 
 #: includes/gateway/class-omise-payment.php:312
-msgid "Omise: Payment failed.<br/>%s (code: %s) (manual sync)."
-msgstr "Omise: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
+msgid "Opn: Payment failed.<br/>%s (code: %s) (manual sync)."
+msgstr "Opn: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
 
 #: includes/gateway/class-omise-payment.php:326
-msgid "Omise: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Omise support team at support@omise.co if you have any questions (manual sync)."
-msgstr "Omise: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOmiseサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
+msgid "Opn: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Opn support team at support@omise.co if you have any questions (manual sync)."
+msgstr "Opn: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:337
-msgid "Omise: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
-msgstr "Omise: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
+msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
+msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:353
-msgid "Cannot read the payment status. Please try sync again or contact Omise support team at support@omise.co if you have any questions."
-msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOmiseサポートチーム（support@omise.co）にお問い合わせください。"
+msgid "Cannot read the payment status. Please try sync again or contact Opn support team at support@omise.co if you have any questions."
+msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください。"
 
 #: includes/gateway/class-omise-payment.php:359
-msgid "Omise: Sync failed (manual sync).<br/>%s (manual sync)."
-msgstr "Omise: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
+msgid "Opn: Sync failed (manual sync).<br/>%s (manual sync)."
+msgstr "Opn: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
 
 #: omise-woocommerce.php:111
-msgid "Omise: Capture this order"
-msgstr "Omise: 注文のキャプチャ"
+msgid "Opn: Capture this order"
+msgstr "Opn: 注文のキャプチャ"
 
 #: omise-woocommerce.php:114
-msgid "Omise: Manual sync payment status"
-msgstr "Omise: マニュアル同期での決済状況"
+msgid "Opn: Manual sync payment status"
+msgstr "Opn: マニュアル同期での決済状況"
 
 #: templates/payment/form-creditcard.php:2
 msgid "Card number"
@@ -439,20 +439,20 @@ msgid "Remember this card"
 msgstr "カード情報を保存する"
 
 #: Plugin Name of the plugin/theme
-msgid "Omise Payment Gateway"
-msgstr "Omise 決済ゲートウェイ"
+msgid "Opn Payment Gateway"
+msgstr "Opn 決済ゲートウェイ"
 
 #: Plugin URI of the plugin/theme
 msgid "https://www.omise.co/woocommerce"
 msgstr "https://www.omise.co/ja/woocommerce-plugin/japan"
 
 #: Description of the plugin/theme
-msgid "Omise WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce."
-msgstr " Omise WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOmise 決済ゲートウェイのサポートをWooCommerceに追加します。"
+msgid "Opn WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payment Gateway payment method to WooCommerce."
+msgstr " Opn WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOpn 決済ゲートウェイのサポートをWooCommerceに追加します。"
 
 #: Author of the plugin/theme
-msgid "Omise"
-msgstr "Omise "
+msgid "Opn"
+msgstr "Opn "
 
 #: Author URI of the plugin/theme
 msgid "https://www.omise.co"

--- a/languages/omise-ja.po
+++ b/languages/omise-ja.po
@@ -31,7 +31,7 @@ msgid "Enable/Disable"
 msgstr "有効/無効"
 
 #: includes/gateway/class-omise-payment-alipay.php:44
-msgid "Enable Opn Payments  Alipay Payment"
+msgid "Enable Opn Payments Alipay Payment"
 msgstr "Opn Paymentsのアリペイ決済を有効化します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:49 includes/gateway/class-omise-payment-creditcard.php:63
@@ -131,7 +131,7 @@ msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn Payme
 msgstr "Opn Payments決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:58
-msgid "Enable Opn Payments  Credit / Debit Card Payment"
+msgid "Enable Opn Payments Credit / Debit Card Payment"
 msgstr "Opn Paymentsのクレジットカード／デビットカード決済システムを有効化します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:66
@@ -231,7 +231,7 @@ msgid "Accept payment through <strong>Internet Banking</strong> via Opn Payments
 msgstr "Opn Payments決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:50
-msgid "Enable Opn Payments  Internet Banking Payment"
+msgid "Enable Opn Payments Internet Banking Payment"
 msgstr "Opn Paymentsのインターネットバンキングを有効化にします。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:58

--- a/languages/omise.pot
+++ b/languages/omise.pot
@@ -1,4 +1,4 @@
-# This file is distributed under the same license as the Omise package.
+# This file is distributed under the same license as the Opn package.
 msgid ""
 msgstr ""
 "Project-Id-Version: Omise Payment Gateway v3.2\n"
@@ -17,12 +17,12 @@ msgstr ""
 "X-Generator: grunt-wp-i18n1.0.0\n"
 
 #: includes/gateway/class-omise-payment-alipay.php:21
-msgid "Omise Alipay"
-msgstr "Omise アリペイ"
+msgid "Opn Alipay"
+msgstr "Opn アリペイ"
 
 #: includes/gateway/class-omise-payment-alipay.php:22
 msgid "Accept payment through Alipay"
-msgstr "Omiseを通してアリペイ決済を提供します。"
+msgstr "Opnを通してアリペイ決済を提供します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:42 includes/gateway/class-omise-payment-creditcard.php:56
 #: includes/gateway/class-omise-payment-internetbanking.php:48
@@ -30,8 +30,8 @@ msgid "Enable/Disable"
 msgstr "有効/無効"
 
 #: includes/gateway/class-omise-payment-alipay.php:44
-msgid "Enable Omise Alipay Payment"
-msgstr "Omiseのアリペイ決済を有効化します。"
+msgid "Enable Opn  Alipay Payment"
+msgstr "Opnのアリペイ決済を有効化します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:49 includes/gateway/class-omise-payment-creditcard.php:63
 #: includes/gateway/class-omise-payment-internetbanking.php:55
@@ -66,17 +66,17 @@ msgid"try submit your order again or report our support team that you have found
 msgstr "ていただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-alipay.php:88
-msgid "Omise: Processing a payment with Alipay solution."
-msgstr "Omise: アリペイソリューションで決済処理."
+msgid "Opn: Processing a payment with Alipay solution."
+msgstr "Opn: アリペイソリューションで決済処理."
 
 #: includes/gateway/class-omise-payment-alipay.php:99 includes/gateway/class-omise-payment-creditcard.php:289
 #: includes/gateway/class-omise-payment-internetbanking.php:115
-msgid "Omise: Charge (ID: %s) has been created"
-msgstr "Omise: 課金（ID：%s）が作成されました。"
+msgid "Opn: Charge (ID: %s) has been created"
+msgstr "Opn: 課金（ID：%s）が作成されました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:106 includes/gateway/class-omise-payment-internetbanking.php:122
-msgid "Omise: Redirecting buyer out to %s"
-msgstr "Omise: 購入者を %s にリダイレクトします。"
+msgid "Opn: Redirecting buyer out to %s"
+msgstr "Opn: 購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-alipay.php:122 includes/gateway/class-omise-payment-internetbanking.php:138
 msgid "Please feel free to try submit your order again or contact our support team if you have any questions (Your temporary order id is '%s')"
@@ -90,8 +90,8 @@ msgstr "お客様の決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:142 includes/gateway/class-omise-payment-creditcard.php:385
 #: includes/gateway/class-omise-payment-internetbanking.php:158
-msgid "Omise: Payment failed, %s"
-msgstr "Omise: 決済が完了できませんでした。%s"
+msgid "Opn: Payment failed, %s"
+msgstr "Opn: 決済が完了できませんでした。%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:158 includes/gateway/class-omise-payment-creditcard.php:492
 #: includes/gateway/class-omise-payment-internetbanking.php:174
@@ -100,38 +100,38 @@ msgstr "お客様の決済結果を確認できませんでした。<br/>すで�
 
 #: includes/gateway/class-omise-payment-alipay.php:168 includes/gateway/class-omise-payment-creditcard.php:502
 #: includes/gateway/class-omise-payment-internetbanking.php:184
-msgid "Omise: Validating the payment result.."
-msgstr "Omise: 決済処理の結果を返します。"
+msgid "Opn: Validating the payment result.."
+msgstr "Opn: 決済処理の結果を返します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:180
-msgid "Omise: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Omise dashboard again later"
-msgstr "Omise: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOmiseダッシュボードにてご確認ください。"
+msgid "Opn: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
+msgstr "Opn: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:196 includes/gateway/class-omise-payment-creditcard.php:338
 #: includes/gateway/class-omise-payment-creditcard.php:532 includes/gateway/class-omise-payment-internetbanking.php:212
-msgid "Omise: Payment successful.<br/>An amount %1$s %2$s has been paid"
-msgstr "Omise: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
+msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:212 includes/gateway/class-omise-payment-creditcard.php:361
 msgid "Note that your payment might already has been processed. Please contact our support team if you have any questions."
-msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Omiseサポートチームまでお問い合わせください。"
+msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Opnサポートチームまでお問い合わせください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:228 includes/gateway/class-omise-payment-creditcard.php:577
 #: includes/gateway/class-omise-payment-internetbanking.php:244
-msgid "Omise: Payment failed.<br/>%s"
-msgstr "Omise: 決済を完了できませんでした。<br/>%s"
+msgid "Opn: Payment failed.<br/>%s"
+msgstr "Opn: 決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-creditcard.php:21
-msgid "Omise Credit / Debit Card"
-msgstr "Omise クレジットカード ／ デビットカード"
+msgid "Opn Credit / Debit Card"
+msgstr "Opn クレジットカード ／ デビットカード"
 
 #: includes/gateway/class-omise-payment-creditcard.php:23
-msgid "Accept payment through <strong>Credit / Debit Card</strong> via Omise payment gateway."
-msgstr "Omise決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
+msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn payment gateway."
+msgstr "Opn決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:58
-msgid "Enable Omise Credit / Debit Card Payment"
-msgstr "Omiseのクレジットカード／デビットカード決済システムを有効化します。"
+msgid "Enable Opn  Credit / Debit Card Payment"
+msgstr "Opnのクレジットカード／デビットカード決済システムを有効化します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:66
 msgid "Credit / Debit Card"
@@ -166,20 +166,20 @@ msgid "Enabling 3-D Secure payment means that buyer will be redirected to the 3-
 msgstr "3-Dセキュア決済を有効にすると、購入者は決済処理中に3-Dセキュアの認証ページにリダイレクトされます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:98
-msgid "Please be informed that you must contact Omise support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
-msgstr "本オプションのご利用を希望される方は、Omiseサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
+msgid "Please be informed that you must contact Opn support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
+msgstr "本オプションのご利用を希望される方は、Opnサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:104
 msgid "Supported card icons"
 msgstr "ご利用可能ブランド"
 
 #: includes/gateway/class-omise-payment-creditcard.php:134
-msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Omise payment gateway."
+msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Opn payment gateway."
 msgstr "ご提供可能なカードブランドのアイコンを決済画面に表示できます。<br/>本項目の選択内容は、カード処理システムには影響いたしません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:191
-msgid "Omise: Processing a payment with Credit Card solution.."
-msgstr "Omise: クレジットカード決済"
+msgid "Opn: Processing a payment with Credit Card solution.."
+msgstr "Opn: クレジットカード決済"
 
 #: includes/gateway/class-omise-payment-creditcard.php:198
 msgid "Please select an existing card or enter a new card information."
@@ -191,75 +191,75 @@ msgstr "ご使用のカードでは決済処理ができません。カード情
 
 #: includes/gateway/class-omise-payment-creditcard.php:250
 msgid "Note that nothing wrong by you, this might be from our store issue.<br/><br/>Please feel free to try submit your order again or report our support team that you have found this problem (Your temporary order id is '%s')"
-msgstr "お客様側ではなく、Omiseサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
+msgstr "お客様側ではなく、Opnサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-creditcard.php:303
-msgid "Omise: Processing with a 3-D Secure payment, redirecting buyer out to %s"
-msgstr "Omise: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
+msgid "Opn: Processing with a 3-D Secure payment, redirecting buyer out to %s"
+msgstr "Opn: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:320 includes/gateway/class-omise-payment-creditcard.php:514
-msgid "Omise: Payment processing.<br/>An amount %1$s %2$s has been authorized"
-msgstr "Omise: 決済処理 <br/> %1$s %2$s が認証されました。"
+msgid "Opn: Payment processing.<br/>An amount %1$s %2$s has been authorized"
+msgstr "Opn: 決済処理 <br/> %1$s %2$s が認証されました。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:411
 msgid "We cannot process your refund.<br/>Note that nothing wrong by you, this might be from the store issue.<br/><br/>Please feel try to create a refund again or report our support team that you have found this problem"
-msgstr "返金処理ができません。<br/>お客様側ではなく、Omiseサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
+msgstr "返金処理ができません。<br/>お客様側ではなく、Opnサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:423
-msgid "Omise: Refunding a payment with an amount %1$s %2$s"
-msgstr "Omise: %1$s %2$sを返金します。"
+msgid "Opn: Refunding a payment with an amount %1$s %2$s"
+msgstr "Opn: %1$s %2$sを返金します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:439
-msgid "Omise: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Omise: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
+msgid "Opn: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:451
-msgid "Omise: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Omise: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
+msgid "Opn: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:466 includes/gateway/class-omise-payment-creditcard.php:477
-msgid "Omise: Refund failed.<br/>%s"
-msgstr "Omise: 返金が完了できませんでした。"
+msgid "Opn: Refund failed.<br/>%s"
+msgstr "Opn: 返金が完了できませんでした。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:21
-msgid "Omise Internet Banking"
-msgstr "Omise インターネットバンキング"
+msgid "Opn Internet Banking"
+msgstr "Opn インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:23
-msgid "Accept payment through <strong>Internet Banking</strong> via Omise payment gateway (only available in Thailand)."
-msgstr "Omise決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
+msgid "Accept payment through <strong>Internet Banking</strong> via Opn payment gateway (only available in Thailand)."
+msgstr "Opn決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:50
-msgid "Enable Omise Internet Banking Payment"
-msgstr "Omiseのインターネットバンキングを有効化にします。"
+msgid "Enable Opn  Internet Banking Payment"
+msgstr "Opnのインターネットバンキングを有効化にします。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:58
 msgid "Internet Banking"
 msgstr "インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:104
-msgid "Omise: Processing a payment with Internet Banking solution.."
-msgstr "Omise: インターネットバンキングで決済を行います。"
+msgid "Opn: Processing a payment with Internet Banking solution.."
+msgstr "Opn: インターネットバンキングで決済を行います。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:196
-msgid "Omise: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Omise dashboard again later"
-msgstr "Omise: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOmiseダッシュボードにてご確認ください。"
+msgid "Opn: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
+msgstr "Opn: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment.php:57
 msgid "Payment Settings"
 msgstr "設定"
 
 #: includes/gateway/class-omise-payment.php:61
-msgid "All of your keys can be found at your Omise dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
-msgstr "加盟店毎に付与されるAPIキーはOmiseダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
+msgid "All of your keys can be found at your Opn dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
+msgstr "加盟店毎に付与されるAPIキーはOpnダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
 
 #: includes/gateway/class-omise-payment.php:73
 msgid "Test mode"
 msgstr "テストモード"
 
 #: includes/gateway/class-omise-payment.php:75
-msgid "Enabling test mode means that all your transactions will be performed under the Omise test account."
-msgstr "テストモードを有効化すると、全取引がOmiseテストアカウント下で実行されます。"
+msgid "Enabling test mode means that all your transactions will be performed under the Opn test account."
+msgstr "テストモードを有効化すると、全取引がOpnテストアカウント下で実行されます。"
 
 #: includes/gateway/class-omise-payment.php:80
 msgid "Public key for test"
@@ -278,40 +278,40 @@ msgid "Secret key for live"
 msgstr "ライブモード用シークレットキー"
 
 #: includes/gateway/class-omise-payment.php:261
-msgid "Omise: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
-msgstr "Omise: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
+msgid "Opn: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
 
 #: includes/gateway/class-omise-payment.php:273
-msgid "Omise: Payment failed (manual capture).<br/>%s"
-msgstr "Omise: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
+msgid "Opn: Payment failed (manual capture).<br/>%s"
+msgstr "Opn: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
 
 #: includes/gateway/class-omise-payment.php:312
-msgid "Omise: Payment failed.<br/>%s (code: %s) (manual sync)."
-msgstr "Omise: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
+msgid "Opn: Payment failed.<br/>%s (code: %s) (manual sync)."
+msgstr "Opn: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
 
 #: includes/gateway/class-omise-payment.php:326
-msgid "Omise: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Omise support team at support@omise.co if you have any questions (manual sync)."
-msgstr "Omise: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOmiseサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
+msgid "Opn: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Opn support team at support@omise.co if you have any questions (manual sync)."
+msgstr "Opn: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:337
-msgid "Omise: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
-msgstr "Omise: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
+msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
+msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:353
-msgid "Cannot read the payment status. Please try sync again or contact Omise support team at support@omise.co if you have any questions."
-msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOmiseサポートチーム（support@omise.co）にお問い合わせください。"
+msgid "Cannot read the payment status. Please try sync again or contact Opn support team at support@omise.co if you have any questions."
+msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください。"
 
 #: includes/gateway/class-omise-payment.php:359
-msgid "Omise: Sync failed (manual sync).<br/>%s (manual sync)."
-msgstr "Omise: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
+msgid "Opn: Sync failed (manual sync).<br/>%s (manual sync)."
+msgstr "Opn: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
 
 #: omise-woocommerce.php:111
-msgid "Omise: Capture this order"
-msgstr "Omise: 注文のキャプチャ"
+msgid "Opn: Capture this order"
+msgstr "Opn: 注文のキャプチャ"
 
 #: omise-woocommerce.php:114
-msgid "Omise: Manual sync payment status"
-msgstr "Omise: マニュアル同期での決済状況"
+msgid "Opn: Manual sync payment status"
+msgstr "Opn: マニュアル同期での決済状況"
 
 #: templates/payment/form-creditcard.php:2
 msgid "Card number"
@@ -386,20 +386,20 @@ msgid "Remember this card"
 msgstr "カード情報を保存する"
 
 #: Plugin Name of the plugin/theme
-msgid "Omise Payment Gateway"
-msgstr "Omise 決済ゲートウェイ"
+msgid "Opn Payment Gateway"
+msgstr "Opn 決済ゲートウェイ"
 
 #: Plugin URI of the plugin/theme
 msgid "https://www.omise.co/woocommerce"
 msgstr "https://www.omise.co/ja/woocommerce-plugin/japan"
 
 #: Description of the plugin/theme
-msgid "Omise WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce."
-msgstr " Omise WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOmise 決済ゲートウェイのサポートをWooCommerceに追加します。"
+msgid "Opn WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payment Gateway payment method to WooCommerce."
+msgstr " Opn WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOpn 決済ゲートウェイのサポートをWooCommerceに追加します。"
 
 #: Author of the plugin/theme
-msgid "Omise"
-msgstr "Omise "
+msgid "Opn"
+msgstr "Opn "
 
 #: Author URI of the plugin/theme
 msgid "https://www.omise.co"

--- a/languages/omise.pot
+++ b/languages/omise.pot
@@ -30,7 +30,7 @@ msgid "Enable/Disable"
 msgstr "有効/無効"
 
 #: includes/gateway/class-omise-payment-alipay.php:44
-msgid "Enable Opn Payments  Alipay Payment"
+msgid "Enable Opn Payments Alipay Payment"
 msgstr "Opn Paymentsのアリペイ決済を有効化します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:49 includes/gateway/class-omise-payment-creditcard.php:63
@@ -130,7 +130,7 @@ msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn Payme
 msgstr "Opn Payments決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:58
-msgid "Enable Opn Payments  Credit / Debit Card Payment"
+msgid "Enable Opn Payments Credit / Debit Card Payment"
 msgstr "Opn Paymentsのクレジットカード／デビットカード決済システムを有効化します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:66
@@ -230,7 +230,7 @@ msgid "Accept payment through <strong>Internet Banking</strong> via Opn Payments
 msgstr "Opn Payments決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:50
-msgid "Enable Opn Payments  Internet Banking Payment"
+msgid "Enable Opn Payments Internet Banking Payment"
 msgstr "Opn Paymentsのインターネットバンキングを有効化にします。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:58

--- a/languages/omise.pot
+++ b/languages/omise.pot
@@ -1,4 +1,4 @@
-# This file is distributed under the same license as the Opn package.
+# This file is distributed under the same license as the Opn Payments package.
 msgid ""
 msgstr ""
 "Project-Id-Version: Omise Payment Gateway v3.2\n"
@@ -17,12 +17,12 @@ msgstr ""
 "X-Generator: grunt-wp-i18n1.0.0\n"
 
 #: includes/gateway/class-omise-payment-alipay.php:21
-msgid "Opn Alipay"
-msgstr "Opn アリペイ"
+msgid "Opn Payments Alipay"
+msgstr "Opn Payments アリペイ"
 
 #: includes/gateway/class-omise-payment-alipay.php:22
 msgid "Accept payment through Alipay"
-msgstr "Opnを通してアリペイ決済を提供します。"
+msgstr "Opn Paymentsを通してアリペイ決済を提供します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:42 includes/gateway/class-omise-payment-creditcard.php:56
 #: includes/gateway/class-omise-payment-internetbanking.php:48
@@ -30,8 +30,8 @@ msgid "Enable/Disable"
 msgstr "有効/無効"
 
 #: includes/gateway/class-omise-payment-alipay.php:44
-msgid "Enable Opn  Alipay Payment"
-msgstr "Opnのアリペイ決済を有効化します。"
+msgid "Enable Opn Payments  Alipay Payment"
+msgstr "Opn Paymentsのアリペイ決済を有効化します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:49 includes/gateway/class-omise-payment-creditcard.php:63
 #: includes/gateway/class-omise-payment-internetbanking.php:55
@@ -66,17 +66,17 @@ msgid"try submit your order again or report our support team that you have found
 msgstr "ていただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-alipay.php:88
-msgid "Opn: Processing a payment with Alipay solution."
-msgstr "Opn: アリペイソリューションで決済処理."
+msgid "Opn Payments: Processing a payment with Alipay solution."
+msgstr "Opn Payments: アリペイソリューションで決済処理."
 
 #: includes/gateway/class-omise-payment-alipay.php:99 includes/gateway/class-omise-payment-creditcard.php:289
 #: includes/gateway/class-omise-payment-internetbanking.php:115
-msgid "Opn: Charge (ID: %s) has been created"
-msgstr "Opn: 課金（ID：%s）が作成されました。"
+msgid "Opn Payments: Charge (ID: %s) has been created"
+msgstr "Opn Payments: 課金（ID：%s）が作成されました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:106 includes/gateway/class-omise-payment-internetbanking.php:122
-msgid "Opn: Redirecting buyer out to %s"
-msgstr "Opn: 購入者を %s にリダイレクトします。"
+msgid "Opn Payments: Redirecting buyer out to %s"
+msgstr "Opn Payments: 購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-alipay.php:122 includes/gateway/class-omise-payment-internetbanking.php:138
 msgid "Please feel free to try submit your order again or contact our support team if you have any questions (Your temporary order id is '%s')"
@@ -90,8 +90,8 @@ msgstr "お客様の決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:142 includes/gateway/class-omise-payment-creditcard.php:385
 #: includes/gateway/class-omise-payment-internetbanking.php:158
-msgid "Opn: Payment failed, %s"
-msgstr "Opn: 決済が完了できませんでした。%s"
+msgid "Opn Payments: Payment failed, %s"
+msgstr "Opn Payments: 決済が完了できませんでした。%s"
 
 #: includes/gateway/class-omise-payment-alipay.php:158 includes/gateway/class-omise-payment-creditcard.php:492
 #: includes/gateway/class-omise-payment-internetbanking.php:174
@@ -100,38 +100,38 @@ msgstr "お客様の決済結果を確認できませんでした。<br/>すで�
 
 #: includes/gateway/class-omise-payment-alipay.php:168 includes/gateway/class-omise-payment-creditcard.php:502
 #: includes/gateway/class-omise-payment-internetbanking.php:184
-msgid "Opn: Validating the payment result.."
-msgstr "Opn: 決済処理の結果を返します。"
+msgid "Opn Payments: Validating the payment result.."
+msgstr "Opn Payments: 決済処理の結果を返します。"
 
 #: includes/gateway/class-omise-payment-alipay.php:180
-msgid "Opn: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
-msgstr "Opn: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
+msgid "Opn Payments: The payment has been processing.<br/>Due to the Alipay process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn Payments dashboard again later"
+msgstr "Opn Payments: 決済処理中です。<br/>アリペイ側の決済処理により、反映には数秒から1時間程かかる場合がございます。Order Actionsパネルから手動で「決済スータスを同期する」を実行いただくか、またはOpn Paymentsダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:196 includes/gateway/class-omise-payment-creditcard.php:338
 #: includes/gateway/class-omise-payment-creditcard.php:532 includes/gateway/class-omise-payment-internetbanking.php:212
-msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid"
-msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
+msgid "Opn Payments: Payment successful.<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn Payments: 決済が完了しました。<br/>%1$s %2$sが支払われました。"
 
 #: includes/gateway/class-omise-payment-alipay.php:212 includes/gateway/class-omise-payment-creditcard.php:361
 msgid "Note that your payment might already has been processed. Please contact our support team if you have any questions."
-msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Opnサポートチームまでお問い合わせください。"
+msgstr "決済処理中の可能性がありますのでご注意ください。ご不明な点がございましたら、Opn Paymentsサポートチームまでお問い合わせください。"
 
 #: includes/gateway/class-omise-payment-alipay.php:228 includes/gateway/class-omise-payment-creditcard.php:577
 #: includes/gateway/class-omise-payment-internetbanking.php:244
-msgid "Opn: Payment failed.<br/>%s"
-msgstr "Opn: 決済を完了できませんでした。<br/>%s"
+msgid "Opn Payments: Payment failed.<br/>%s"
+msgstr "Opn Payments: 決済を完了できませんでした。<br/>%s"
 
 #: includes/gateway/class-omise-payment-creditcard.php:21
-msgid "Opn Credit / Debit Card"
-msgstr "Opn クレジットカード ／ デビットカード"
+msgid "Opn Payments Credit / Debit Card"
+msgstr "Opn Payments クレジットカード ／ デビットカード"
 
 #: includes/gateway/class-omise-payment-creditcard.php:23
-msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn payment gateway."
-msgstr "Opn決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
+msgid "Accept payment through <strong>Credit / Debit Card</strong> via Opn Payments payment gateway."
+msgstr "Opn Payments決済ゲートウェイを経由して<strong>クレジットカード／デビットカード</strong>決済を受け付けます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:58
-msgid "Enable Opn  Credit / Debit Card Payment"
-msgstr "Opnのクレジットカード／デビットカード決済システムを有効化します。"
+msgid "Enable Opn Payments  Credit / Debit Card Payment"
+msgstr "Opn Paymentsのクレジットカード／デビットカード決済システムを有効化します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:66
 msgid "Credit / Debit Card"
@@ -166,20 +166,20 @@ msgid "Enabling 3-D Secure payment means that buyer will be redirected to the 3-
 msgstr "3-Dセキュア決済を有効にすると、購入者は決済処理中に3-Dセキュアの認証ページにリダイレクトされます。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:98
-msgid "Please be informed that you must contact Opn support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
-msgstr "本オプションのご利用を希望される方は、Opnサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
+msgid "Please be informed that you must contact Opn Payments support team (support@omise.co) before enable or disable this option.<br/> (Japan-based accounts are not eligible for the service.)"
+msgstr "本オプションのご利用を希望される方は、Opn Paymentsサポートチーム(support@omise.co)までご連絡ください。<br/>なお、誠に恐れ入りますが、日本国内の加盟店は現在ご利用いただけません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:104
 msgid "Supported card icons"
 msgstr "ご利用可能ブランド"
 
 #: includes/gateway/class-omise-payment-creditcard.php:134
-msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Opn payment gateway."
+msgid "This only controls the icons displayed on the checkout page.<br />It is not related to card processing on Opn Payments payment gateway."
 msgstr "ご提供可能なカードブランドのアイコンを決済画面に表示できます。<br/>本項目の選択内容は、カード処理システムには影響いたしません。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:191
-msgid "Opn: Processing a payment with Credit Card solution.."
-msgstr "Opn: クレジットカード決済"
+msgid "Opn Payments: Processing a payment with Credit Card solution.."
+msgstr "Opn Payments: クレジットカード決済"
 
 #: includes/gateway/class-omise-payment-creditcard.php:198
 msgid "Please select an existing card or enter a new card information."
@@ -191,75 +191,75 @@ msgstr "ご使用のカードでは決済処理ができません。カード情
 
 #: includes/gateway/class-omise-payment-creditcard.php:250
 msgid "Note that nothing wrong by you, this might be from our store issue.<br/><br/>Please feel free to try submit your order again or report our support team that you have found this problem (Your temporary order id is '%s')"
-msgstr "お客様側ではなく、Opnサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
+msgstr "お客様側ではなく、Opn Paymentsサイドの問題だと考えられます。お手数ですが、再度ご注文をいただくか、サポートチームまでご報告ください。（お問い合わせの際は注文ID '%s') をご提示ください。）"
 
 #: includes/gateway/class-omise-payment-creditcard.php:303
-msgid "Opn: Processing with a 3-D Secure payment, redirecting buyer out to %s"
-msgstr "Opn: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
+msgid "Opn Payments: Processing with a 3-D Secure payment, redirecting buyer out to %s"
+msgstr "Opn Payments: 3Dセキュアによる二要素認証のため、購入者を %s にリダイレクトします。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:320 includes/gateway/class-omise-payment-creditcard.php:514
-msgid "Opn: Payment processing.<br/>An amount %1$s %2$s has been authorized"
-msgstr "Opn: 決済処理 <br/> %1$s %2$s が認証されました。"
+msgid "Opn Payments: Payment processing.<br/>An amount %1$s %2$s has been authorized"
+msgstr "Opn Payments: 決済処理 <br/> %1$s %2$s が認証されました。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:411
 msgid "We cannot process your refund.<br/>Note that nothing wrong by you, this might be from the store issue.<br/><br/>Please feel try to create a refund again or report our support team that you have found this problem"
-msgstr "返金処理ができません。<br/>お客様側ではなく、Opnサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
+msgstr "返金処理ができません。<br/>お客様側ではなく、Opn Paymentsサイドの問題だと考えられます。<br/><br/>お手数ですが、再度 返金手続きを行っていただくか、サポートチームまでご報告ください。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:423
-msgid "Opn: Refunding a payment with an amount %1$s %2$s"
-msgstr "Opn: %1$s %2$sを返金します。"
+msgid "Opn Payments: Refunding a payment with an amount %1$s %2$s"
+msgstr "Opn Payments: %1$s %2$sを返金します。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:439
-msgid "Opn: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Opn: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
+msgid "Opn Payments: Voided an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn Payments: %1$s %2$sが無効になりました。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:451
-msgid "Opn: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
-msgstr "Opn: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
+msgid "Opn Payments: Refunded an amount %1$s %2$s.<br/>Refund id is %3$s"
+msgstr "Opn Payments: %1$s %2$sが返金済です。<br/>返金IDは %3$sです。"
 
 #: includes/gateway/class-omise-payment-creditcard.php:466 includes/gateway/class-omise-payment-creditcard.php:477
-msgid "Opn: Refund failed.<br/>%s"
-msgstr "Opn: 返金が完了できませんでした。"
+msgid "Opn Payments: Refund failed.<br/>%s"
+msgstr "Opn Payments: 返金が完了できませんでした。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:21
-msgid "Opn Internet Banking"
-msgstr "Opn インターネットバンキング"
+msgid "Opn Payments Internet Banking"
+msgstr "Opn Payments インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:23
-msgid "Accept payment through <strong>Internet Banking</strong> via Opn payment gateway (only available in Thailand)."
-msgstr "Opn決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
+msgid "Accept payment through <strong>Internet Banking</strong> via Opn Payments payment gateway (only available in Thailand)."
+msgstr "Opn Payments決済ゲートウェイを通して<strong>インターネットバンキング<strong>をご提供します（現在、タイ契約加盟店様のみご利用可能です）"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:50
-msgid "Enable Opn  Internet Banking Payment"
-msgstr "Opnのインターネットバンキングを有効化にします。"
+msgid "Enable Opn Payments  Internet Banking Payment"
+msgstr "Opn Paymentsのインターネットバンキングを有効化にします。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:58
 msgid "Internet Banking"
 msgstr "インターネットバンキング"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:104
-msgid "Opn: Processing a payment with Internet Banking solution.."
-msgstr "Opn: インターネットバンキングで決済を行います。"
+msgid "Opn Payments: Processing a payment with Internet Banking solution.."
+msgstr "Opn Payments: インターネットバンキングで決済を行います。"
 
 #: includes/gateway/class-omise-payment-internetbanking.php:196
-msgid "Opn: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn dashboard again later"
-msgstr "Opn: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOpnダッシュボードにてご確認ください。"
+msgid "Opn Payments: The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or an hour. Please do a manual 'Sync Payment Status' action from the Order Actions panel or check the payment status directly at Opn Payments dashboard again later"
+msgstr "Opn Payments: 決済処理中です。<br/>銀行側の決済処理により、反映には数秒から1時間程度かかる場合がございます。Order Actionsバネルから手動で「決済ステータスを同期する」を実行いただくか、またはOpn Paymentsダッシュボードにてご確認ください。"
 
 #: includes/gateway/class-omise-payment.php:57
 msgid "Payment Settings"
 msgstr "設定"
 
 #: includes/gateway/class-omise-payment.php:61
-msgid "All of your keys can be found at your Opn dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
-msgstr "加盟店毎に付与されるAPIキーはOpnダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
+msgid "All of your keys can be found at your Opn Payments dashboard, check the following links.<br/><a href=\"%s\">Test keys</a> or <a href=\"%s" "\">Live keys</a> (login required)"
+msgstr "加盟店毎に付与されるAPIキーはOpn Paymentsダッシュボードから取得できます<br/><a href=\"%s\">テストキー</a> or <a href=\"%s" "\">ライブキー</a>（アカウントログイン必須）"
 
 #: includes/gateway/class-omise-payment.php:73
 msgid "Test mode"
 msgstr "テストモード"
 
 #: includes/gateway/class-omise-payment.php:75
-msgid "Enabling test mode means that all your transactions will be performed under the Opn test account."
-msgstr "テストモードを有効化すると、全取引がOpnテストアカウント下で実行されます。"
+msgid "Enabling test mode means that all your transactions will be performed under the Opn Payments test account."
+msgstr "テストモードを有効化すると、全取引がOpn Paymentsテストアカウント下で実行されます。"
 
 #: includes/gateway/class-omise-payment.php:80
 msgid "Public key for test"
@@ -278,40 +278,40 @@ msgid "Secret key for live"
 msgstr "ライブモード用シークレットキー"
 
 #: includes/gateway/class-omise-payment.php:261
-msgid "Opn: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
-msgstr "Opn: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
+msgid "Opn Payments: Payment successful (manual capture).<br/>An amount %1$s %2$s has been paid"
+msgstr "Opn Payments: 決済が完了しました（マニュアルキャプチャ）。<br/> %1$s %2$s の決済を行いました。"
 
 #: includes/gateway/class-omise-payment.php:273
-msgid "Opn: Payment failed (manual capture).<br/>%s"
-msgstr "Opn: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
+msgid "Opn Payments: Payment failed (manual capture).<br/>%s"
+msgstr "Opn Payments: 決済が完了できませんでした。（マニュアルキャプチャ）<br/>%s"
 
 #: includes/gateway/class-omise-payment.php:312
-msgid "Opn: Payment failed.<br/>%s (code: %s) (manual sync)."
-msgstr "Opn: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
+msgid "Opn Payments: Payment failed.<br/>%s (code: %s) (manual sync)."
+msgstr "Opn Payments: 決済が完了できませんでした。<br/>%s (コード: %s) (マニュアル同期)。"
 
 #: includes/gateway/class-omise-payment.php:326
-msgid "Opn: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Opn support team at support@omise.co if you have any questions (manual sync)."
-msgstr "Opn: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
+msgid "Opn Payments: Payment is still in progress.<br/>You might wait for a moment before click sync the status again or contact Opn Payments support team at support@omise.co if you have any questions (manual sync)."
+msgstr "Opn Payments: 決済処理中です。<br/>しばらく待ってから再度ステータスの同期を行うか、ご不明な点があればOpn Paymentsサポートチーム（support@omise.co）にお問い合わせください（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:337
-msgid "Opn: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
-msgstr "Opn: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
+msgid "Opn Payments: Payment successful.<br/>An amount %1$s %2$s has been paid (manual sync)."
+msgstr "Opn Payments: 決済が完了しました。<br/>%1$s %2$sが支払われました（マニュアル同期）。"
 
 #: includes/gateway/class-omise-payment.php:353
-msgid "Cannot read the payment status. Please try sync again or contact Opn support team at support@omise.co if you have any questions."
-msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOpnサポートチーム（support@omise.co）にお問い合わせください。"
+msgid "Cannot read the payment status. Please try sync again or contact Opn Payments support team at support@omise.co if you have any questions."
+msgstr "決済結果を確認できませんでした。再度同期をお試しいただくか、ご不明な点があればOpn Paymentsサポートチーム（support@omise.co）にお問い合わせください。"
 
 #: includes/gateway/class-omise-payment.php:359
-msgid "Opn: Sync failed (manual sync).<br/>%s (manual sync)."
-msgstr "Opn: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
+msgid "Opn Payments: Sync failed (manual sync).<br/>%s (manual sync)."
+msgstr "Opn Payments: 同期に失敗しました（マニュアル同期）。<br/>%s (マニュアル同期)。"
 
 #: omise-woocommerce.php:111
-msgid "Opn: Capture this order"
-msgstr "Opn: 注文のキャプチャ"
+msgid "Opn Payments: Capture this order"
+msgstr "Opn Payments: 注文のキャプチャ"
 
 #: omise-woocommerce.php:114
-msgid "Opn: Manual sync payment status"
-msgstr "Opn: マニュアル同期での決済状況"
+msgid "Opn Payments: Manual sync payment status"
+msgstr "Opn Payments: マニュアル同期での決済状況"
 
 #: templates/payment/form-creditcard.php:2
 msgid "Card number"
@@ -386,20 +386,20 @@ msgid "Remember this card"
 msgstr "カード情報を保存する"
 
 #: Plugin Name of the plugin/theme
-msgid "Opn Payment Gateway"
-msgstr "Opn 決済ゲートウェイ"
+msgid "Opn Payments Payment Gateway"
+msgstr "Opn Payments 決済ゲートウェイ"
 
 #: Plugin URI of the plugin/theme
 msgid "https://www.omise.co/woocommerce"
 msgstr "https://www.omise.co/ja/woocommerce-plugin/japan"
 
 #: Description of the plugin/theme
-msgid "Opn WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payment Gateway payment method to WooCommerce."
-msgstr " Opn WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOpn 決済ゲートウェイのサポートをWooCommerceに追加します。"
+msgid "Opn Payments WooCommerce Gateway Plugin is a wordpress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payments Payment Gateway payment method to WooCommerce."
+msgstr " Opn Payments WooCommerce ゲートウェイプラグインは、WooCommerce用に特化し設計されたWordPressのプラグインです。このプラグインはOpn Payments 決済ゲートウェイのサポートをWooCommerceに追加します。"
 
 #: Author of the plugin/theme
-msgid "Opn"
-msgstr "Opn "
+msgid "Opn Payments"
+msgstr "Opn Payments "
 
 #: Author URI of the plugin/theme
 msgid "https://www.omise.co"

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Omise Payment Gateway
  * Plugin URI:  https://www.omise.co/woocommerce
- * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin 
+ * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin
  * designed specifically for WooCommerce. The plugin adds support for 
  * Omise Payment Gateway payment method to WooCommerce.
  * Version:     4.26.0
@@ -54,7 +54,7 @@ class Omise
 
 	/**
 	 * Check if all dependencies are loaded
-	 * properly before Omise-WooCommerce.
+	 * properly before Omise WooCommerce.
 	 *
 	 * @since  3.2
 	 */
@@ -99,7 +99,7 @@ class Omise
 	{
 ?>
 		<div class="error">
-			<p><?php echo __('Omise WooCommerce plugin requires <strong>WooCommerce</strong> to be activated.', 'omise'); ?></p>
+			<p><?php echo __('Opn WooCommerce plugin requires <strong>WooCommerce</strong> to be activated.', 'omise'); ?></p>
 		</div>
 <?php
 	}
@@ -265,10 +265,10 @@ class Omise
 			'omise_charge_items',
 			array(
 				'supports' => array('title', 'custom-fields'),
-				'label'    => 'Omise Charge Items',
+				'label'    => 'Opn Charge Items',
 				'labels'   => array(
-					'name'          => 'Omise Charge Items',
-					'singular_name' => 'Omise Charge Item'
+					'name'          => 'Opn Charge Items',
+					'singular_name' => 'Opn Charge Item'
 				)
 			)
 		);

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -1,13 +1,11 @@
 <?php
 
 /**
- * Plugin Name: Omise Payment Gateway
+ * Plugin Name: Opn Payments
  * Plugin URI:  https://www.omise.co/woocommerce
- * Description: Omise WooCommerce Gateway Plugin is a WordPress plugin
- * designed specifically for WooCommerce. The plugin adds support for 
- * Omise Payment Gateway payment method to WooCommerce.
+ * Description: Opn Payments is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payments Payment Gateway's payment methods to WooCommerce.
  * Version:     4.26.0
- * Author:      Omise and contributors
+ * Author:      Opn Payments and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
  * WC requires at least: 3.3.4

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -99,7 +99,7 @@ class Omise
 	{
 ?>
 		<div class="error">
-			<p><?php echo __('Opn WooCommerce plugin requires <strong>WooCommerce</strong> to be activated.', 'omise'); ?></p>
+			<p><?php echo __('Opn Payments WooCommerce plugin requires <strong>WooCommerce</strong> to be activated.', 'omise'); ?></p>
 		</div>
 <?php
 	}
@@ -265,10 +265,10 @@ class Omise
 			'omise_charge_items',
 			array(
 				'supports' => array('title', 'custom-fields'),
-				'label'    => 'Opn Charge Items',
+				'label'    => 'Opn Payments Charge Items',
 				'labels'   => array(
-					'name'          => 'Opn Charge Items',
-					'singular_name' => 'Opn Charge Item'
+					'name'          => 'Opn Payments Charge Items',
+					'singular_name' => 'Opn Payments Charge Item'
 				)
 			)
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -1,35 +1,36 @@
-=== Omise WooCommerce ===
+=== Opn Payments ===
 Contributors: Omise
-Tags: omise, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
+Tags: omise, opn, opn payments, payment, payment gateway, woocommerce plugin, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 6.0.2
 Stable tag: 4.26.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
-Omise plugin is is the official payment extension which provides support for Omise payment gateway for store builders working on the WooCommerce platform
+Opn Payments plugin is the official payment extension which provides support for Opn Payments payment gateway for store builders working on the WooCommerce platform
 
 == Description ==
 
-Omise WooCommerce Gateway Plugin is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Omise Payment Gateway payment method to WooCommerce.
+Opn Payments is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payments Payment Gateway's payment methods to WooCommerce.
 
 == Installation ==
 
 After getting the source code, either downloading as a zip or git clone, put it in WordPress plugins folder (i.e. mv omise /wp-content/plugins/ or upload a zip via WordPress admin Plugins section, just like the other WordPress plugins).
 
-Then, Omise Gateway WordPress plugin should be appeared in WordPress admin page, under the Plugins menu.
+Then, Opn Payments WordPress plugin should be appeared in WordPress admin page, under the Plugins menu.
 From there:
 1. Activate the plugin
 2. Go to WooCommerce -> Settings
-3. Select the Checkout tab on top.
-4. Select Omise payment gateway at the bottom of the page, under Payment Gateways.
-5. Optionally, if you\'d like to have Omise Payment gateway as a default payment gateway, you can check Default.
-6. Click the Settings button and adjust the options.
+3. Select the Payments tab on top.
+4. Enable the payment methods that starts with Opn Payments.
+5. Click on Set up to if you like to add description.
+6. Optionally, if you\'d like to have Opn Payments as a default payment gateway, you can check Default.
+7. Click the Settings button and adjust the options.
 
 == Screenshots ==
-1. Omise Payment Gateway Dashboard
-2. Omise Payment Gateway Setting Page
-3. Omise Payment Gateway Checkout Form
+1. Opn Payments Dashboard
+2. Opn Payments Setting Page
+3. Opn Payments Checkout Form
 
 == Changelog ==
 


### PR DESCRIPTION
#### 1. Objective

Rebrand the text visible to merchants and users from Omise to Opn Payments.

Jira Ticket: [#592](https://opn-ooo.atlassian.net/browse/ENGA3-592)

**Note:**
- Not changing the name of the plugin as it might result in merchants not getting the `new version available` update alert as Wordpress won’t find the plugin in their directory.
  - https://wordpress.stackexchange.com/questions/23460/what-triggers-a-plugin-update-alert

#### 2. Description of change

Updated the name Omise to Opn Payments on following things:
- Menu
- Page title
- Payment method names
- Translation files
- Text used in `_e()` and `__()` to translate the text.

#### 3. Quality assurance

- Check the menu and the setting pages
- Check payment method names
- Checkout with a product and process a failed payment to see the change in errors

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 4.26.0