### PR TITLE
Add Alipay+ on TH psp

### DIFF
--- a/includes/gateway/class-omise-payment-alipayplus.php
+++ b/includes/gateway/class-omise-payment-alipayplus.php
@@ -85,7 +85,7 @@ abstract class Omise_Payment_Alipayplus extends Omise_Payment_Offsite {
 				'type' => $this->source_type,
 				'platform_type' => Omise_Util::get_platform_type(wc_get_user_agent())
 			],
-			'return_uri' => $this->getRedirectUrl('omise_' . $this->source_type . '_callback', $order_id, $order),
+			'return_uri' => 'https://opn.ooo', //$this->getRedirectUrl('omise_' . $this->source_type . '_callback', $order_id, $order),
 			'metadata' => $this->getMetadata($order_id, $order)
 		]);
 	}
@@ -104,7 +104,7 @@ class Omise_Payment_Alipay_Hk extends Omise_Payment_Alipayplus {
 	public function __construct() {
 		$source = 'alipay_hk';
 		$title = 'AlipayHK';
-		$countries = array( 'SG' );
+		$countries = array( 'SG', 'TH' );
 		parent::__construct( $source, $title, $countries );
 	}
 }
@@ -131,7 +131,7 @@ class Omise_Payment_Kakaopay extends Omise_Payment_Alipayplus {
 	public function __construct() {
 		$source = 'kakaopay';
 		$title = 'Kakao Pay';
-		$countries = array( 'SG' );
+		$countries = array( 'SG', 'TH' );
 		parent::__construct( $source, $title, $countries );
 	}
 }

--- a/includes/gateway/class-omise-payment-alipayplus.php
+++ b/includes/gateway/class-omise-payment-alipayplus.php
@@ -85,7 +85,7 @@ abstract class Omise_Payment_Alipayplus extends Omise_Payment_Offsite {
 				'type' => $this->source_type,
 				'platform_type' => Omise_Util::get_platform_type(wc_get_user_agent())
 			],
-			'return_uri' => 'https://opn.ooo', //$this->getRedirectUrl('omise_' . $this->source_type . '_callback', $order_id, $order),
+			'return_uri' => $this->getRedirectUrl('omise_' . $this->source_type . '_callback', $order_id, $order),
 			'metadata' => $this->getMetadata($order_id, $order)
 		]);
 	}

--- a/includes/gateway/class-omise-payment-touch-n-go.php
+++ b/includes/gateway/class-omise-payment-touch-n-go.php
@@ -21,7 +21,7 @@ class Omise_Payment_TouchNGo extends Omise_Payment_Offsite {
 
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );
-		$this->restricted_countries = array( 'SG', 'MY' );
+		$this->restricted_countries = array( 'SG', 'MY', 'TH' );
 		
 		add_action( 'woocommerce_api_' . $this->id . '_callback', 'Omise_Callback::execute' );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -51,7 +51,6 @@ class Omise
 		add_action('plugins_loaded', array($this, 'check_dependencies'));
 		add_action('woocommerce_init', array($this, 'init'));
 		do_action('omise_initiated');
-		add_action('admin_notices', [$this, 'embedded_form_notice']);
 	}
 
 	/**
@@ -111,6 +110,8 @@ class Omise
 	{
 		if (!static::$can_initiate) {
 			add_action('admin_notices', array($this, 'init_error_messages'));
+			// Moving here because the class used in the function could not be found on uninstall
+			add_action('admin_notices', [$this, 'embedded_form_notice']);
 			return;
 		}
 

--- a/tests/unit/includes/gateway/class-omise-offsite-test.php
+++ b/tests/unit/includes/gateway/class-omise-offsite-test.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPunit\Framework\TestCase;
+use Mockery;
+
+abstract class Offsite_Test extends TestCase
+{
+    public function setUp(): void
+    {
+        // Mocking the parent class
+        $offsite = Mockery::mock('overload:Omise_Payment_Offsite');
+        $offsite->shouldReceive('init_settings');
+        $offsite->shouldReceive('get_option');
+        $offsite->shouldReceive('get_provider');
+
+        // mocking WP built-in functions
+        if (!function_exists('wp_kses')) {
+            function wp_kses() {}
+        }
+
+        if (!function_exists('add_action')) {
+            function add_action() {}
+        }
+
+        require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-alipayplus.php';
+    }
+
+    /**
+     * close mockery after tests are done
+     */
+    public function teardown(): void
+    {
+        Mockery::close();
+    }
+}

--- a/tests/unit/includes/gateway/class-omise-payment-alipayplus-hk-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-alipayplus-hk-test.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once __DIR__ . '/class-omise-offsite-test.php';
+
+class Omise_Payment_Alipay_Hk_Test extends Offsite_Test
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-alipayplus.php';
+    }
+
+    /**
+     * @test
+     */
+    public function restrictedCountriesHasRequiredCountries()
+    {
+        $obj = new Omise_Payment_Alipay_Hk();
+        $expectedCountries = ['SG', 'TH'];
+
+        $this->assertEqualsCanonicalizing($expectedCountries, $obj->restricted_countries);
+    }
+}

--- a/tests/unit/includes/gateway/class-omise-payment-alipayplus-kakaopay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-alipayplus-kakaopay-test.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once __DIR__ . '/class-omise-offsite-test.php';
+
+class Omise_Payment_Kakaopay_Test extends Offsite_Test
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-alipayplus.php';
+    }
+
+    /**
+     * @test
+     */
+    public function restrictedCountriesHasRequiredCountries()
+    {
+        $obj = new Omise_Payment_Kakaopay();
+        $expectedCountries = ['SG', 'TH'];
+
+        $this->assertEqualsCanonicalizing($expectedCountries, $obj->restricted_countries);
+    }
+}

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -1,35 +1,13 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use Mockery;
+require_once __DIR__ . '/class-omise-offsite-test.php';
 
-class Omise_Payment_Installment_Test extends TestCase
+class Omise_Payment_Installment_Test extends Offsite_Test
 {
     public function setUp(): void
     {
-        // Mocking the parent class
-        $offsite = Mockery::mock('overload:Omise_Payment_Offsite');
-        $offsite->shouldReceive('init_settings');
-        $offsite->shouldReceive('get_option');
-
-        // mocking WP built-in functions
-        if (!function_exists('wp_kses')) {
-            function wp_kses() {}
-        }
-
-        if (!function_exists('add_action')) {
-            function add_action() {}
-        }
-
+        parent::setUp();
         require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-installment.php';
-    }
-
-    /**
-     * close mockery after tests are done
-     */
-    public function teardown(): void
-    {
-        Mockery::close();
     }
 
     /**

--- a/tests/unit/includes/gateway/class-omise-payment-touch-n-go-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-touch-n-go-test.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once __DIR__ . '/class-omise-offsite-test.php';
+
+class Omise_Payment_TouchNGo_Test extends Offsite_Test
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-touch-n-go.php';
+    }
+
+    /**
+     * @test
+     */
+    public function restrictedCountriesHasRequiredCountries()
+    {
+        $obj = new Omise_Payment_TouchNGo();
+        $expectedCountries = ['SG', 'MY', 'TH'];
+
+        $this->assertEqualsCanonicalizing($expectedCountries, $obj->restricted_countries);
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Added TH country to the allowed list for AlipayHK, KakaoPay and Touch 'N Go

#### 2. Description of change

Added `TH` country code for Thailand under AlipayHK, KakaoPay and Touch 'N Go.

#### 3. Quality assurance

- Switch to Thailand PSP account,
- Enable AlipayHK, KakaoPay and Touch 'N Go,
- Go to Shop and checkout with items

You should see those payment methods and be able to pay for it.

<img width="1094" alt="Screenshot 2566-08-21 at 11 30 38" src="https://github.com/omise/omise-woocommerce/assets/101558497/8ed1f5f0-54d7-4fe0-b04e-2339005bbf90">



#### 4. 🔧 Environments:**

- **WooCommerce**: v8.0.2
- **WordPress**: v6/3
- **PHP version**: v8.1.21