### PR TITLE
Fixed Japanese translation issue in secure form.

### DIFF
--- a/assets/javascripts/omise-embedded-card.js
+++ b/assets/javascripts/omise-embedded-card.js
@@ -25,17 +25,11 @@ function showOmiseEmbeddedCardForm({
   }
   element.style.height = iframeElementHeight + 'px'
 
-  const localeMatching = {
-    en_US: 'en',
-    ja_JP: 'ja',
-    th_TH: 'th'
-  }
-
   OmiseCard.configure({
     publicKey: publicKey,
     element,
     customCardForm: true,
-    locale: localeMatching[locale] ?? 'en',
+    locale: 'en',
     customCardFormTheme: theme,
     customCardFormHideRememberCard: hideRememberCard ?? false,
     customCardFormBrandIcons: brandIcons ?? null,

--- a/assets/javascripts/omise-embedded-card.js
+++ b/assets/javascripts/omise-embedded-card.js
@@ -29,7 +29,7 @@ function showOmiseEmbeddedCardForm({
     publicKey: publicKey,
     element,
     customCardForm: true,
-    locale: 'en',
+    locale: locale,
     customCardFormTheme: theme,
     customCardFormHideRememberCard: hideRememberCard ?? false,
     customCardFormBrandIcons: brandIcons ?? null,


### PR DESCRIPTION
#### 1. Objective

Fix Japanese translation issue in secure form.

#### 2. Description of change

We removed the `localMatching` array which was not necessary. because we get the required value from the LOCALE.

![Screenshot 2566-08-03 at 15 52 04](https://github.com/omise/omise-woocommerce/assets/101558497/d7cd7617-6515-42b9-ae41-77566ac6d7db)
<br/>

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- WooCommerce: v7.8.2
- WordPress: v6.2.2
- PHP version: 8.1
- Omise WooCommerce: 5.2.0
