### PR TITLE
Add #[AllowDynamicProperties] to not emit deprecation notice.

### DIFF
--- a/includes/class-omise-wc-myaccount.php
+++ b/includes/class-omise-wc-myaccount.php
@@ -2,6 +2,7 @@
 defined( 'ABSPATH' ) or die( 'No direct script access allowed.' );
 
 if ( ! class_exists( 'Omise_MyAccount' ) ) {
+	#[AllowDynamicProperties]
 	class Omise_MyAccount
 	{
 		private static $instance;

--- a/includes/classes/class-omise-customer.php
+++ b/includes/classes/class-omise-customer.php
@@ -2,6 +2,7 @@
 defined( 'ABSPATH' ) or die( "No direct script access allowed." );
 
 if ( ! class_exists( 'Omise_Customer' ) ) {
+    #[AllowDynamicProperties]
 	class Omise_Customer
     {
         private $customer;

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -9,6 +9,7 @@ if ( class_exists( 'Omise_Payment' ) ) {
 	return;
 }
 
+#[AllowDynamicProperties]
 abstract class Omise_Payment extends WC_Payment_Gateway {
 	use Sync_Order;
 

--- a/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
+++ b/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
@@ -4,7 +4,7 @@ define('OMISE_PHP_LIB_VERSION', '2.16.0');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class OmiseApiResource extends OmiseObject
 {
     // Request methods

--- a/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
+++ b/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php
@@ -4,6 +4,7 @@ define('OMISE_PHP_LIB_VERSION', '2.16.0');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
+#[AllowDynamicProperties]
 class OmiseApiResource extends OmiseObject
 {
     // Request methods

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -15,6 +15,7 @@
  */
 defined('ABSPATH') or die('No direct script access allowed.');
 
+#[AllowDynamicProperties]
 class Omise
 {
 	/**


### PR DESCRIPTION
## Description

Suppress deprecation notices for dynamic properties introduced in PHP 8.2 by adding #[AllowDynamicProperties].

- https://www.php.net/manual/en/class.allowdynamicproperties.php
- https://php.watch/versions/8.2/dynamic-properties-deprecated#AllowDynamicProperties

## Rollback procedure

`default rollback procedure`
