### PR TITLE
[ENGA3-857]: Fix `Uncaught Error: Call to a member function getShopeeBackend() on null`

### DIFF
--- a/includes/gateway/class-omise-payment-shopeepay.php
+++ b/includes/gateway/class-omise-payment-shopeepay.php
@@ -83,6 +83,11 @@ class Omise_Payment_ShopeePay extends Omise_Payment_Offsite
 	private function getSource()
 	{
 		$capabilities = Omise_Capabilities::retrieve();
+
+		if (!$capabilities) {
+			return self::ID;
+		}
+
 		$isShopeepayJumpAppEnabled = $capabilities->getShopeeBackend(self::JUMPAPP_ID);
 		$isShopeepayEnabled = $capabilities->getShopeeBackend(self::ID);
 


### PR DESCRIPTION
#### 1. Objective

Fix `Uncaught Error: Call to a member function getShopeeBackend() on null` issue.

Jira Ticket: [#857](https://opn-ooo.atlassian.net/browse/ENGA3-857)

#### 2. Description of change

In `getSource` method of `Omise_Payment_ShopeePay` class, we added a check whether capabilities is `null` or not. If it's null then return `shopeepay` source type as default.

#### 3. Quality assurance

Remove the keys.