### PR TITLE
[ENGA3-732] : Rebrand Lotus's Bill Payment

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -64,7 +64,7 @@ fieldset.card-exists {
 }
 
 /**
- * Omise Bill Payment Tesco
+ * Omise Bill Payment Lotus
  * CSS for the 'Thank You' (order-received) page.
  */
 .omise-konbini-details,

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -230,7 +230,14 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 
 			// Set HTML attributes based on <rect> node's attributes.
 			$div_rect = $xhtml->createElement( 'div' );
-			$div_rect->setAttribute( 'style', "float: left; position: relative; height: 50px; border-left: $width solid #000000; width: 0; margin-left: $margin" );
+			$div_rect->setAttribute('style', sprintf(
+				'float: left; position: relative;
+				height: 50px;
+				border-left:  %spx solid #000000;
+				width: 0; margin-left: %s',
+				$width,
+				$margin
+			));
 			$div_wrapper->appendChild( $div_rect );
 
 			$prevX     = $attributes['x'];

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -10,9 +10,9 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_billpayment_tesco';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn Payments Bill Payment: Tesco', 'omise' );
+		$this->method_title       = __( 'Opn Payments Bill Payment: Lotus\'s', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>Tesco Bill Payment</strong> via Opn Payments payment gateway.', 'omise' ),
+			__( 'Accept payments through <strong>Lotus\'s Bill Payment</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -40,7 +40,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments Tesco Bill Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments Lotus\'s Bill Payment', 'omise' ),
 				'default' => 'no'
 			),
 
@@ -48,7 +48,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 				'title'       => __( 'Title', 'omise' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
-				'default'     => __( 'Bill Payment: Tesco', 'omise' ),
+				'default'     => __( 'Lotus\'s Bill Payment', 'omise' ),
 			),
 
 			'description' => array(
@@ -124,7 +124,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 				<?php
 				echo sprintf(
 					wp_kses(
-						__( 'Please bring this barcode to pay at Tesco Lotus by:<br/><strong>%1$s %2$s</strong>.', 'omise' ),
+						__( 'Please bring this barcode to pay at Lotus\'s by:<br/><strong>%1$s %2$s</strong>.', 'omise' ),
 						array( 'br' => array(), 'strong' => array() )
 					),
 					wc_format_datetime( $expires_datetime, wc_date_format() ),
@@ -153,7 +153,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 					echo wp_kses(
 						__(
 							'
-							Tesco Lotus may charge a small fee for the transaction.<br/>
+							Lotus\'s Bill Payment may charge a small fee for the transaction.<br/>
 							If you fail to make payment by the stated time, your order will be automatically canceled.
 							', 'omise'
 						),
@@ -188,7 +188,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 	}
 
 	/**
-	 * Convert a given SVG Bill Payment Tesco's barcode to HTML format.
+	 * Convert a given SVG Bill Payment Lotus's barcode to HTML format.
 	 *
 	 * Note that the SVG barcode contains with the following structure:
 	 *
@@ -210,7 +210,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 	 *
 	 * @param  string $barcode_svg
 	 *
-	 * @return string  of a generated Bill Payment Tesco's barcode in HTML format.
+	 * @return string  of a generated Bill Payment Lotus's barcode in HTML format.
 	 */
 	public function barcode_svg_to_html( $barcode_svg ) {
 		$xml       = new SimpleXMLElement( $barcode_svg );

--- a/includes/gateway/class-omise-payment-billpayment-tesco.php
+++ b/includes/gateway/class-omise-payment-billpayment-tesco.php
@@ -10,7 +10,7 @@ class Omise_Payment_Billpayment_Tesco extends Omise_Payment_Offline {
 
 		$this->id                 = 'omise_billpayment_tesco';
 		$this->has_fields         = false;
-		$this->method_title       = __( 'Opn Payments Bill Payment: Lotus\'s', 'omise' );
+		$this->method_title       = __( 'Opn Payments Lotus\'s Bill Payment', 'omise' );
 		$this->method_description = wp_kses(
 			__( 'Accept payments through <strong>Lotus\'s Bill Payment</strong> via Opn Payments payment gateway.', 'omise' ),
 			array( 'strong' => array() )


### PR DESCRIPTION
#### 1. Objective

Rebrand from Tesco to Lotus's Bill Payment

[ENGA3-732](https://opn-ooo.atlassian.net/browse/ENGA3-732)
[Rebranding Guideline](https://opn-ooo.atlassian.net/wiki/spaces/FRON/pages/742260915/Lotus+s+Rebranding)

#### 2. Description of change

change from `bill payment tesco` text to `lotus's bill payment`

<img width="483" alt="Screen Shot 2022-12-20 at 4 20 05 PM" src="https://user-images.githubusercontent.com/108650842/208630528-b1f12dd7-e5ee-410b-8be1-bf76438b74cc.png">
<img width="483" alt="Screen Shot 2022-12-20 at 4 14 57 PM" src="https://user-images.githubusercontent.com/108650842/208629448-239d6601-ea26-4962-8eb6-c98f9500107c.png">
<img width="483" alt="Screen Shot 2022-12-20 at 4 14 30 PM" src="https://user-images.githubusercontent.com/108650842/208629453-fdaf89bc-20c0-4347-b2d2-8ebc63f3c434.png">
<img width="483" alt="Screen Shot 2022-12-20 at 4 13 29 PM" src="https://user-images.githubusercontent.com/108650842/208629461-a36ae539-0a5a-435c-bd7c-57f495b56818.png">


#### 3. Quality assurance

Enable lotus's bill payment and make payment

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A