### PR TITLE
[ENGA3-835]: Removed the comma at the end of the line 33 as it is throwing error on PHP 7.2 and below.

### DIFF
--- a/includes/admin/views/omise-page-settings.php
+++ b/includes/admin/views/omise-page-settings.php
@@ -29,7 +29,7 @@
 					'a'  => array( 'href' => array(), 'target' => array() )
 				)
 			),
-			esc_url( 'https://dashboard.omise.co/v2/settings/keys' ),
+			esc_url( 'https://dashboard.omise.co/v2/settings/keys' )
 		);
 		?>
 	</p>


### PR DESCRIPTION
#### 1. Objective

Removed the comma at the end of the line 33 as it is throwing error on PHP 7.2 and below.

Jira Ticket: [#835](https://opn-ooo.atlassian.net/browse/ENGA3-835)

#### 2. Description of change

Removed the comma at the end of second argument of `sprintf` because we don't have a third parameter.

#### 3. Quality assurance

Switch PHP version to 7.2 or below in docker and run the docker. Once container is up, go to the setting page. You should now see any error.

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 7.2
- Omise WooCommerce: 4.27.0