### PR TITLE
Fix auto scroll to secure form issue

### DIFF
--- a/assets/javascripts/omise-embedded-card.js
+++ b/assets/javascripts/omise-embedded-card.js
@@ -66,4 +66,20 @@ function showOmiseEmbeddedCardForm({
     onCreateTokenSuccess: onSuccess ?? noop,
     onError: onError ?? noop
   });
+
+  preventAutoScrollToSecureForm()
+}
+
+// Link: https://stackoverflow.com/questions/6596668/iframe-on-the-page-bottom-avoid-automatic-scroll-of-the-page
+function preventAutoScrollToSecureForm() {
+  const iframe = document.getElementById('omise-checkout-iframe-app');
+
+  iframe.addEventListener('load', function () {
+    // hide iframe to avoid auto scroll to secure form
+    iframe.style.display = "none";
+
+    // Bring back secure form
+    // why 1000? 0-800: didn't work, 900: Gave flaky results
+    setTimeout(() => iframe.style.display = "block", 1000)
+  });
 }

--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -295,7 +295,12 @@
 		});
 
 		$(document).on('updated_checkout', function () {
-			initializeSecureCardForm();
+			const iframe = document.getElementById('omise-checkout-iframe-app');
+
+			// Ignore if secure form is already initialized.
+			if (!iframe) {
+				initializeSecureCardForm();
+			}
 		});
 
 		initializeSecureCardForm();


### PR DESCRIPTION
#### 1. Objective

Fix auto scroll to secure form issue

#### 2. Description of change

- Added a check on existence of the secure form on `updated_checkout` event. This event was triggering when we update postal code.
- Hidden the secure form when iframe is loaded to avoid auto scroll to the iframe. We make is visible again after 1 sec.

#### 3. Quality assurance

Precondition:
- Use mobile device
- Enable secure form from WP admin
- There should not be any saved card

Case 1:
- Add items to cart and checkout
- Fill in the billing info.
- When you update postal code, the focus should not be shifted to credit card form.

Case 2:
- Add items to cart and checkout with credit card. This will set default payment to credit card on your next order
- For the next order, add items to cart and go to checkout page. The page should not scroll down to the credit card form.

**🔧 Environments:**

- WooCommerce: v8.3.1
- WordPress: v6.4.2
- PHP version: 8.1

#### 4. Impact of the change

- N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

- N/A