### PR TITLE
Resolve checkout issue when billing info was updated (WooCommerce Block)

### DIFF
--- a/assets/javascripts/omise-embedded-card.js
+++ b/assets/javascripts/omise-embedded-card.js
@@ -33,37 +33,42 @@ function showOmiseEmbeddedCardForm({
     fontName = font.custom_name.trim()
   }
 
-  OmiseCard.configure({
-    publicKey: publicKey,
-    element,
-    customCardForm: true,
-    locale: locale,
-    customCardFormTheme: theme,
-    customCardFormHideRememberCard: hideRememberCard ?? false,
-    customCardFormBrandIcons: brandIcons ?? null,
-    style: {
-      fontFamily: fontName,
-      fontSize: font.size,
-      input: {
-        height: input.height,
-        borderRadius: input.border_radius,
-        border: `1.2px solid ${input.border_color}`,
-        focusBorder: `1.2px solid ${input.active_border_color}`,
-        background: input.background_color,
-        color: input.text_color,
-        labelColor: input.label_color,
-        placeholderColor: input.placeholder_color,
+  // when card payment is selected and a page is refreshed then it takes around 1s
+  // for OmiseCard to be available. So, we add a timeout of 1 sec. refer to
+  // showOmiseEmbeddedCardForm() in assets/javascrips/omise-embedded-card.js
+  setTimeout(() => {
+    OmiseCard.configure({
+      publicKey: publicKey,
+      element,
+      customCardForm: true,
+      locale: locale,
+      customCardFormTheme: theme,
+      customCardFormHideRememberCard: hideRememberCard ?? false,
+      customCardFormBrandIcons: brandIcons ?? null,
+      style: {
+        fontFamily: fontName,
+        fontSize: font.size,
+        input: {
+          height: input.height,
+          borderRadius: input.border_radius,
+          border: `1.2px solid ${input.border_color}`,
+          focusBorder: `1.2px solid ${input.active_border_color}`,
+          background: input.background_color,
+          color: input.text_color,
+          labelColor: input.label_color,
+          placeholderColor: input.placeholder_color,
+        },
+        checkBox: {
+          textColor: checkbox.text_color,
+          themeColor: checkbox.theme_color,
+          border: `1.2px solid ${input.border_color}`,
+        }
       },
-      checkBox: {
-        textColor: checkbox.text_color,
-        themeColor: checkbox.theme_color,
-        border: `1.2px solid ${input.border_color}`,
-      }
-    },
-  });
+    });
 
-  OmiseCard.open({
-    onCreateTokenSuccess: onSuccess ?? noop,
-    onError: onError ?? noop
-  });
+    OmiseCard.open({
+      onCreateTokenSuccess: onSuccess ?? noop,
+      onError: onError ?? noop
+    });
+  }, 1000)
 }

--- a/includes/blocks/assets/js/build/credit_card.asset.php
+++ b/includes/blocks/assets/js/build/credit_card.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wc-blocks-registry', 'wc-settings', 'wp-element', 'wp-html-entities', 'wp-i18n'), 'version' => '9d9c940edd665b09cdd8e15ab6212835');
+<?php return array('dependencies' => array('react', 'wc-blocks-registry', 'wc-settings', 'wp-element', 'wp-html-entities', 'wp-i18n'), 'version' => 'f631d260a4f3392a7920d2b269411607');

--- a/includes/blocks/assets/js/common.js
+++ b/includes/blocks/assets/js/common.js
@@ -11,7 +11,7 @@ export function registerOmisePaymentMethod({settings, label}) {
         const { PaymentMethodLabel } = props.components
         return <PaymentMethodLabel text={ label } />
     }
-    
+
     registerPaymentMethod( {
         name: settings.name || "",
         label: <Label />,

--- a/includes/blocks/assets/js/credit_card/saved-cards.js
+++ b/includes/blocks/assets/js/credit_card/saved-cards.js
@@ -1,4 +1,3 @@
-import {useEffect, useRef} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export const SavedCard = ({onChange, existingCards}) => {

--- a/includes/blocks/gateways/omise-block-credit-card.php
+++ b/includes/blocks/gateways/omise-block-credit-card.php
@@ -48,10 +48,12 @@ class Omise_Block_Credit_Card extends AbstractPaymentMethodType {
                 wp_register_script(
                     'embedded-js',
                     plugins_url( '../../assets/javascripts/omise-embedded-card.js', __FILE__ ),
-                    [],
+                    ['omise-js'],
                     OMISE_WOOCOMMERCE_PLUGIN_VERSION,
                     true
                 );
+
+                $script_asset['dependencies'] = array_merge($script_asset['dependencies'], ['embedded-js']);
 
                 wp_register_script(
                     "{$this->name}-payments-blocks",

--- a/includes/blocks/omise-block-config.php
+++ b/includes/blocks/omise-block-config.php
@@ -1,6 +1,7 @@
 <?php
 
-use Automattic\WooCommerce\Blocks\Registry\Container;
+use Automattic\WooCommerce\StoreApi\StoreApi;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 
 class Omise_Block_Config {
 

--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -87,12 +87,37 @@ class Omise_Capabilities {
 		// If endpoint url is `order-received`, it mean thank you page.
 		$isPaymentPage = is_checkout() && !is_wc_endpoint_url( 'order-received' );
 
-		global $wp;
-		$isFromCheckout = !$wp
-			? false
-			: strpos($wp->request, '/checkout') === strlen($wp->request) - strlen('/checkout');
+		return $isPaymentPage || $isOmiseSettingPage || self::isFromCheckoutPage();
+	}
 
-		return $isPaymentPage || $isOmiseSettingPage || $isFromCheckout;
+	public static function isFromCheckoutPage()
+	{
+		global $wp;
+
+		if (!$wp) {
+			return false;
+		}
+
+		$endpoints = ['checkout', 'batch'];
+
+		foreach($endpoints as $endpoint) {
+			if (trim($wp->request) !== '') {
+				$len = strlen($wp->request);
+				if (strpos($wp->request, $endpoint) === $len - strlen($endpoint)) {
+					return true;
+				}
+			}
+
+			if (isset($wp->query_vars['rest_route'])) {
+				$route = $wp->query_vars['rest_route'];
+				$len = strlen($route);
+				if (strpos($route, $endpoint) === $len - strlen($endpoint)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/unit/includes/class-omise-capabilities-test.php
+++ b/tests/unit/includes/class-omise-capabilities-test.php
@@ -109,6 +109,35 @@ class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 	{
 		return [ ['abc', false], ['truemoney', true], ['truemoney_jumpapp', true] ];
 	}
+
+	/**
+	 * @dataProvider ajax_call_to_store_api_provider
+	 * @covers Omise_Capabilities
+	 */
+	public function test_ajax_call_to_store_api_calls_omise_capability_api($request, $query_vars, $expected)
+	{
+		if ($request || $query_vars) {
+			$wp = new stdClass();
+			$wp->request = $request;
+			$wp->query_vars = $query_vars;
+			$GLOBALS['wp'] = $wp;
+		}
+
+		$capabilities = new Omise_Capabilities;
+		$result = $capabilities::isFromCheckoutPage();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function ajax_call_to_store_api_provider()
+	{
+		return [
+			[null, null, false], // empty to test empty wp
+			['wp-json/wc/store/v1/batch', [], true],
+			['wp-json/wc/store/v1/batch', ['rest_route' => '/wc/store/v1/batch'], true],
+			['', ['rest_route' => '/wc/store/v1/batch'], true],
+			['', '', false]
+		];
+	}
 }
 
 class Omise_Payment_Truemoney_Stub


### PR DESCRIPTION
## Description

Resolve checkout issue when billing info was updated.

In Omise Capabilities, we are limited which pages are able to call the API to reduce the number of calls. It was not allowing Store Rest API to call capabilities resulting in payment methods being disabled. This PR allows store API endpoints to call capabilities API to resolve checkout error of payment method not showing up.

## Rollback procedure

`default rollback procedure`
