### PR TITLE
Adding admin_notices action once all dependencies are loaded.

### DIFF
--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -110,6 +110,10 @@ class Omise
 	{
 		if (!static::$can_initiate) {
 			add_action('admin_notices', array($this, 'init_error_messages'));
+		}
+
+		// adding action after all dependencies are loaded.
+		if (static::$can_initiate) {
 			// Moving here because the class used in the function could not be found on uninstall
 			add_action('admin_notices', [$this, 'embedded_form_notice']);
 			return;

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -112,13 +112,6 @@ class Omise
 			add_action('admin_notices', array($this, 'init_error_messages'));
 		}
 
-		// adding action after all dependencies are loaded.
-		if (static::$can_initiate) {
-			// Moving here because the class used in the function could not be found on uninstall
-			add_action('admin_notices', [$this, 'embedded_form_notice']);
-			return;
-		}
-
 		$this->load_plugin_textdomain();
 		$this->include_classes();
 		$this->define_constants();
@@ -130,6 +123,13 @@ class Omise
 		$this->register_ajax_actions();
 
 		prepare_omise_myaccount_panel();
+
+		// adding action after all dependencies are loaded.
+		if (static::$can_initiate) {
+			// Moving here because the class used in the function could not be found on uninstall
+			add_action('admin_notices', [$this, 'embedded_form_notice']);
+			return;
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### 1. Objective

Fix the error that occurs if you uninstall WooCommerce before Opn Payment plugin.