### PR TITLE
[ENGA3-644] : Update to Dahboard v2 URL

### DIFF
--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -24,14 +24,12 @@
 		<?php
 		echo sprintf(
 			wp_kses(
-				__( 'All of your keys can be found at your Opn Payments dashboard, check the following links.<br/><a href="%s">Test keys</a> or <a href="%s">Live keys</a> (login required)', 'omise' ),
+				__( 'All of your keys can be found at your Opn Payments dashboard, check <a target="_blank" href="%s">here link</a> for the keys. (login required)', 'omise' ),
 				array(
-					'br' => array(),
-					'a'  => array( 'href' => array() )
+					'a'  => array( 'href' => array(), 'target' => array() )
 				)
 			),
-			esc_url( 'https://dashboard.omise.co/test/keys' ),
-			esc_url( 'https://dashboard.omise.co/live/keys' )
+			esc_url( 'https://dashboard.omise.co/v2/settings/keys' ),
 		);
 		?>
 	</p>
@@ -124,7 +122,7 @@
 										)
 									),
 									esc_url( 'https://www.omise.co/api-webhooks' ),
-									esc_url( 'https://dashboard.omise.co/test/webhooks/edit' )
+									esc_url( 'https://dashboard.omise.co/v2/settings/webhooks' )
 								);
 								?>
 						</fieldset>


### PR DESCRIPTION
#### 1. Objective

Update to Dahboard v2 URL

Since we moved to dashboard v2, the link for keys and webhook are broken 

[ENGA3-644](https://opn-ooo.atlassian.net/browse/ENGA3-644)

#### 2. Description of change

- update dashboard v2 url

#### 3. Quality assurance

Got To setting page and click on the link for keys and webhook..
It should open to a respective pages.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A