### PR TITLE
Resolve PHP warnings

### DIFF
--- a/includes/class-omise-admin.php
+++ b/includes/class-omise-admin.php
@@ -64,7 +64,7 @@ if (!class_exists('Omise_Admin')) {
 		public function wordpress_hook_card_form_customization()
 		{
 			add_submenu_page(
-				null,
+				"",
 				__('Custom card form customization', 'omise'),
 				Omise_Page_Card_From_Customization::PAGE_NAME,
 				'manage_options',


### PR DESCRIPTION
## Description

Resolve PHP warnings for strpos() and str_repalce()

### More information (if any)  

We replaced `null` with empty string `''` as the first parameter to `add_submenu_page` because this WP function calls `strpos` and `str_replace` behind the scene and from PHP 8.1, passing `null` is deprecated.

## Rollback procedure

`default rollback procedure`
