### PR TITLE
Fix installment payment when admin manually pay for order

### DIFF
--- a/assets/javascripts/omise-embedded-card.js
+++ b/assets/javascripts/omise-embedded-card.js
@@ -25,11 +25,17 @@ function showOmiseEmbeddedCardForm({
   }
   element.style.height = iframeElementHeight + 'px'
 
+  const localeMatching = {
+    en_US: 'en',
+    ja_JP: 'ja',
+    th_TH: 'th'
+  }
+
   OmiseCard.configure({
     publicKey: publicKey,
     element,
     customCardForm: true,
-    locale: locale,
+    locale: localeMatching[locale] ?? 'en',
     customCardFormTheme: theme,
     customCardFormHideRememberCard: hideRememberCard ?? false,
     customCardFormBrandIcons: brandIcons ?? null,

--- a/assets/javascripts/omise-embedded-card.js
+++ b/assets/javascripts/omise-embedded-card.js
@@ -25,17 +25,11 @@ function showOmiseEmbeddedCardForm({
   }
   element.style.height = iframeElementHeight + 'px'
 
-  const localeMatching = {
-    en_US: 'en',
-    ja_JP: 'ja',
-    th_TH: 'th'
-  }
-
   OmiseCard.configure({
     publicKey: publicKey,
     element,
     customCardForm: true,
-    locale: localeMatching[locale] ?? 'en',
+    locale: locale,
     customCardFormTheme: theme,
     customCardFormHideRememberCard: hideRememberCard ?? false,
     customCardFormBrandIcons: brandIcons ?? null,

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -98,7 +98,7 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite
 		) {
 			$order_id = (int)$wp->query_vars['order-pay'];
 			$order = wc_get_order( $order_id );
-			return $order->total;
+			return $order->get_total();
 		}
 
 		// if not an order page then get total from the cart

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -71,6 +71,7 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite
 
 		$currency   = get_woocommerce_currency();
 		$cart_total = $this->getTotalAmount();
+
 		$capabilities = $this->backend->capabilities();
 		$installmentMinLimit = $capabilities->getInstallmentMinLimit();
 
@@ -89,13 +90,14 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite
 	 */
 	public function getTotalAmount()
 	{
-		// if it's order pay page for admin then get the order total
 		global $wp;
 
-		if ( isset($wp->query_vars['order-pay']) && absint($wp->query_vars['order-pay']) > 0 ) {
-			$order_id = absint($wp->query_vars['order-pay']); // The order ID
-
-			$order = wc_get_order( $order_id ); // Get the WC_Order Object instance
+		if (
+			isset($wp->query_vars['order-pay']) &&
+			(int)$wp->query_vars['order-pay'] > 0
+		) {
+			$order_id = (int)$wp->query_vars['order-pay'];
+			$order = wc_get_order( $order_id );
 			return $order->total;
 		}
 

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -70,7 +70,7 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite
 		parent::payment_fields();
 
 		$currency   = get_woocommerce_currency();
-		$cart_total = WC()->cart->total;
+		$cart_total = $this->getTotalAmount();
 		$capabilities = $this->backend->capabilities();
 		$installmentMinLimit = $capabilities->getInstallmentMinLimit();
 
@@ -82,6 +82,25 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite
 				'installment_min_limit' => number_format(Omise_Money::convert_currency_unit($installmentMinLimit, $currency))
 			)
 		);
+	}
+
+	/**
+	 * Get the total amount of an order
+	 */
+	public function getTotalAmount()
+	{
+		// if it's order pay page for admin then get the order total
+		global $wp;
+
+		if ( isset($wp->query_vars['order-pay']) && absint($wp->query_vars['order-pay']) > 0 ) {
+			$order_id = absint($wp->query_vars['order-pay']); // The order ID
+
+			$order = wc_get_order( $order_id ); // Get the WC_Order Object instance
+			return $order->total;
+		}
+
+		// if not an order page then get total from the cart
+		return WC()->cart->total;
 	}
 
 	/**

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -25,7 +25,7 @@ class Omise_Payment_Installment_Test extends TestCase
     }
 
     /**
-     * clsoe mockery after tests are done
+     * close mockery after tests are done
      */
     public function teardown(): void
     {

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -7,32 +7,12 @@ class Omise_Payment_Installment_Test extends TestCase
 {
 	public function setUp(): void
     {
+        // Mocking the parent class
         $offsite = Mockery::mock('overload:Omise_Payment_Offsite');
         $offsite->shouldReceive('init_settings');
         $offsite->shouldReceive('get_option');
 
-        if (!function_exists('wc_get_order')) {
-			function wc_get_order($orderId) {
-                $class = new stdClass();
-                $class->total = 999999;
-                return $class;
-			}
-		}
-
-		if (!function_exists('WC')) {
-			function WC() {
-                $class = new stdClass();
-                $class->cart = new stdClass();
-                $class->cart->total = 999999;
-                return $class;
-			}
-		}
-
-        if (!isset($_GLOBALS['wp'])) {
-            $wp = new stdClass();
-            $wp->query_vars = ['order-pay' => 11];
-        }
-
+        // mocking WP built-in functions
         if (!function_exists('wp_kses')) {
             function wp_kses() {}
         }
@@ -55,8 +35,43 @@ class Omise_Payment_Installment_Test extends TestCase
     /**
      * @test
      */
-    public function getTotalAmount()
+    public function getTotalAmountFromAdminOrderpage()
     {
+        // mocking built-in WooCommerce function
+        if (!function_exists('wc_get_order')) {
+			function wc_get_order() {
+                $class = new stdClass();
+                $class->total = 999999;
+                return $class;
+			}
+		}
+
+        // mocking the WP global variable $wp
+        $wp = new stdClass();
+        $wp->query_vars = ['order-pay' => 123];
+        $GLOBALS['wp'] = $wp;
+
+        $installment = new Omise_Payment_Installment();
+        $total = $installment->getTotalAmount();
+
+        $this->assertEquals($total, 999999);
+    }
+
+    /**
+     * @test
+     */
+    public function getTotalAmountFromCart()
+    {
+        // mocking WC() method
+        if (!function_exists('WC')) {
+			function WC() {
+                $class = new stdClass();
+                $class->cart = new stdClass();
+                $class->cart->total = 999999;
+                return $class;
+			}
+		}
+
         $installment = new Omise_Payment_Installment();
         $total = $installment->getTotalAmount();
 

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -39,10 +39,14 @@ class Omise_Payment_Installment_Test extends TestCase
     {
         // mocking built-in WooCommerce function
         if (!function_exists('wc_get_order')) {
-            function wc_get_order()
-            {
-                $class = new stdClass();
-                $class->total = 999999;
+            function wc_get_order() {
+                $class = new class {
+                    public $property;
+                
+                    public function get_total() { 
+                        return 999999;
+                    }
+                };
                 return $class;
             }
         }
@@ -65,8 +69,7 @@ class Omise_Payment_Installment_Test extends TestCase
     {
         // mocking WC() method
         if (!function_exists('WC')) {
-            function WC()
-            {
+            function WC() {
                 $class = new stdClass();
                 $class->cart = new stdClass();
                 $class->cart->total = 999999;

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -5,7 +5,7 @@ use Mockery;
 
 class Omise_Payment_Installment_Test extends TestCase
 {
-	public function setUp(): void
+    public function setUp(): void
     {
         // Mocking the parent class
         $offsite = Mockery::mock('overload:Omise_Payment_Offsite');
@@ -21,16 +21,16 @@ class Omise_Payment_Installment_Test extends TestCase
             function add_action() {}
         }
 
-		require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-installment.php';
-	}
+        require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-installment.php';
+    }
 
     /**
-	 * close mockery after test cases are done
-	 */
-	public function tearDown(): void
-	{
-		Mockery::close();
-	}
+     * clsoe mockery after tests are done
+     */
+    public function teardown(): void
+    {
+        Mockery::close();
+    }
 
     /**
      * @test
@@ -39,12 +39,13 @@ class Omise_Payment_Installment_Test extends TestCase
     {
         // mocking built-in WooCommerce function
         if (!function_exists('wc_get_order')) {
-			function wc_get_order() {
+            function wc_get_order()
+            {
                 $class = new stdClass();
                 $class->total = 999999;
                 return $class;
-			}
-		}
+            }
+        }
 
         // mocking the WP global variable $wp
         $wp = new stdClass();
@@ -64,13 +65,14 @@ class Omise_Payment_Installment_Test extends TestCase
     {
         // mocking WC() method
         if (!function_exists('WC')) {
-			function WC() {
+            function WC()
+            {
                 $class = new stdClass();
                 $class->cart = new stdClass();
                 $class->cart->total = 999999;
                 return $class;
-			}
-		}
+            }
+        }
 
         $installment = new Omise_Payment_Installment();
         $total = $installment->getTotalAmount();

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -1,0 +1,45 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../class-omise-unit-test.php';
+
+class Omise_Payment_Installment_Test extends TestCase
+{
+	public static function setUpBeforeClass(): void
+    {
+        if (!function_exists('wc_get_order')) {
+			function wc_get_order($orderId) {
+                $class = new stdClass();
+                $class->total = 999999;
+                return $class;
+			}
+		}
+
+		if (!function_exists('WC')) {
+			function WC() {
+                $class = new stdClass();
+                $class->cart = new stdClass();
+                $class->cart->total = 999999;
+			}
+		}
+
+        if (!isset($_GLOBALS['wp'])) {
+            $wp = new stdClass();
+            $wp->query_vars = ['order-pay' => 11];
+        }
+
+		require_once __DIR__ . '/../../../includes/gateway/class-omise-payment-installation.php';
+	}
+
+    /**
+     * @test
+     */
+    public function getTotalAmount()
+    {
+        $installment = new Omise_Payment_Installment();
+        $total = $installment->getTotalAmount();
+
+        $this->assertEquals($total, 999999);
+    }
+}

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -1,13 +1,16 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-
-require_once __DIR__ . '/../../class-omise-unit-test.php';
+use Mockery;
 
 class Omise_Payment_Installment_Test extends TestCase
 {
-	public static function setUpBeforeClass(): void
+	public function setUp(): void
     {
+        $offsite = Mockery::mock('overload:Omise_Payment_Offsite');
+        $offsite->shouldReceive('init_settings');
+        $offsite->shouldReceive('get_option');
+
         if (!function_exists('wc_get_order')) {
 			function wc_get_order($orderId) {
                 $class = new stdClass();
@@ -21,6 +24,7 @@ class Omise_Payment_Installment_Test extends TestCase
                 $class = new stdClass();
                 $class->cart = new stdClass();
                 $class->cart->total = 999999;
+                return $class;
 			}
 		}
 
@@ -29,7 +33,23 @@ class Omise_Payment_Installment_Test extends TestCase
             $wp->query_vars = ['order-pay' => 11];
         }
 
-		require_once __DIR__ . '/../../../includes/gateway/class-omise-payment-installation.php';
+        if (!function_exists('wp_kses')) {
+            function wp_kses() {}
+        }
+
+        if (!function_exists('add_action')) {
+            function add_action() {}
+        }
+
+		require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-installment.php';
+	}
+
+    /**
+	 * close mockery after test cases are done
+	 */
+	public function tearDown(): void
+	{
+		Mockery::close();
 	}
 
     /**


### PR DESCRIPTION
#### 1. Objective

Fix installment payment when admin manually pay for order.

#### 2. Description of change

Installment payment was not functioning properly when admin manually pay for order because the total amount was 0. This happened because logic was getting the total from the cart. But, cart is not present when admin pay for an order. So, we added a check that will get the total amount from order if the payment page is triggered by admin. If not then we get the total from cart.

<img width="860" alt="Screenshot 2566-08-04 at 09 43 19" src="https://github.com/omise/omise-woocommerce/assets/101558497/faf40530-c0a9-4f12-a3ae-b42145cb44b7">
<br/><br/>

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- WooCommerce: v7.8.2
- WordPress: v6.2.2
- PHP version: 8.1
- Omise WooCommerce: 5.1.1
