### PR TITLE
[ENGA3-1173]: Updated the secure form database key to the correct one.

### DIFF
--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -59,10 +59,10 @@ class Omise
 	public function embedded_form_notice()
 	{
 		$this->omiseCardGateway = new Omise_Payment_Creditcard();
-		$embedded_form_enabled = $this->omiseCardGateway->get_option('embedded_form_enabled');
+		$secure_form_enabled = $this->omiseCardGateway->get_option('secure_form_enabled');
 
 		// hide if user enables the embedded form.
-		if (!(bool)$embedded_form_enabled) {
+		if (!(bool)$secure_form_enabled) {
 			$translation = __('Update your plugin to the latest version to enable Secure Form and maximize the security of your customers’ information. You will need to re-customize the credit card checkout form after the upgrade. <a target="_blank" href="https://www.omise.co/woocommerce-plugin">Learn how to enable Secure Form</a>.', 'omise');
 			echo "<div class='notice notice-warning is-dismissible'><p><strong>Opn Payments:</strong> $translation</p></div>";
 		}


### PR DESCRIPTION
#### 1. Objective

Fix the issue of secure form notification not turning off.

Jira Ticket: (#1173)[https://opn-ooo.atlassian.net/browse/ENGA3-1173]

#### 2. Description of change

Updated the key where secure form status is saved from `embedded_form_enabled` to `secure_form_enabled`.

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 5.0.0