### PR TITLE
Use wc order number metadata

### DIFF
--- a/includes/gateway/abstract-omise-payment-base-card.php
+++ b/includes/gateway/abstract-omise-payment-base-card.php
@@ -62,13 +62,14 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 	private function prepareChargeData($order_id, $order, $omise_customer_id, $card_id, $token)
 	{
 		$currency = $order->get_currency();
+		$order_number = $order->get_order_number();
 		$data = [
 			'amount' => Omise_Money::to_subunit($order->get_total(), $currency),
 			'currency' => $currency,
-			'description' => 'WooCommerce Order id ' . $order_id,
+			'description' => 'WooCommerce Order id ' . $order_number,
 			'return_uri' => $this->get_redirect_url('omise_callback', $order_id, $order),
 			'metadata' => $this->get_metadata(
-				$order_id,
+				$order_number,
 				[ 'secure_form_enabled' => $this->getSecureFormState()]
 			),
 		];

--- a/includes/gateway/traits/charge-request-builder-trait.php
+++ b/includes/gateway/traits/charge-request-builder-trait.php
@@ -10,13 +10,14 @@ trait Charge_Request_Builder
 	)
 	{
 		$currency = $order->get_currency();
-		$description = 'WooCommerce Order id ' . $order_id;
+		$order_number = $order->get_order_number();
+		$description = 'WooCommerce Order id ' . $order_number;
 
 		$request = [
 			'amount'      => Omise_Money::to_subunit($order->get_total(), $currency),
 			'currency'    => $currency,
 			'description' => $description,
-			'metadata'    => $this->get_metadata($order_id),
+			'metadata'    => $this->get_metadata($order_number),
 			'source' 	  => [ 'type' => $source_type ]
 		];
 
@@ -40,13 +41,13 @@ trait Charge_Request_Builder
 	}
 
 	/**
-	 * @param string $order_id
+	 * @param string $order_number
 	 * @param array $additionalData
 	 */
-	public function get_metadata($order_id, $additionalData = [])
+	public function get_metadata($order_number, $additionalData = [])
 	{
 		// override order_id as a reference for webhook handlers.
-		$orderId = [ 'order_id' => $order_id ];
+		$orderId = [ 'order_id' => $order_number ];
 		return array_merge($orderId, $additionalData);
 	}
 

--- a/tests/unit/includes/gateway/abstract-omise-payment-base-card-test.php
+++ b/tests/unit/includes/gateway/abstract-omise-payment-base-card-test.php
@@ -62,6 +62,8 @@ class Omise_Payment_Base_Card_Test extends TestCase
             ->andReturn($expectedAmount);  // in units
         $orderMock->shouldReceive('add_meta_data')
             ->andReturn(['order_id' => 'order_123']);
+        $orderMock->shouldReceive('get_order_number')
+            ->andReturn(1234);
         $orderMock->shouldReceive('get_user')
             ->andReturn((object)[
                 'ID' => 'user_123',

--- a/tests/unit/includes/gateway/traits/charge-request-builder-test.php
+++ b/tests/unit/includes/gateway/traits/charge-request-builder-test.php
@@ -34,6 +34,8 @@ class Charge_Request_Builder_Test extends TestCase
         $orderMock->shouldReceive('get_total')
             ->andReturn($expectedAmount);  // in units
         $orderMock->shouldReceive('add_meta_data');
+        $orderMock->shouldReceive('get_order_number')
+            ->andReturn(1234);
         return $orderMock;
     }
 


### PR DESCRIPTION
## Description

Use `get_order_number` instead of `order_id` for the charge metadata so that users can customize order number.

## Decision(s)

It is safe to replace order ID with `get_order_number` for the use case because it returns order ID by default. If user choose to customize order number using some plugins then it will return the order number in the new format.

https://woocommerce.github.io/code-reference/classes/WC-Order.html#method_get_order_number
 
## Rollback procedure

`default rollback procedure`
