### PR TITLE
[ENGA3-1334]: Remove free products from the Atome bill

### DIFF
--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -80,12 +80,12 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
     public function payment_fields()
     {
         parent::payment_fields();
-        $viewData = $this->validateMinRequiredAmount();
+        $viewData = $this->validateAtomeRequest();
 
         Omise_Util::render_view('templates/payment/form-atome.php', $viewData);
     }
 
-    private function validateMinRequiredAmount()
+    private function validateAtomeRequest()
     {
         $limits = [
             'thb' => [
@@ -103,7 +103,14 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
         ];
 
         $currency = strtolower(get_woocommerce_currency());
-        $cartTotal = WC()->cart->total;
+        $cart = WC()->cart;
+
+        if ($cart->subtotal === 0) {
+            return [
+                'status' => false,
+                'message' => 'Complimentary products cannot be billed.'
+            ];
+        }
 
         if (!isset($limits[$currency])) {
             return [
@@ -114,7 +121,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
 
         $limit = $limits[$currency];
 
-        if ($cartTotal < $limit['min']) {
+        if ($cart->total < $limit['min']) {
             return [
                 'status' => false,
                 'message' => sprintf(
@@ -125,7 +132,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             ];
         }
 
-        if ($cartTotal > $limit['max']) {
+        if ($cart->total > $limit['max']) {
             return [
                 'status' => false,
                 'message' => __(

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -191,14 +191,20 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
 
         // Loop through ordered items
         foreach ($items as $key => $item) {
+            // item don't have price. So we have to take subtotal and divide it by quantity to get the price
+            $pricePerItem = $item['subtotal'] / $item['qty'];
+
+            // Remove product from the list if the price is 0
+            if ((float)$pricePerItem === 0.00) {
+                continue;
+            }
+
             // Check if product has variation.
             $product = $item['variation_id'] ?
                 new WC_Product_Variation($item['variation_id'])
                 : new WC_Product($item['product_id']);
 
             $sku = $product->get_sku();
-            // item don't have price. So we have to take subtotal and divide it by quantity to get the price
-            $pricePerItem = $item['subtotal'] / $item['qty'];
 
             $products[$key] = [
                 'quantity' => $item['qty'],


### PR DESCRIPTION
#### 1. Objective

Remove free or complimentary products from the Atome bill

Jira Ticket: [#1334](https://opn-ooo.atlassian.net/browse/MIT-1334)

#### 2. Description of change

Add a logic to check the price of subtotal which is the total amount of the products combined excluding shipping cost.

<img width="1079" alt="Screenshot 2566-05-19 at 12 30 26" src="https://github.com/omise/omise-woocommerce/assets/101558497/55c911c5-bddf-4737-bfe3-0afd36c31e82">

#### 3. Quality assurance

- Add a freebie product in the cart
- Try to pay via Atome

**🔧 Environments:**

- WooCommerce: v6.7.0
- WordPress: v6.0.2
- PHP version: 8.1
- Omise WooCommerce: 5.1.0