### PR TITLE
[ENGA3-929]:  Added Atome as payment method

### DIFF
--- a/assets/javascripts/omise-payment-atome.js
+++ b/assets/javascripts/omise-payment-atome.js
@@ -1,0 +1,50 @@
+(function ($) {
+	const $form = $('form.checkout, form#order_review');
+
+	function hideError() {
+		$(".woocommerce-error").remove();
+	}
+
+	function showError(message) {
+		if (!message) {
+			return;
+		}
+
+		let $ulError = $("<ul>").addClass("woocommerce-error");
+        $ulError.html("<li>" + message + "</li>");
+        $form.prepend($ulError);
+		$("html, body").animate({ scrollTop:0 },"slow");
+	}
+
+	function omiseFormHandler() {
+        hideError();
+		if ($('#payment_method_omise_atome').is(':checked')) {
+            if ($("#omise_atome_phone_default").is(":checked")) {
+                return true;
+            }
+			
+            if (!$('#omise_phone_number').val()) {
+                $form.block({
+                    message: null,
+                    overlayCSS: {
+                        background: '#fff url(' + wc_checkout_params.ajax_loader_url + ') no-repeat center',
+                        backgroundSize: '16px 16px',
+                        opacity: 0.6
+                    }
+                });
+                showError('Phone number is required in Atome');
+                $form.unblock();
+                return false;
+            }
+
+            $form.unblock();
+            $form.submit();
+		}
+	}
+
+	$(function () {
+		$('form.checkout').on('checkout_place_order', function (e) {
+			return omiseFormHandler();
+		});
+	})
+})(jQuery)

--- a/includes/class-omise-payment-factory.php
+++ b/includes/class-omise-payment-factory.php
@@ -38,7 +38,8 @@ class Omise_Payment_Factory {
 		'Omise_Payment_ShopeePay',
 		'Omise_Payment_Maybank_QR',
 		'Omise_Payment_DuitNow_QR',
-		'Omise_Payment_DuitNow_OBW'
+		'Omise_Payment_DuitNow_OBW',
+		'Omise_Payment_Atome'
 	);
 
 	/**

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -18,14 +18,14 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             [ 'strong' => [] ]
 		);
 
-		$this->supports           = array( 'products', 'refunds' );
+		$this->supports           = ['products', 'refunds'];
 
 		$this->init_form_fields();
 		$this->init_settings();
 
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );
-		$this->restricted_countries = array( 'TH' );
+		$this->restricted_countries = ['TH', 'SG', 'MY'];
 		$this->source_type          = 'atome';
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -182,12 +182,13 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             // Check if product has variation.
             $productId = $product_variation_id ? $item['variation_id'] : $item['product_id'];
             $product = new WC_Product($productId);
+            $sku = $product->get_sku();
 
             $products[$key] = [
                 'quantity' => $item['qty'],
                 'name' => $item['name'],
                 'amount' => Omise_Money::to_subunit($item['total'], $currency),
-                'sku' => $product->get_sku()
+                'sku' => empty($sku) ? $productId : $sku // if sku is not present then pass productId
             ];
         }
 

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -1,0 +1,189 @@
+<?php
+defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
+
+/**
+ * @since 3.9
+ */
+class Omise_Payment_Atome extends Omise_Payment_Offsite
+{
+	public function __construct()
+	{
+		parent::__construct();
+
+		$this->id                 = 'omise_atome';
+		$this->has_fields         = true;
+		$this->method_title       = __( 'Opn Payments Atome', 'omise' );
+		$this->method_description = wp_kses(
+			__( 'Accept payments through <strong>Atome</strong> via Opn Payments payment gateway.', 'omise' ),
+            [ 'strong' => [] ]
+		);
+
+		$this->supports           = array( 'products', 'refunds' );
+
+		$this->init_form_fields();
+		$this->init_settings();
+
+		$this->title                = $this->get_option( 'title' );
+		$this->description          = $this->get_option( 'description' );
+		$this->restricted_countries = array( 'TH' );
+		$this->source_type          = 'atome';
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action( 'woocommerce_api_' . $this->id . '_callback', 'Omise_Callback::execute' );
+		add_action( 'woocommerce_order_action_' . $this->id . '_sync_payment', array( $this, 'sync_payment' ) );
+	}
+
+	/**
+	 * @see WC_Settings_API::init_form_fields()
+	 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
+	 */
+	public function init_form_fields()
+	{
+		$this->form_fields = array(
+			'enabled' => array(
+				'title'   => __( 'Enable/Disable', 'omise' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Enable Opn Payments Atome Payment', 'omise' ),
+				'default' => 'no'
+			),
+
+			'title' => array(
+				'title'       => __( 'Title', 'omise' ),
+				'type'        => 'text',
+				'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
+				'default'     => __( 'Atome', 'omise' ),
+			),
+
+			'description' => array(
+				'title'       => __( 'Description', 'omise' ),
+				'type'        => 'textarea',
+				'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
+			),
+		);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function payment_fields()
+	{
+		parent::payment_fields();
+        $viewData = $this->validateMinRequiredAmount();
+
+		Omise_Util::render_view('templates/payment/form-atome.php', $viewData);
+	}
+
+    private function validateMinRequiredAmount()
+    {
+        $limits = [
+            'thb' => [
+                'min' => 20,
+                'max' => 150000,
+            ],
+            'sgd' => [
+                'min' => 1.5,
+                'max' => 20000,
+            ],
+            'myr' => [
+                'min' => 10,
+                'max' => 100000,
+            ]
+        ];
+
+        $currency = strtolower(get_woocommerce_currency());
+        $cartTotal = (WC()->cart->total);
+
+        if (!isset($limits[$currency])) {
+            return [
+                'status' => false,
+                'message' => 'Currency not supported'
+            ];
+        }
+
+        $limit = $limits[$currency];
+
+        if ($cartTotal < $limit['min']) {
+            return [
+                'status' => false,
+                'message' => sprintf(
+                    "Amount must be greater than %u %s",
+                    number_format($limit['min'], 2),
+                    strtoupper($currency)
+                )
+            ];
+        }
+
+        if ($cartTotal > $limit['max']) {
+            return [
+                'status' => false,
+                'message' => __(
+                    'Amount must be less than %1 %2',
+                    number_format($limit['max'], 2),
+                    $currency
+                )
+            ];
+        }
+
+        return ['status' => true];
+    }
+
+	/**
+	 * @inheritdoc
+	 */
+	public function charge($order_id, $order)
+	{
+		$phone_number = isset($_POST['omise_atome_phone_default'] ) && 1 == $_POST['omise_atome_phone_default'] ? $order->get_billing_phone() : sanitize_text_field( $_POST['omise_phone_number'] );
+		$currency = $order->get_currency();
+
+		return OmiseCharge::create([
+			'amount' => Omise_Money::to_subunit($order->get_total(), $currency),
+			'currency' => $currency,
+			'description' => apply_filters('omise_charge_params_description', 'WooCommerce Order id ' . $order_id, $order),
+			'source' => [
+                'type' => $this->source_type,
+                'phone_number' => $phone_number,
+                'shipping' => $this->getAddress($order),
+                'items' => $this->getItems($order, $currency)
+            ],
+			'return_uri' => $this->getRedirectUrl('omise_atome_callback', $order_id, $order),
+			'metadata' => $this->getMetadata($order_id, $order)
+		]);
+	}
+
+    private function getAddress($order)
+    {
+        $address = $order->get_address('billing');
+
+        return [
+            'country' => $address['country'],
+            'city' => $address['city'],
+            'postal_code' => $address['postcode'],
+            'state' => $address['state'],
+            'street1' => $address['address_1']
+        ];
+    }
+
+    private function getItems($order, $currency)
+    {
+        $items = $order->get_items();
+        $products = [];
+
+        // Loop through ordered items
+        foreach ($items as $key => $item) {
+            $product_variation_id = $item['variation_id'];
+        
+            // Check if product has variation.
+            $productId = $product_variation_id ? $item['variation_id'] : $item['product_id'];
+            $product = new WC_Product($productId);
+
+            $products[$key] = [
+                'quantity' => $item['qty'],
+                'name' => $item['name'],
+                'amount' => Omise_Money::to_subunit($item['total'], $currency),
+                'sku' => $product->get_sku()
+            ];
+        }
+
+        return $products;
+    }
+}

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -28,6 +28,8 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
         $this->restricted_countries = ['TH', 'SG', 'MY'];
         $this->source_type          = 'atome';
 
+        $this->register_omise_atome_scripts();
+
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
         add_action('woocommerce_api_' . $this->id . '_callback', 'Omise_Callback::execute');
         add_action('woocommerce_order_action_' . $this->id . '_sync_payment', array($this, 'sync_payment'));
@@ -61,6 +63,16 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             ),
         );
     }
