### PR TITLE
Bump v5.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### [v5.6.1 _(Nov 16, 2023)_](https://github.com/omise/omise-woocommerce/releases/tag/v5.6.1)
+- Fixed a custom font name bug. (PR [#419](https://github.com/omise/omise-woocommerce/pull/419))
+
 ### [v5.6.0 _(Nov 15, 2023)_](https://github.com/omise/omise-woocommerce/releases/tag/v5.6.0)
 - Support Google fonts other than Poppins. (PR [#416](https://github.com/omise/omise-woocommerce/pull/416))
 

--- a/includes/admin/class-omise-page-card-form-customization.php
+++ b/includes/admin/class-omise-page-card-form-customization.php
@@ -88,6 +88,14 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 		if (empty($formDesign)) {
 			$formDesign = $this->get_default_design_setting();
 		}
+
+		// Old saved settings might not have the newer fields. Make sure
+		// we add the missing field
+		// TODO: Find a better way to handle this
+		if (!in_array('custom_name', $formDesign['font'])) {
+			$formDesign['font']['custom_name'] = '';
+		}
+
 		return $formDesign;
 	}
 

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Opn Payments
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Opn Payments is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payments Payment Gateway's payment methods to WooCommerce.
- * Version:     5.6.0
+ * Version:     5.6.1
  * Author:      Opn Payments and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -22,7 +22,7 @@ class Omise
 	 *
 	 * @var string
 	 */
-	public $version = '5.6.0';
+	public $version = '5.6.1';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Opn Payments
 Tags: opn payments, payment, payment gateway, woocommerce plugin, omise, opn, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 6.4.0
-Stable tag: 5.6.0
+Stable tag: 5.6.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -33,6 +33,10 @@ From there:
 3. Opn Payments Checkout Form
 
 == Changelog ==
+
+= 5.6.1 =
+
+- Fixed a custom font name bug. (PR [#419](https://github.com/omise/omise-woocommerce/pull/419))
 
 = 5.6.0 =
 

--- a/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
+++ b/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
@@ -9,17 +9,14 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
 {
     public function setUp(): void
     {
-        // mocking WP built-in functions
-        if (!function_exists('get_option')) {
-            function get_option() {}
-        }
-
+        Brain\Monkey\setUp();
         Mockery::mock('alias:Omise_Admin_Page');
         require_once __DIR__ . '/../../../../includes/admin/class-omise-page-card-form-customization.php';
     }
 
     public function tearDown(): void
     {
+        Brain\Monkey\tearDown();
         Mockery::close();
     }
 
@@ -91,6 +88,48 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
         $themeValues = $this->invokeMethod($obj, 'get_dark_theme', []);
 
         $this->assertEqualsCanonicalizing($expected, $themeValues);
+    }
+
+    /**
+     * Test for merchants using secure form prior to v5.6.0
+     * Make sure it includes custom_name
+     * @test
+     */
+    public function testGetDesignSettingIncludesCustomName()
+    {
+        // settings of merchant's secure form prior to v5.6.0
+        $savedSettings = [
+            'font' => [
+                'name' => 'Poppins',
+                'size' => 16,
+            ],
+            'input' => [
+                'height' => '44px',
+                'border_radius' => '4px',
+                'border_color' => '#475266',
+                'active_border_color' => '#475266',
+                'background_color' => '#131926',
+                'label_color' => '#E6EAF2',
+                'text_color' => '#ffffff',
+                'placeholder_color' => '#DBDBDB',
+            ],
+            'checkbox' => [
+                'text_color' => '#E6EAF2',
+                'theme_color' => '#1451CC',
+            ]
+        ];
+
+        Brain\Monkey\Functions\stubs( [
+            'get_option' => $savedSettings,
+		] );
+
+        $obj = Omise_Page_Card_From_Customization::get_instance();
+        $designValues = $obj->get_design_setting();
+
+        $expected = $savedSettings;
+        $expected['font']['custom_name'] = '';
+        $this->assertEqualsCanonicalizing($expected, $designValues);
+        $this->assertArrayHasKey('custom_name', $designValues['font']);
     }
 
     /**


### PR DESCRIPTION
#### 1. Objective

Release v5.6.1

#### What's new
- Fixed a custom font name bug. (PR [#419](https://github.com/omise/omise-woocommerce/pull/419))