### PR TITLE
Remove white box appearing under WeChat Pay

### DIFF
--- a/includes/gateway/class-omise-payment-wechat-pay.php
+++ b/includes/gateway/class-omise-payment-wechat-pay.php
@@ -8,7 +8,7 @@ class Omise_Payment_Wechat_Pay extends Omise_Payment_Offsite
 		parent::__construct();
 
 		$this->id                 = 'omise_wechat_pay';
-		$this->has_fields         = true;
+		$this->has_fields         = false;
 		$this->method_title       = __( 'Opn Payments WeChat Pay', 'omise' );
 		$this->method_description = wp_kses(
 			__( 'Accept payment through <strong>WeChat Pay</strong> via Opn Payments payment gateway.', 'omise' ),


### PR DESCRIPTION
## Description

Remove white box appearing under WeChat Pay

<img width="1355" alt="Screenshot 2567-03-14 at 11 31 38" src="https://github.com/omise/omise-woocommerce/assets/101558497/60aa3d08-97e9-44e2-be88-95838f889951">

### More information (if any)  

Changed value of has_fields from true to false as we don't have other fields in WeChat Pay.

## Rollback procedure

`default rollback procedure`
