### PR TITLE
Add QR expires count down for promptpay

### DIFF
--- a/assets/javascripts/omise-promptpay-count-down.js
+++ b/assets/javascripts/omise-promptpay-count-down.js
@@ -1,0 +1,43 @@
+(function () {
+    let countDownInterval;
+
+    function calculateCountdown() {
+        const currentDateTime = new Date();
+        const expiresAtDateTime = new Date(omise.qr_expires_at);
+        const difference = expiresAtDateTime - currentDateTime;
+        const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+        const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+        return { hours, minutes, seconds };
+    }
+
+    function padZero(num) {
+        return num.toString().padStart(2, '0');
+    }
+
+    function updateCountdown(fromInterval = true) {
+        const countdownDisplay = document.getElementById('countdown');
+        if(!countdownDisplay) {
+            return;
+        }
+
+        const { hours, minutes, seconds } = calculateCountdown();
+
+        if (hours + minutes + seconds < 0) {
+            // To prevent infinite loading, we need to reload and clear interval 
+            // only when it is from setInterval function.
+            if (fromInterval) {
+                clearInterval(countDownInterval)
+                window.location.reload()
+            }
+            return;
+        }
+
+        countdownDisplay.innerHTML = `${padZero(hours)}:${padZero(minutes)}:${padZero(seconds)}`;
+        if (!countDownInterval) {
+            countDownInterval = setInterval(updateCountdown, 1000);
+        }
+    }
+
+    updateCountdown(false)
+})()

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -96,7 +96,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 	 * @param string $id Value to be added in the id attribute of the svg element
 	 */
 	private function load_qr_svg_to_DOM($url, $id = null) {
-		$svg_file = file_get_contents($url);
+		$svg_file = $this->file_get_contents($url);
 
 		$find_string   = '<svg';
 		$position = strpos($svg_file, $find_string);
@@ -136,7 +136,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 		}
 
 		$charge = OmiseCharge::retrieve( $this->get_charge_id_from_order() );
