### PR TITLE
Update class-omise-payment-konbini.php

### DIFF
--- a/includes/gateway/class-omise-payment-konbini.php
+++ b/includes/gateway/class-omise-payment-konbini.php
@@ -141,7 +141,7 @@ class Omise_Payment_Konbini extends Omise_Payment_Offline {
 	 * @see   woocommerce/templates/emails/plain/email-order-details.php
 	 */
 	public function email_link( $order ) {
-		if ( $this->id == $order->get_payment_method() ) {
+		if ( $this->id == $order->get_payment_method() && !$order->get_date_paid() ) {
 			$this->display_link( $order, 'email' );
 		}
 	}


### PR DESCRIPTION
Add payment link to konbini emails only if order is not paid yet

#### 1. Objective

Konbini Payment link is added in every email notification, this is confusing, both for admins that do not know what they are clicking and for customers that receive notification after successful payment.

This section will be used in the release notes. 

#### 2. Description of change

check if the order is still unpaid before adding the Konbini payment link in the email with the woocommerce_email_after_order_table action

