### PR TITLE
Fix Webpack's AutoPublicPathRuntimeModule has a DOM Clobbering Gadget that leads to XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3412,19 +3412,11 @@
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
             "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
-            }
-        },
-        "node_modules/@types/eslint-scope": {
-            "version": "3.7.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-            "dev": true,
-            "dependencies": {
-                "@types/eslint": "*",
-                "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -4731,10 +4723,10 @@
                 "acorn-walk": "^8.0.2"
             }
         },
-        "node_modules/acorn-import-assertions": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+        "node_modules/acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
             "dev": true,
             "peerDependencies": {
                 "acorn": "^8"
@@ -7455,9 +7447,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.16.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
-            "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -17644,21 +17636,20 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.91.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-            "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+            "version": "5.95.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+            "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
             "dev": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
                 "@webassemblyjs/wasm-edit": "^1.12.1",
                 "@webassemblyjs/wasm-parser": "^1.12.1",
                 "acorn": "^8.7.1",
-                "acorn-import-assertions": "^1.9.0",
+                "acorn-import-attributes": "^1.9.5",
                 "browserslist": "^4.21.10",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.16.0",
+                "enhanced-resolve": "^5.17.1",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",


### PR DESCRIPTION

## Description
We discovered a DOM Clobbering vulnerability in Webpack’s `AutoPublicPathRuntimeModule`. The DOM Clobbering gadget in the module can lead to cross-site scripting (XSS) in web pages where scriptless attacker-controlled HTML elements (e.g., an `img` tag with an unsanitized `name` attribute) are present.

[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CVE-2024-43788](https://nvd.nist.gov/vuln/detail/CVE-2024-43788)

## Rollback procedure
`default rollback procedure`