### PR TITLE
[ENGA3-929]: Truemoney wallet's phone number field not displaying issue fixed

### DIFF
--- a/templates/payment/form-atome.php
+++ b/templates/payment/form-atome.php
@@ -1,34 +1,29 @@
-<?php if($viewData['status']) : ?>
+<?php if ($viewData['status']) : ?>
     <fieldset id="omise-form-atome">
-        <?php _e( 'Atome phone number', 'omise' ); ?><br/>
+        <?php _e('Atome phone number', 'omise'); ?><br />
 
         <p class="form-row form-row-wide omise-label-inline">
             <input id="omise_atome_phone_default" type="checkbox" name="omise_atome_phone_default" value="1" checked="checked" />
-            <label for="omise_atome_phone_default"><?php _e( 'Same as Billing Detail', 'omise' ); ?></label>
+            <label for="omise_atome_phone_default"><?php _e('Same as Billing Detail', 'omise'); ?></label>
         </p>
 
         <p id="omise_atome_phone_field" class="form-row form-row-wide" style="display: none;">
             <span class="woocommerce-input-wrapper">
-                <input
-                    id="omise_atome_phone_number"
-                    class="input-text"
-                    name="omise_atome_phone_number"
-                    type="tel"
-                    autocomplete="off"
-                    placeholder="+66123456789"
-                />
+                <input id="omise_atome_phone_number" class="input-text" name="omise_atome_phone_number" type="tel" autocomplete="off" placeholder="+66123456789" />
             </span>
+        </p>
+
+        <p class="omise-secondary-text">
+            <?php _e('The phone number will be used for creating Atome charge', 'omise'); ?>
         </p>
     </fieldset>
 
     <script type="text/javascript">
-        var phone_number_field   = document.getElementById( 'omise_atome_phone_field' );
-        var phone_number_default = document.getElementById( 'omise_atome_phone_default' );
-
-        phone_number_default.addEventListener( 'change', ( e ) => {
-            phone_number_field.style.display = e.target.checked ? "none" : "block";
-        } );
+        document.getElementById('omise_atome_phone_default').addEventListener('change', (e) => {
+            const phone_number_field_atome = document.getElementById('omise_atome_phone_field')
+            phone_number_field_atome.style.display = e.target.checked ? "none" : "block";
+        });
     </script>
-<?php else: ?>
+<?php else : ?>
     <?php echo $viewData['message']; ?>
 <?php endif; ?>


### PR DESCRIPTION
#### 1. Objective

Fix the issue of Truemoney wallet's phone number field not being displayed when user choose option to enter a different phone number

#### 2. Description of change

Same variable name in two different script caused the previous variable to override by the next variable. We also added a message in the Atome informing users why the phone number is required.

![Screenshot 2566-04-17 at 11 10 34](https://user-images.githubusercontent.com/101558497/232378954-ec7c5ec6-9c3c-437f-b459-cb083176de0e.png)
