### PR TITLE
Bug fixed on guest user checkout

### DIFF
--- a/includes/gateway/abstract-omise-payment-base-card.php
+++ b/includes/gateway/abstract-omise-payment-base-card.php
@@ -24,11 +24,7 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 		}
 
 		$user = $order->get_user();
-		$omise_customer_id = null;
-
-		if(!empty($user)) {
-			$omise_customer_id = $this->is_test() ? $user->test_omise_customer_id : $user->live_omise_customer_id;
-		}
+		$omise_customer_id = $this->getOmiseCustomerId($user);
 
 		// Saving card.
 		$saveCustomerCard = $_POST['omise_save_customer_card'];
@@ -40,6 +36,17 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 
 		$data = $this->prepareChargeData($order_id, $order, $omise_customer_id, $card_id, $token);
 		return OmiseCharge::create($data);
+	}
+
+	/**
+	 * get omise customer id from user
+	 * @param object|null $user
+	 */
+	private function getOmiseCustomerId($user) {
+		if(empty($user)) {
+			return null;
+		}
+		return $this->is_test() ? $user->test_omise_customer_id : $user->live_omise_customer_id;
 	}
 
 	/**

--- a/includes/gateway/abstract-omise-payment-base-card.php
+++ b/includes/gateway/abstract-omise-payment-base-card.php
@@ -24,7 +24,11 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 		}
 
 		$user = $order->get_user();
-		$omise_customer_id = $this->is_test() ? $user->test_omise_customer_id : $user->live_omise_customer_id;
+		$omise_customer_id = null;
+
+		if(!empty($user)) {
+			$omise_customer_id = $this->is_test() ? $user->test_omise_customer_id : $user->live_omise_customer_id;
+		}
 
 		// Saving card.
 		$saveCustomerCard = $_POST['omise_save_customer_card'];


### PR DESCRIPTION
#### 1. Objective

Bug fixed on guest user checkout

#### 2. Description of change

When `$user = $order->get_user();` is empty, `$user->test_omise_customer_id`  or `$user->live_omise_customer_id` will throw `attempt to read property test_omise_customer_id from null`.

So we need to check user is not empty before we get value from user.

#### 3. Quality assurance

Create manual order with guest user from admin panel and use customer payment page link to make payment where user is  not logged in (eg. try with different browser).

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal
