### PR TITLE
Resolve the issue where no payment methods are displayed when the browser's back button is clicked from an issuer page.

### DIFF
--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -98,7 +98,7 @@ class Omise_Capabilities {
 			return false;
 		}
 
-		$endpoints = ['checkout', 'batch', 'cart/select-shipping-rate'];
+		$endpoints = ['checkout', 'batch', 'cart', 'cart/select-shipping-rate'];
 
 		foreach($endpoints as $endpoint) {
 			if (trim($wp->request) !== '') {


### PR DESCRIPTION
## Description

Resolved the issue where no payment methods are displayed when the browser's back button is clicked from an issuer page.

- Added /cart endpoint to whitelist for capability API.

## Rollback procedure

`default rollback procedure`
