### PR TITLE
Bug fixed secure form not show in pay for order page

### DIFF
--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -254,8 +254,8 @@
 		}
 	}
 
-	if(Boolean(omise_params.secure_form_enabled)) {
-		$(document).on('updated_checkout', function () {
+	function initializeSecureCardForm() {
+		if (Boolean(omise_params.secure_form_enabled)) {
 			showOmiseEmbeddedCardForm({
 				element: document.getElementById('omise-card'),
 				publicKey: omise_params.key,
@@ -270,7 +270,7 @@
 					$form.unblock()
 				}
 			})
-		});
+		}
 	}
 
 	$(function () {
@@ -293,6 +293,11 @@
 			$('.omise_token').remove();
 		});
 
+		$(document).on('updated_checkout', function () {
+			initializeSecureCardForm();
+		});
+
+		initializeSecureCardForm();
 		googlePay();
 	})
 })(jQuery)


### PR DESCRIPTION
#### 1. Objective

Bug fixed secure form not show in pay for order page

#### 2. Description of change

- Secure form not show on pay for order page because `updated_checkout` event was never trigger from checkout page. So, we need to call `showOmiseEmbeddedCardForm` on page loaded. 
- We also still need to call `showOmiseEmbeddedCardForm` under `updated_checkout` event since the secure form is disappeared on normal checkout page when checkout form is updated.

<img width="734" alt="Screenshot 2023-04-26 at 12 50 08 PM" src="https://user-images.githubusercontent.com/108650842/234481369-9fe96f03-a416-4cff-a3bf-4e73385266e9.png">

#### 3. Quality assurance

- Create order from admin panel and click on `customer payment page` under order detail section.
- Select credit card and it show show secure form. (Make sure you have enabled secure form in opn payment setting.)

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes
