### PR TITLE
[ENGA3-785]: Fix the method to get currency to the correct method.

### DIFF
--- a/includes/gateway/class-omise-payment-alipay.php
+++ b/includes/gateway/class-omise-payment-alipay.php
@@ -57,7 +57,7 @@ class Omise_Payment_Alipay extends Omise_Payment_Offsite {
 	 */
 	public function charge($order_id, $order)
 	{
-		$currency = $order->getCurrency();
+		$currency = $order->get_currency();
 		return OmiseCharge::create([
 			'amount'      => Omise_Money::to_subunit($order->get_total(), $currency),
 			'currency'    => $currency,


### PR DESCRIPTION
#### 1. Objective

Fix the wrong implementation of the method to fetch the currency.

Jira Ticket: [#785](https://opn-ooo.atlassian.net/browse/ENGA3-785)

#### 2. Description of change

Changed the `getCurrency` method to `get_curreny` method.

#### 3. Quality assurance

- Connect with Thailand PSP
- Enable Alipay on your Opn account.
- Place an order with Alipay.

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 4.27.0