### PR TITLE
Remove white box appearing under Truemoney

### DIFF
--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -122,6 +122,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 		$capabilities = Omise_Capabilities::retrieve();
 
 		if (!$capabilities) {
+			$this->has_fields = false;
 			return self::JUMPAPP;
 		}
 
@@ -136,6 +137,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 		// Case 1: Both jumpapp and wallet are enabled
 		// Case 2: jumpapp is enabled and wallet is disabled
 		// Case 3: Both are disabled.
+		$this->has_fields = false;
 		return self::JUMPAPP;
 	}
 }


### PR DESCRIPTION
## Description

Remove white box appearing under Truemoney when the source type is `truemoney_jumpapp`.

<img width="1264" alt="Screenshot 2567-03-14 at 14 30 40" src="https://github.com/omise/omise-woocommerce/assets/101558497/b743cf08-6e4b-4e17-b20a-5fe513350ce4">

## Rollback procedure

`default rollback procedure`