-		if ( self::STATUS_PENDING !== $charge['status'] ) {
+		if ( $this->get_pending_status() !== $charge['status'] ) {
 			return;
 		}
 

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -96,7 +96,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 	 * @param string $id Value to be added in the id attribute of the svg element
 	 */
 	private function load_qr_svg_to_DOM($url, $id = null) {
-		$svg_file = $this->file_get_contents($url);
+		$svg_file = File_Get_Contents_Wrapper::get_contents($url);
 
 		$find_string   = '<svg';
 		$position = strpos($svg_file, $find_string);

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -143,16 +143,6 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * file_get_contents wrapper
-	 * 
-	 * Since we cannot mock global function,
-	 * we have to create a wrapper for file_get_contents.
-	 */
-	public function file_get_contents( $url ) {
-		return file_get_contents( $url );
-	}
-
-	/**
 	 * Register all required javascripts
 	 */
 	public function omise_checkout_assets() {

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -133,6 +133,26 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * get pending status
+	 * 
+	 * This function is crate to get value for pending status,
+	 * since we cannot mock constant values for unit test.
+	 */
+	public function get_pending_status() {
+		return self::STATUS_PENDING;
+	}
+
+	/**
+	 * file_get_contents wrapper
+	 * 
+	 * Since we cannot mock global function,
+	 * we have to create a wrapper for file_get_contents.
+	 */
+	public function file_get_contents( $url ) {
+		return file_get_contents( $url );
+	}
+
+	/**
 	 * Register all required javascripts
 	 */
 	public function omise_checkout_assets() {

--- a/includes/libraries/omise-plugin/Omise.php
+++ b/includes/libraries/omise-plugin/Omise.php
@@ -6,3 +6,4 @@ require_once dirname(__FILE__).'/helpers/mailer.php';
 require_once dirname(__FILE__).'/helpers/request.php';
 require_once dirname(__FILE__).'/helpers/token.php';
 require_once dirname(__FILE__).'/helpers/RedirectUrl.php';
+require_once dirname(__FILE__).'/helpers/file_get_contents_wrapper.php';

--- a/includes/libraries/omise-plugin/helpers/file_get_contents_wrapper.php
+++ b/includes/libraries/omise-plugin/helpers/file_get_contents_wrapper.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * file_get_contents wrapper class
+ * 
+ * Since we cannot mock global function,
+ * we have to create a wrapper for file_get_contents.
+ */
+class File_Get_Contents_Wrapper
+{
+	public static function get_contents($url)
+	{
+		return file_get_contents($url);
+	}
+}

--- a/tests/unit/includes/gateway/abstract-omise-payment-offline-test.php
+++ b/tests/unit/includes/gateway/abstract-omise-payment-offline-test.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/bootstrap-test-setup.php';
 
-class Omise_Payment_Offline_Test extends Bootstrap_Test_Setup
+abstract class Omise_Payment_Offline_Test extends Bootstrap_Test_Setup
 {
     public function setUp(): void
     {

--- a/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
@@ -1,0 +1,76 @@
+<?php
+
+use Mockery\Mock;
+
+class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
+{
+    public $mockOrder;
+    public $mockWcDateTime;
+    public $mockLocalizeScript;
+    public $mockOmisePluginHelper;
+    public $mockOmisePaymentOffline;
+    public $mockOmiseCharge;
+
+    public function setUp(): void
+    {
+        function wc_timezone_offset() {}
+        function wp_create_nonce() {}
+        function admin_url() {}
+
+        $this->mockOrder = Mockery::mock();
+        $this->mockLocalizeScript = Mockery::mock();
+        $this->mockWcDateTime = Mockery::mock('overload:WC_DateTime');
+        $this->mockOmisePluginHelper = Mockery::mock('overload:OmisePluginHelperWcOrder')->shouldIgnoreMissing();
+        $this->mockOmisePaymentOffline = Mockery::mock('overload:Omise_Payment_Offline');
+        $this->mockOmiseCharge = Mockery::mock('overload:OmiseCharge');
+
+        require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-promptpay.php';
+    }
+
+    /**
+     * @test
+     */
+    public function textExpiresAtFieldIsPassedToJavascript()
+    {
+        $expiresAt = '2023-11-22T14:48:00.000Z';
+
+        $this->mockOmisePaymentOffline->shouldReceive('init_settings');
+        $this->mockOmisePaymentOffline->shouldReceive('get_option');
+        $this->mockOmisePaymentOffline->shouldReceive('load_order')->andReturn(true);
+        $this->mockOmisePaymentOffline->shouldReceive('get_charge_id_from_order')->andReturn('charge_xxx');
+        $this->mockOmisePaymentOffline->shouldReceive('get_pending_status')->andReturn('pending');
+        $this->mockOmisePaymentOffline->shouldReceive('file_get_contents')->andReturn('');
+
+        $this->mockWcDateTime->shouldReceive('set_utc_offset');
+        $this->mockWcDateTime->shouldReceive('format')->with('c')->andReturn($expiresAt);
+
+        $this->mockOmiseCharge->shouldReceive('retrieve')->andReturn([
+            'status' => 'pending',
+            'expires_at' => $expiresAt,
+            'source' => [
+                'scannable_code' => [
+                    'image' => [
+                        'id' => 1,
+                        'download_uri' => '',
+                    ]
+                ]
+            ]
+        ]);
+
+        // check that qr_expires_at is passed to `omise-promptpay-count-down` script with omise object
+        $this->mockLocalizeScript->shouldReceive('call')
+            ->with('omise-promptpay-count-down', 'omise', [
+                'qr_expires_at' => $expiresAt
+            ]);
+
+        $GLOBALS['mock_wp_localize_script'] = $this->mockLocalizeScript;
+
+        function wp_localize_script($scriptName, $object, $params) {
+            return $GLOBALS['mock_wp_localize_script']->call($scriptName, $object, $params);
+        }
+
+        $obj = new Omise_Payment_Promptpay();
+        $result = $obj->display_qrcode($this->mockOrder, 'view');
+        $this->assertNull($result);
+    }
+}

--- a/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
@@ -36,7 +36,7 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
     {
         $expiresAt = '2023-11-22T14:48:00.000Z';
 
-        $this->mockFileGetContent->shouldReceive('get_contents')->once();
+        $this->mockFileGetContent->shouldReceive('get_contents')->once()->andReturn('<svg></svg>');
 
         $this->mockOmisePaymentOffline->shouldReceive('init_settings');
         $this->mockOmisePaymentOffline->shouldReceive('get_option');

--- a/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
@@ -10,6 +10,7 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
     public $mockOmisePluginHelper;
     public $mockOmisePaymentOffline;
     public $mockOmiseCharge;
+    public $mockFileGetContent;
 
     public function setUp(): void
     {
@@ -23,6 +24,7 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
         $this->mockOmisePluginHelper = Mockery::mock('overload:OmisePluginHelperWcOrder')->shouldIgnoreMissing();
         $this->mockOmisePaymentOffline = Mockery::mock('overload:Omise_Payment_Offline');
         $this->mockOmiseCharge = Mockery::mock('overload:OmiseCharge');
+        $this->mockFileGetContent = Mockery::mock('overload:File_Get_Contents_Wrapper');
 
         require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-promptpay.php';
     }
@@ -33,6 +35,8 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
     public function textExpiresAtFieldIsPassedToJavascript()
     {
         $expiresAt = '2023-11-22T14:48:00.000Z';
+
+        $this->mockFileGetContent->shouldReceive('get_contents')->once();
 
         $this->mockOmisePaymentOffline->shouldReceive('init_settings');
         $this->mockOmisePaymentOffline->shouldReceive('get_option');


### PR DESCRIPTION
#### 1. Objective

Add QR expires count down for promptpay

https://opn-ooo.atlassian.net/browse/MIT-1889

#### 2. Description of change

- Show QR code expire count down instead of date time.
- Created `get_pending_status` function since it does not support to mock constant.
- Created `file_get_contents` wrapper class since it does not support to mock global function.

<img width="428" alt="Screenshot 2023-10-12 at 1 44 09 PM" src="https://github.com/omise/omise-woocommerce/assets/108650842/005b1d01-a706-4177-a8d7-009c7c36db53">

#### 3. Quality assurance

- Crate payment with promptpay QR  and checked count down is correct.
- And wait for expiration and refresh the page which should be hidden QR code image.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal
