### PR TITLE
Added a frontend validation to accept only number between 10-13 and a…

### DIFF
--- a/assets/javascripts/omise-payment-atome.js
+++ b/assets/javascripts/omise-payment-atome.js
@@ -16,7 +16,7 @@
 		$("html, body").animate({ scrollTop:0 },"slow");
 	}
 
-    function omiseHanldeError(message) {
+    function omiseHandleError(message) {
         $form.block({
             message: null,
             overlayCSS: {
@@ -40,13 +40,13 @@
             const phoneNumber = $('#omise_atome_phone_number').val();
 			
             if (!phoneNumber) {
-                return omiseHanldeError('Phone number is required in Atome');
+                return omiseHandleError('Phone number is required in Atome');
             }
 
             const phonePattern = /(\+)?([0-9]{10,13})/;
 
             if (!phonePattern.test(phoneNumber)) {
-                return omiseHanldeError('Phone number should be a number in Atome');
+                return omiseHandleError('Phone number should be a number in Atome');
             }
 
             $form.unblock();

--- a/assets/javascripts/omise-payment-atome.js
+++ b/assets/javascripts/omise-payment-atome.js
@@ -16,25 +16,37 @@
 		$("html, body").animate({ scrollTop:0 },"slow");
 	}
 
+    function omiseHanldeError(message) {
+        $form.block({
+            message: null,
+            overlayCSS: {
+                background: '#fff url(' + wc_checkout_params.ajax_loader_url + ') no-repeat center',
+                backgroundSize: '16px 16px',
+                opacity: 0.6
+            }
+        });
+        showError(message);
+        $form.unblock();
+        return false;
+    }
+
 	function omiseFormHandler() {
         hideError();
 		if ($('#payment_method_omise_atome').is(':checked')) {
             if ($("#omise_atome_phone_default").is(":checked")) {
                 return true;
             }
+
+            const phoneNumber = $('#omise_atome_phone_number').val();
 			
-            if (!$('#omise_phone_number').val()) {
-                $form.block({
-                    message: null,
-                    overlayCSS: {
-                        background: '#fff url(' + wc_checkout_params.ajax_loader_url + ') no-repeat center',
-                        backgroundSize: '16px 16px',
-                        opacity: 0.6
-                    }
-                });
-                showError('Phone number is required in Atome');
-                $form.unblock();
-                return false;
+            if (!phoneNumber) {
+                return omiseHanldeError('Phone number is required in Atome');
+            }
+
+            const phonePattern = /(\+)?([0-9]{10,13})/;
+
+            if (!phonePattern.test(phoneNumber)) {
+                return omiseHanldeError('Phone number should be a number in Atome');
             }
 
             $form.unblock();

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -145,10 +145,12 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
     public function charge($order_id, $order)
     {
         $currency = $order->get_currency();
-        $default_phone_selected = $_POST['omise_atome_phone_default'];
-        $phone_number = isset($default_phone_selected) && 1 == $default_phone_selected ?
+        $default_phone_selected = isset($_POST['omise_atome_phone_default']) ?
+            $_POST['omise_atome_phone_default']
+            : false;
+        $phone_number = true === (bool)$default_phone_selected ?
             $order->get_billing_phone()
-            : sanitize_text_field($_POST['omise_phone_number']);
+            : sanitize_text_field($_POST['omise_atome_phone_number']);
 
         return OmiseCharge::create([
             'amount' => Omise_Money::to_subunit($order->get_total(), $currency),

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -148,7 +148,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
         $default_phone_selected = isset($_POST['omise_atome_phone_default']) ?
             $_POST['omise_atome_phone_default']
             : false;
-        $phone_number = true === (bool)$default_phone_selected ?
+        $phone_number = (bool)$default_phone_selected ?
             $order->get_billing_phone()
             : sanitize_text_field($_POST['omise_atome_phone_number']);
 

--- a/templates/payment/form-atome.php
+++ b/templates/payment/form-atome.php
@@ -9,7 +9,7 @@
 
         <p id="omise_atome_phone_field" class="form-row form-row-wide" style="display: none;">
             <span class="woocommerce-input-wrapper">
-                <input id="omise_phone_number" class="input-text" name="omise_phone_number" type="tel" autocomplete="off">
+                <input id="omise_atome_phone_number" class="input-text" name="omise_atome_phone_number" type="tel" autocomplete="off">
             </span>
         </p>
     </fieldset>

--- a/templates/payment/form-atome.php
+++ b/templates/payment/form-atome.php
@@ -9,7 +9,14 @@
 
         <p id="omise_atome_phone_field" class="form-row form-row-wide" style="display: none;">
             <span class="woocommerce-input-wrapper">
-                <input id="omise_atome_phone_number" class="input-text" name="omise_atome_phone_number" type="tel" autocomplete="off">
+                <input
+                    id="omise_atome_phone_number"
+                    class="input-text"
+                    name="omise_atome_phone_number"
+                    type="tel"
+                    autocomplete="off"
+                    placeholder="+66123456789"
+                />
             </span>
         </p>
     </fieldset>


### PR DESCRIPTION
#### 1. Objective

Added a frontend validation to accept only number between 10-13 and an optional + sign in front.

Jira Ticket: [#929](https://opn-ooo.atlassian.net/browse/ENGA3-929)

#### 2. Description of change

Add a validation in the JS and fixed a bug when checkbox `same as billing address` was not selected.

#### 3. Quality assurance

Case 1:
- Adding a string should show `Phone number should be a number in Atome`

<img width="1052" alt="Screenshot 2566-04-10 at 18 18 23" src="https://user-images.githubusercontent.com/101558497/230892757-e79dc78c-0aad-46c4-948f-7d86a01e6b95.png">

Case 2:
- Adding no phone number should show `Phone number is required in Atome`

<img width="1126" alt="Screenshot 2566-04-10 at 18 18 35" src="https://user-images.githubusercontent.com/101558497/230892920-145ad1b4-7c66-4340-ae4a-64ae660a59ac.png">

Case 3
- Adding a phone number with or without `+` should redirect to Atome page.

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 5.0.0