+
+    private function register_omise_atome_scripts() {
+		wp_enqueue_script(
+			'omise-atome-js',
+			plugins_url( '../assets/javascripts/omise-payment-atome.js', dirname( __FILE__ ) ),
+			array( 'jquery' ),
+			WC_VERSION,
+			true
+		);
+	}
 
     /**
      * @inheritdoc

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -91,7 +91,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
         ];
 
         $currency = strtolower(get_woocommerce_currency());
-        $cartTotal = (WC()->cart->total);
+        $cartTotal = WC()->cart->total;
 
         if (!isset($limits[$currency])) {
             return [

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -119,7 +119,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
                 'message' => __(
                     'Amount must be less than %1 %2',
                     number_format($limit['max'], 2),
-                    $currency
+                    strtoupper($currency)
                 )
             ];
         }

--- a/includes/gateway/class-omise-payment-duitnow-obw.php
+++ b/includes/gateway/class-omise-payment-duitnow-obw.php
@@ -62,8 +62,6 @@ class Omise_Payment_DuitNow_OBW extends Omise_Payment_Offsite
 	public function payment_fields()
 	{
 		parent::payment_fields();
-		$currency   = get_woocommerce_currency();
-		$cart_total = WC()->cart->total;
 
 		Omise_Util::render_view(
 			'templates/payment/form-duitnow-obw.php',

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -200,6 +200,7 @@ class Omise
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-shopeepay.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-touch-n-go.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment.php';
+		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/gateway/class-omise-payment-atome.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-php/lib/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/libraries/omise-plugin/Omise.php';
 		require_once OMISE_WOOCOMMERCE_PLUGIN_PATH . '/includes/class-omise-ajax-actions.php';

--- a/templates/payment/form-atome.php
+++ b/templates/payment/form-atome.php
@@ -1,0 +1,27 @@
+<?php if($viewData['status']) : ?>
+    <fieldset id="omise-form-atome">
+        <?php _e( 'Atome phone number', 'omise' ); ?><br/>
+
+        <p class="form-row form-row-wide omise-label-inline">
+            <input id="omise_atome_phone_default" type="checkbox" name="omise_atome_phone_default" value="1" checked="checked" />
+            <label for="omise_atome_phone_default"><?php _e( 'Same as Billing Detail', 'omise' ); ?></label>
+        </p>
+
+        <p id="omise_atome_phone_field" class="form-row form-row-wide" style="display: none;">
+            <span class="woocommerce-input-wrapper">
+                <input id="omise_phone_number" class="input-text" name="omise_phone_number" type="tel" autocomplete="off">
+            </span>
+        </p>
+    </fieldset>
+
+    <script type="text/javascript">
+        var phone_number_field   = document.getElementById( 'omise_atome_phone_field' );
+        var phone_number_default = document.getElementById( 'omise_atome_phone_default' );
+
+        phone_number_default.addEventListener( 'change', ( e ) => {
+            phone_number_field.style.display = e.target.checked ? "none" : "block";
+        } );
+    </script>
+<?php else: ?>
+    <?php echo $viewData['message']; ?>
+<?php endif; ?>


### PR DESCRIPTION
#### 1. Objective

Add Atome as payment method

Jira Ticket: [#929](https://opn-ooo.atlassian.net/browse/ENGA3-929)

#### 2. Description of change

Added gateway and form file for Atome.

**WooCommerce Admin**

<img width="1255" alt="Screenshot 2566-04-04 at 12 07 05" src="https://user-images.githubusercontent.com/101558497/229692272-5a04721b-ce14-4461-bc97-b9f32a6ecd39.png">

**Checkout page using phone number from billing**

<img width="1079" alt="Screenshot 2566-04-04 at 12 07 41" src="https://user-images.githubusercontent.com/101558497/229692292-3b88959c-4d2e-41a9-9b20-79f5aa717f5d.png">

**Checkout page using new phone number**

<img width="1070" alt="Screenshot 2566-04-04 at 12 07 49" src="https://user-images.githubusercontent.com/101558497/229692310-6c3d545a-914f-44ab-bd43-18d9b2444e86.png">

**Charge created in Opn dashboard**

<img width="1036" alt="Screenshot 2566-04-04 at 12 08 40" src="https://user-images.githubusercontent.com/101558497/229692375-fc2f3111-1f0d-477b-a95a-8673430c5871.png">


#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 5.0.0