### PR TITLE
Bug Fixed not compatible with country based payments plugin

### DIFF
--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -255,9 +255,10 @@
 	}
 
 	function initializeSecureCardForm() {
-		if (Boolean(omise_params.secure_form_enabled)) {
+		const omiseCardElement = document.getElementById('omise-card');
+		if (omiseCardElement && Boolean(omise_params.secure_form_enabled)) {
 			showOmiseEmbeddedCardForm({
-				element: document.getElementById('omise-card'),
+				element: omiseCardElement,
 				publicKey: omise_params.key,
 				hideRememberCard: HIDE_REMEMBER_CARD,
 				locale: LOCALE,


### PR DESCRIPTION
#### 1. Objective

Bug Fixed not compatible with country based payments plugin

#### 2. Description of change

Country based payments plugin remove the the whole html element of omise card payment, if user not selected the country in shipping address.

#### 3. Quality assurance

Tested locally with 
- For first time user 
- Tested with normal user
- Tested with guest user

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal