### PR TITLE
Declare HPOS as compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,10 @@
     "homepage": "https://www.omise.co/",
     "license": "MIT",
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^9.5"
+        "phpunit/phpunit": "^5.7 || ^9.5",
+        "mockery/mockery": "^1.6"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit --testdox --colors"
     }
 }

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -47,10 +47,24 @@ class Omise
 	 */
 	public function __construct()
 	{
+		add_action('before_woocommerce_init', [$this, 'enable_hpos']);
 		add_action('plugins_loaded', array($this, 'check_dependencies'));
 		add_action('woocommerce_init', array($this, 'init'));
 		do_action('omise_initiated');
 		add_action('admin_notices', [$this, 'embedded_form_notice']);
+	}
+
+	/**
+	 * enable high performance order storage(HPOS) feature
+	 */
+	public function enable_hpos() {
+		if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+				'custom_order_tables', 
+				__FILE__, 
+				true
+			);
+		}
 	}
 
 	/**

--- a/tests/unit/omise-woocommerce-test.php
+++ b/tests/unit/omise-woocommerce-test.php
@@ -36,7 +36,7 @@ class Omise_Test extends TestCase
 	}
 
 	/**
-	 * Making sure that when FeaturesUtil do not exist,
+	 * Making sure that when FeaturesUtil class do not exist,
 	 * it doesn't throw any error
 	 */
 	public function test_when_features_util_class_do_not_exist()
@@ -46,13 +46,12 @@ class Omise_Test extends TestCase
 	}
 
 	/**
-	 * Making sure that when FeaturesUti exist,
-	 * it doesn't throw any error
+	 * Making sure that when FeaturesUti class exist,
+	 * it doesn't throw any error and the 'declare_compatibility' method should be called once
 	 */
 	public function test_when_features_util_class_exist()
 	{
 		$featuresUtilMock = Mockery::mock('alias:\Automattic\WooCommerce\Utilities\FeaturesUtil');
-		// If the class exists, the 'declare_compatibility' method should be called once.
 		$featuresUtilMock->shouldReceive('declare_compatibility')->once();
 		$this->model->enable_hpos();
 		$this->assertTrue(class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class));

--- a/tests/unit/omise-woocommerce-test.php
+++ b/tests/unit/omise-woocommerce-test.php
@@ -1,0 +1,60 @@
+<?php
+
+use Omise;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class Omise_Test extends TestCase
+{
+	private Omise $model;
+
+	/**
+	 * setup add_action and do_action before the test run
+	 */
+	public function setUp(): void
+	{
+		if (!function_exists('add_action')) {
+			function add_action()
+			{
+			}
+		}
+		if (!function_exists('do_action')) {
+			function do_action()
+			{
+			}
+		}
+		require_once __DIR__ . '/../../omise-woocommerce.php';
+		$this->model = Omise::instance();
+	}
+
+	/**
+	 * close mockery after test cases are done
+	 */
+	public function tearDown(): void
+	{
+		Mockery::close();
+	}
+
+	/**
+	 * Making sure that when FeaturesUtil do not exist,
+	 * it doesn't throw any error
+	 */
+	public function test_when_features_util_class_do_not_exist()
+	{
+		$this->model->enable_hpos();
+		$this->assertFalse(class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class));
+	}
+
+	/**
+	 * Making sure that when FeaturesUti exist,
+	 * it doesn't throw any error
+	 */
+	public function test_when_features_util_class_exist()
+	{
+		$featuresUtilMock = Mockery::mock('alias:\Automattic\WooCommerce\Utilities\FeaturesUtil');
+		// If the class exists, the 'declare_compatibility' method should be called once.
+		$featuresUtilMock->shouldReceive('declare_compatibility')->once();
+		$this->model->enable_hpos();
+		$this->assertTrue(class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class));
+	}
+}


### PR DESCRIPTION
#### 1. Objective

Declare HPOS as compatible

#### 2. Description of change

[Added declaration as describe by WC documentation](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#declaring-extension-incompatibility)

#### 3. Quality assurance

N/A

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal
