### PR TITLE
[MIT-1695] Add TrueMoney jump app

### DIFF
--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -255,16 +255,16 @@ class Omise_Capabilities {
 	/**
 	 * Retrieves details of TrueMoney from capabilities.
 	 *
-	 * @param string $sourceType
+	 * @param string $source_type
 	 */
-	public function get_truemoney_backend($sourceType)
+	public function get_truemoney_backend($source_type)
 	{
-		$truemoneySourceTypes = [Omise_Payment_Truemoney::WALLET, Omise_Payment_Truemoney::JUMPAPP];
+		$truemoney_source_types = [Omise_Payment_Truemoney::WALLET, Omise_Payment_Truemoney::JUMPAPP];
 
-		if (!in_array($sourceType, $truemoneySourceTypes)) {
+		if (!in_array($source_type, $truemoney_source_types)) {
 			return null;
 		}
 
-		return $this->getBackendByType($sourceType);
+		return $this->getBackendByType($source_type);
 	}
 }

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -251,4 +251,20 @@ class Omise_Capabilities {
 	{
 		return $this->capabilities['limits']['installment_amount']['min'];
 	}
+
+	/**
+	 * Retrieves details of TrueMoney from capabilities.
+	 *
+	 * @param string $sourceType
+	 */
+	public function get_truemoney_backend($sourceType)
+	{
+		$truemoneySourceTypes = [Omise_Payment_Truemoney::WALLET, Omise_Payment_Truemoney::JUMPAPP];
+
+		if (!in_array($sourceType, $truemoneySourceTypes)) {
+			return null;
+		}
+
+		return $this->getBackendByType($sourceType);
+	}
 }

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -75,9 +75,8 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 	public function payment_fields()
 	{
 		parent::payment_fields();
-
 		if (self::WALLET === $this->source_type) {
-			Omise_Util::render_view( 'templates/payment/form-truemoney.php', array() );
+			Omise_Util::render_view( 'templates/payment/form-truemoney.php', [] );
 		}
 	}
 
@@ -118,7 +117,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 	 * Return the right ShopeePay backend depending on the platform and availability of
 	 * the backend in the capability
 	 */
-	private function get_source()
+	public function get_source()
 	{
 		$capabilities = Omise_Capabilities::retrieve();
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -91,7 +91,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 
 	public function get_charge_request($order_id, $order)
 	{
-		$requestData = $this->build_charge_request(
+		$request_data = $this->build_charge_request(
 			$order_id,
 			$order,
 			$this->source_type,
@@ -99,18 +99,18 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 		);
 
 		if (self::WALLET === $this->source_type) {
-			$phoneOption = $_POST['omise_phone_number_default'];
-			$isPhoneOptionChecked = isset($phoneOption) && 1 == $phoneOption;
-			$phone_number = $isPhoneOptionChecked ?
+			$phone_option = $_POST['omise_phone_number_default'];
+			$is_phone_option_checked = isset($phone_option) && 1 == $phone_option;
+			$phone_number = $is_phone_option_checked ?
 				$order->get_billing_phone() :
 				sanitize_text_field( $_POST['omise_phone_number'] );
 
-			$requestData['source'] = array_merge($requestData['source'], [
+			$request_data['source'] = array_merge($request_data['source'], [
 				'phone_number' => $phone_number
 			]);
 		}
 
-		return $requestData;
+		return $request_data;
 	}
 
 	/**
@@ -125,10 +125,10 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 			return self::JUMPAPP;
 		}
 
-		$isJumpappEnabled = $capabilities->get_truemoney_backend(self::JUMPAPP);
-		$isWalletEnabled = $capabilities->get_truemoney_backend(self::WALLET);
+		$is_jumpapp_enabled = $capabilities->get_truemoney_backend(self::JUMPAPP);
+		$is_wallet_enabled = $capabilities->get_truemoney_backend(self::WALLET);
 
-		if (!empty($isWalletEnabled) && empty($isJumpappEnabled)) {
+		if (!empty($is_wallet_enabled) && empty($is_jumpapp_enabled)) {
 			return self::WALLET;
 		}
 

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -133,17 +133,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 			return self::WALLET;
 		}
 
-		// if (
-		// 	!empty($isJumpappEnabled) && !empty($isWalletEnabled) ||
-		// 	!empty($isJumpappEnabled) && empty($isWalletEnabled)
-		// ) {
-		// 	return self::JUMPAPP;
-		// }
-
-		// if (!empty($isWalletEnabled) && empty($isJumpappEnabled)) {
-		// 	return self::WALLET;
-		// }
-
+		// Return JUMP APP for the following cases:
 		// Case 1: Both jumpapp and wallet are enabled
 		// Case 2: jumpapp is enabled and wallet is disabled
 		// Case 3: Both are disabled.

--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -6,15 +6,22 @@ defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
  */
 class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 {
+	/**
+	 * Backends identifier
+	 * @var string
+	 */
+	const WALLET = 'truemoney';
+	const JUMPAPP = 'truemoney_jumpapp';
+
 	public function __construct()
 	{
 		parent::__construct();
 
 		$this->id                 = 'omise_truemoney';
 		$this->has_fields         = true;
-		$this->method_title       = __( 'Opn Payments TrueMoney Wallet', 'omise' );
+		$this->method_title       = __( 'Opn Payments TrueMoney', 'omise' );
 		$this->method_description = wp_kses(
-			__( 'Accept payments through <strong>TrueMoney Wallet</strong> via Opn Payments payment gateway (only available in Thailand).', 'omise' ),
+			__( 'Accept payments through <strong>TrueMoney</strong> via Opn Payments payment gateway (only available in Thailand).', 'omise' ),
 			array( 'strong' => array() )
 		);
 
@@ -26,7 +33,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );
 		$this->restricted_countries = array( 'TH' );
-		$this->source_type          = 'truemoney';
+		$this->source_type        = $this->get_source();
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_api_' . $this->id . '_callback', 'Omise_Callback::execute' );
@@ -43,7 +50,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable Opn Payments TrueMoney Wallet Payment', 'omise' ),
+				'label'   => __( 'Enable Opn Payments TrueMoney Payment', 'omise' ),
 				'default' => 'no'
 			),
 
@@ -51,7 +58,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 				'title'       => __( 'Title', 'omise' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title the user sees during checkout.', 'omise' ),
-				'default'     => __( 'TrueMoney Wallet', 'omise' ),
+				'default'     => __( 'TrueMoney', 'omise' ),
 			),
 
 			'description' => array(
@@ -68,7 +75,10 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 	public function payment_fields()
 	{
 		parent::payment_fields();
-		Omise_Util::render_view( 'templates/payment/form-truemoney.php', array() );
+
+		if (self::WALLET === $this->source_type) {
+			Omise_Util::render_view( 'templates/payment/form-truemoney.php', array() );
+		}
 	}
 
 	/**
@@ -82,22 +92,61 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 
 	public function get_charge_request($order_id, $order)
 	{
-		$phoneOption = $_POST['omise_phone_number_default'];
-		$isPhoneOptionChecked = isset($phoneOption) && 1 == $phoneOption;
-		$phone_number = $isPhoneOptionChecked ?
-			$order->get_billing_phone() :
-			sanitize_text_field( $_POST['omise_phone_number'] );
-
 		$requestData = $this->build_charge_request(
 			$order_id,
 			$order,
 			$this->source_type,
 			$this->id . '_callback'
 		);
-		$requestData['source'] = array_merge($requestData['source'], [
-			'phone_number' => $phone_number
-		]);
+
+		if (self::WALLET === $this->source_type) {
+			$phoneOption = $_POST['omise_phone_number_default'];
+			$isPhoneOptionChecked = isset($phoneOption) && 1 == $phoneOption;
+			$phone_number = $isPhoneOptionChecked ?
+				$order->get_billing_phone() :
+				sanitize_text_field( $_POST['omise_phone_number'] );
+
+			$requestData['source'] = array_merge($requestData['source'], [
+				'phone_number' => $phone_number
+			]);
+		}
 
 		return $requestData;
+	}
+
+	/**
+	 * Return the right ShopeePay backend depending on the platform and availability of
+	 * the backend in the capability
+	 */
+	private function get_source()
+	{
+		$capabilities = Omise_Capabilities::retrieve();
+
+		if (!$capabilities) {
+			return self::JUMPAPP;
+		}
+
+		$isJumpappEnabled = $capabilities->get_truemoney_backend(self::JUMPAPP);
+		$isWalletEnabled = $capabilities->get_truemoney_backend(self::WALLET);
+
+		if (!empty($isWalletEnabled) && empty($isJumpappEnabled)) {
+			return self::WALLET;
+		}
+
+		// if (
+		// 	!empty($isJumpappEnabled) && !empty($isWalletEnabled) ||
+		// 	!empty($isJumpappEnabled) && empty($isWalletEnabled)
+		// ) {
+		// 	return self::JUMPAPP;
+		// }
+
+		// if (!empty($isWalletEnabled) && empty($isJumpappEnabled)) {
+		// 	return self::WALLET;
+		// }
+
+		// Case 1: Both jumpapp and wallet are enabled
+		// Case 2: jumpapp is enabled and wallet is disabled
+		// Case 3: Both are disabled.
+		return self::JUMPAPP;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Opn Payments ===
 Contributors: Opn Payments
-Tags: opn payments, payment, payment gateway, woocommerce plugin, omise, opn, installment, internet banking, alipay, paynow, truemoney wallet, woocommerce payment
+Tags: opn payments, payment, payment gateway, woocommerce plugin, omise, opn, installment, internet banking, alipay, paynow, truemoney, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 6.4.0
 Stable tag: 5.6.1

--- a/tests/unit/includes/class-omise-capabilities-test.php
+++ b/tests/unit/includes/class-omise-capabilities-test.php
@@ -2,6 +2,9 @@
 
 require_once __DIR__ . '/gateway/bootstrap-test-setup.php';
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 {
 	private $omiseSettingMock;
@@ -15,15 +18,15 @@ class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 	{
 		parent::setUp();
 
+		Mockery::mock('Omise_Payment_Offsite');
 		require_once __DIR__ . '/../../../includes/class-omise-capabilities.php';
+		require_once __DIR__ . '/../../../includes/gateway/class-omise-payment-truemoney.php';
 		$this->omiseSettingMock = Mockery::mock('alias:Omise_Setting');
 		$this->omiseCapabilitiesMock = Mockery::mock('alias:OmiseCapabilities');
-		Mockery::namedMock('Omise_Payment_Truemoney', 'Omise_Payment_Truemoney_Stub');
 	}
 
 	/**
 	 * @dataProvider retrieve_data_provider
-	 * @runInSeparateProcess
 	 * @covers Omise_Capabilities
 	 */
 	public function test_retrieve_should_return_value_when_it_should_call_api($isCheckout, $isThankYouPage, $isAdmin, $adminPageName, $expected)

--- a/tests/unit/includes/class-omise-capabilities-test.php
+++ b/tests/unit/includes/class-omise-capabilities-test.php
@@ -101,8 +101,8 @@ class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 			->andReturn(false);
 
 		$capabilities = new Omise_Capabilities;
-		$isEnabled = $capabilities->get_truemoney_backend('abc');
-		$this->assertNull($isEnabled);
+		$is_enabled = $capabilities->get_truemoney_backend('abc');
+		$this->assertNull($is_enabled);
 	}
 
 	public function truemoney_source_provider()

--- a/tests/unit/includes/class-omise-capabilities-test.php
+++ b/tests/unit/includes/class-omise-capabilities-test.php
@@ -1,8 +1,8 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/gateway/bootstrap-test-setup.php';
 
-class Omise_Capabilities_Test extends TestCase
+class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 {
 	private $omiseSettingMock;
 
@@ -13,17 +13,12 @@ class Omise_Capabilities_Test extends TestCase
 	 */
 	public function setUp(): void
 	{
+		parent::setUp();
+
 		require_once __DIR__ . '/../../../includes/class-omise-capabilities.php';
 		$this->omiseSettingMock = Mockery::mock('alias:Omise_Setting');
 		$this->omiseCapabilitiesMock = Mockery::mock('alias:OmiseCapabilities');
-	}
-
-	/**
-	 * close mockery after test cases are done
-	 */
-	public function tearDown(): void
-	{
-		Mockery::close();
+		Mockery::namedMock('Omise_Payment_Truemoney', 'Omise_Payment_Truemoney_Stub');
 	}
 
 	/**
@@ -32,7 +27,7 @@ class Omise_Capabilities_Test extends TestCase
 	 * @covers Omise_Capabilities
 	 */
 	public function test_retrieve_should_return_value_when_it_should_call_api($isCheckout, $isThankYouPage, $isAdmin, $adminPageName, $expected)
-	{	
+	{
 		// assigning to global variable, so that we can use in child functions
 		$GLOBALS['isCheckout'] = $isCheckout;
 		$GLOBALS['isThankYouPage'] = $isThankYouPage;
@@ -41,9 +36,15 @@ class Omise_Capabilities_Test extends TestCase
 		// mocking page name
 		$_GET['page'] = $adminPageName;
 
-		function is_checkout() { return $GLOBALS['isCheckout']; }
-		function is_wc_endpoint_url($page) { return $GLOBALS['isThankYouPage']; }
-		function is_admin() { return $GLOBALS['isAdmin']; }
+		Brain\Monkey\Functions\expect('is_admin')
+			->with('123')
+			->andReturn($GLOBALS['isAdmin']);
+		Brain\Monkey\Functions\expect('is_checkout')
+			->with('123')
+			->andReturn($GLOBALS['isCheckout']);
+		Brain\Monkey\Functions\expect('is_wc_endpoint_url')
+			->with('123')
+			->andReturn($GLOBALS['isThankYouPage']);
 
 		if ($expected) {
 			$this->omiseSettingMock->shouldReceive('instance')->andReturn($this->omiseSettingMock);
@@ -66,16 +67,53 @@ class Omise_Capabilities_Test extends TestCase
 		return [
 			// checkout page and not thank you page
 			[true, false, false, '', true],
-			// // checkout page and also thank you page
+			// checkout page and also thank you page
 			[true, true, false, '', false],
-			// // omise setting page
+			// omise setting page
 			[true, true, true, 'omise', true],
-			// // other admin page
+			// other admin page
 			[true, true, true, 'other-page', false],
-			// // non checkout page and also no-admin page
+			// non checkout page and also no-admin page
 			[false, false, false, 'other-page', false],
-			// // non checkout page, non admin page
+			// non checkout page, non admin page
 			[false, false, false, '', false],
 		];
 	}
+
+	/**
+	 * @test
+	 */
+	public function test_get_truemoney_backend_returns_null_when_invalid_payment_is_passed()
+	{
+		Brain\Monkey\Functions\expect('is_admin')
+			->with('123')
+			->andReturn(true);
+
+		Brain\Monkey\Functions\expect('is_checkout')
+			->with('123')
+			->andReturn(true);
+
+		Brain\Monkey\Functions\expect('is_wc_endpoint_url')
+			->with('123')
+			->andReturn(false);
+
+		$capabilities = new Omise_Capabilities;
+		$isEnabled = $capabilities->get_truemoney_backend('abc');
+		$this->assertNull($isEnabled);
+	}
+
+	public function truemoney_source_provider()
+	{
+		return [ ['abc', false], ['truemoney', true], ['truemoney_jumpapp', true] ];
+	}
+}
+
+class Omise_Payment_Truemoney_Stub
+{
+	/**
+	 * Backends identifier
+	 * @var string
+	 */
+	const WALLET = 'truemoney';
+	const JUMPAPP = 'truemoney_jumpapp';
 }

--- a/tests/unit/includes/gateway/bootstrap-test-setup.php
+++ b/tests/unit/includes/gateway/bootstrap-test-setup.php
@@ -1,7 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use Brain;
+
 
 abstract class Bootstrap_Test_Setup extends TestCase
 {

--- a/tests/unit/includes/gateway/class-omise-payment-alipayplus-hk-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-alipayplus-hk-test.php
@@ -2,6 +2,9 @@
 
 require_once __DIR__ . '/class-omise-offsite-test.php';
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class Omise_Payment_Alipay_Hk_Test extends Omise_Offsite_Test
 {
     public function setUp(): void

--- a/tests/unit/includes/gateway/class-omise-payment-alipayplus-kakaopay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-alipayplus-kakaopay-test.php
@@ -2,6 +2,9 @@
 
 require_once __DIR__ . '/class-omise-offsite-test.php';
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class Omise_Payment_Kakaopay_Test extends Omise_Offsite_Test
 {
     public function setUp(): void

--- a/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
@@ -1,7 +1,6 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use Brain;
 
 class Omise_Payment_CreditCard_Test extends TestCase
 {

--- a/tests/unit/includes/gateway/class-omise-payment-mobilebanking-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-mobilebanking-test.php
@@ -13,6 +13,9 @@ class Omise_Payment_Mobilebanking_Test extends Omise_Offsite_Test
 
     public function testCharge()
     {
+        Brain\Monkey\Functions\expect('wc_get_user_agent')
+			->with('123')
+			->andReturn('Chrome Web');
         $_POST['omise-offsite'] = 'mobile_banking_bbl';
         $obj = new Omise_Payment_Mobilebanking();
         $this->getChargeTest($obj);

--- a/tests/unit/includes/gateway/class-omise-payment-ocbc-digital-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-ocbc-digital-test.php
@@ -20,12 +20,6 @@ class Omise_Payment_OCBC_Digital_Test extends Omise_Offsite_Test
                 return "http://localhost";
             }
         }
-
-        if (!function_exists('wc_get_user_agent')) {
-            function wc_get_user_agent() {
-                return "Chrome Web";
-            }
-        }
     }
 
     public function tearDown(): void
@@ -85,6 +79,9 @@ class Omise_Payment_OCBC_Digital_Test extends Omise_Offsite_Test
      */
     public function testCharge()
     {
+        Brain\Monkey\Functions\expect('wc_get_user_agent')
+			->with('123')
+			->andReturn('Chrome Web');
         $this->getChargeTest($this->obj);
     }
 }

--- a/tests/unit/includes/gateway/class-omise-payment-ocbc-pao-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-ocbc-pao-test.php
@@ -26,6 +26,9 @@ class Omise_Payment_OCBC_PAO_Test extends Omise_Offsite_Test
      */
     public function testCharge()
     {
+        Brain\Monkey\Functions\expect('wc_get_user_agent')
+			->with('123')
+			->andReturn('Chrome Web');
         $this->getChargeTest($this->obj);
     }
 }

--- a/tests/unit/includes/gateway/class-omise-payment-truemoney-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-truemoney-test.php
@@ -4,35 +4,44 @@ require_once __DIR__ . '/class-omise-offsite-test.php';
 
 class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
 {
+    private $obj;
+
     public function setUp(): void
     {
         $this->sourceType = 'truemoney';
         parent::setUp();
+        Brain\Monkey\Functions\expect('is_admin')
+			->with('123')
+			->andReturn(true);
+		Brain\Monkey\Functions\expect('is_checkout')
+			->with('123')
+			->andReturn(true);
+		Brain\Monkey\Functions\expect('is_wc_endpoint_url')
+			->with('123')
+			->andReturn(true);
         require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-truemoney.php';
+        require_once __DIR__ . '/../../../../includes/class-omise-capabilities.php';
+
+        $this->obj = new Omise_Payment_Truemoney();
     }
 
     public function testGetChargeRequest()
     {
-        $obj = new Omise_Payment_Truemoney();
-
+        // set source type to truemoney wallet
+        $this->obj->source_type = 'truemoney';
         $orderId = 'order_123';
         $expectedAmount = 999999;
         $expectedCurrency = 'thb';
         $orderMock = $this->getOrderMock($expectedAmount, $expectedCurrency);
 
         $_POST['omise_phone_number_default'] = true;
-        $result = $obj->get_charge_request($orderId, $orderMock);
+        $result = $this->obj->get_charge_request($orderId, $orderMock);
 
         $this->assertEquals($orderMock->get_billing_phone(), $result['source']['phone_number']);
-
-        unset($_POST['omise_phone_number_default']);
-        unset($obj);
     }
 
     public function testGetChargeRequestWhenCustomerOverridesDefaultPhone()
     {
-        $obj = new Omise_Payment_Truemoney();
-
         $orderId = 'order_123';
         $expectedAmount = 999999;
         $expectedCurrency = 'thb';
@@ -41,7 +50,7 @@ class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
         $_POST['omise_phone_number_default'] = false;
         $_POST['omise_phone_number'] = '1234567890';
         
-        $result = $obj->get_charge_request($orderId, $orderMock);
+        $result = $this->obj->get_charge_request($orderId, $orderMock);
 
         $this->assertEquals($this->sourceType, $result['source']['type']);
     }
@@ -49,7 +58,6 @@ class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
     public function testCharge()
     {
         $_POST['omise_phone_number_default'] = true;
-        $obj = new Omise_Payment_Truemoney();
-        $this->getChargeTest($obj);
+        $this->getChargeTest($this->obj);
     }
 }

--- a/tests/unit/includes/gateway/class-omise-payment-truemoney-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-truemoney-test.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/class-omise-offsite-test.php';
 
 class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
 {
-    private $mockOmiseCapability;
+    private $omise_capability_mock;
 
     public function setUp(): void
     {
@@ -20,45 +20,45 @@ class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
 			->with('123')
 			->andReturn(true);
         require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-truemoney.php';
-        $this->mockOmiseCapability = Mockery::mock('alias:Omise_Capabilities');
+        $this->omise_capability_mock = Mockery::mock('alias:Omise_Capabilities');
     }
 
     public function test_get_charge_request()
     {
-        $this->mockOmiseCapability->shouldReceive('retrieve')->once();
+        $this->omise_capability_mock->shouldReceive('retrieve')->once();
         // set source type to truemoney wallet
         $obj = new Omise_Payment_Truemoney();
         $obj->source_type = 'truemoney';
-        $orderId = 'order_123';
-        $expectedAmount = 999999;
-        $expectedCurrency = 'thb';
-        $orderMock = $this->getOrderMock($expectedAmount, $expectedCurrency);
+        $order_id = 'order_123';
+        $expected_amount = 999999;
+        $expected_currency = 'thb';
+        $order_mock = $this->getOrderMock($expected_amount, $expected_currency);
 
         $_POST['omise_phone_number_default'] = true;
-        $result = $obj->get_charge_request($orderId, $orderMock);
+        $result = $obj->get_charge_request($order_id, $order_mock);
 
-        $this->assertEquals($orderMock->get_billing_phone(), $result['source']['phone_number']);
+        $this->assertEquals($order_mock->get_billing_phone(), $result['source']['phone_number']);
     }
 
     public function test_get_charge_request_when_customer_overrides_default_phone()
     {
-        $this->mockOmiseCapability->shouldReceive('retrieve')->once();
-        $orderId = 'order_123';
-        $expectedAmount = 999999;
-        $expectedCurrency = 'thb';
-        $orderMock = $this->getOrderMock($expectedAmount, $expectedCurrency);
+        $this->omise_capability_mock->shouldReceive('retrieve')->once();
+        $order_id = 'order_123';
+        $expected_amount = 999999;
+        $expected_currency = 'thb';
+        $order_mock = $this->getOrderMock($expected_amount, $expected_currency);
 
         $_POST['omise_phone_number'] = '1234567890';
 
         $obj = new Omise_Payment_Truemoney();
-        $result = $obj->get_charge_request($orderId, $orderMock);
+        $result = $obj->get_charge_request($order_id, $order_mock);
 
         $this->assertEquals($this->sourceType, $result['source']['type']);
     }
 
     public function test_charge()
     {
-        $this->mockOmiseCapability->shouldReceive('retrieve')->once();
+        $this->omise_capability_mock->shouldReceive('retrieve')->once();
         $_POST['omise_phone_number_default'] = true;
         $obj = new Omise_Payment_Truemoney();
         $this->getChargeTest($obj);
@@ -66,7 +66,7 @@ class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
 
     public function test_get_source_returns_jumpapp()
     {
-        $this->mockOmiseCapability->shouldReceive('retrieve');
+        $this->omise_capability_mock->shouldReceive('retrieve');
         $obj = new Omise_Payment_Truemoney();
         $source_type = $obj->get_source();
         $this->assertEquals('truemoney_jumpapp', $source_type);
@@ -74,7 +74,7 @@ class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
 
     public function test_get_source_returns_wallet()
     {
-        $this->mockOmiseCapability->shouldReceive('retrieve')
+        $this->omise_capability_mock->shouldReceive('retrieve')
             ->andReturn(new class() {
                 public function get_truemoney_backend($source_type) {
                     if ('truemoney' === $source_type) {
@@ -103,7 +103,7 @@ class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
 
     public function test_get_source_returns_jumpapp_when_both_are_enabled()
     {
-        $this->mockOmiseCapability->shouldReceive('retrieve')
+        $this->omise_capability_mock->shouldReceive('retrieve')
             ->andReturn(new class() {
                 public function get_truemoney_backend($source_type) {
                     if ('truemoney' === $source_type) {


### PR DESCRIPTION
## Description

Add TrueMoney jump app.

## Decision(s)

- TrueMoney will default to jump app if both types are enabled. Platform (mobile or web) is irrelevant.
- Merchant will see one TrueMoney as payment method in WooCommerce dashboard. The actual implementation of either jump app or wallet will be determined in the checkout page as per Capabilities API
 
## Rollback procedure

`default rollback procedure`
