### PR TITLE
Fix the issue of GooglePay not showing in shortcode

### DIFF
--- a/includes/gateway/class-omise-payment-googlepay.php
+++ b/includes/gateway/class-omise-payment-googlepay.php
@@ -219,7 +219,7 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
                         merchantId: '" . $this->googlepay_config['merchant_id'] . "',
                     },
                     transactionInfo: {
-                        totalPriceStatus: " . $this->googlepay_config['price_status'] . ",
+                        totalPriceStatus: '" . $this->googlepay_config['price_status'] . "',
                         currencyCode: '" . $this->googlepay_config['currency'] . "',
                     },
                 }

--- a/tests/unit/includes/gateway/class-omise-payment-googlepay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-googlepay-test.php
@@ -129,7 +129,7 @@ class Omise_Payment_GooglePay_Test extends TestCase
                         merchantId: '',
                     },
                     transactionInfo: {
-                        totalPriceStatus: NOT_CURRENTLY_KNOWN,
+                        totalPriceStatus: 'NOT_CURRENTLY_KNOWN',
                         currencyCode: 'thb',
                     },
                 }


### PR DESCRIPTION
## Description

Fix the issue of GooglePay not showing in shortcode by adding the missing quotes around the value of totalPriceStatus to resolve GooglePay not showing issue.

**Issue**
<img width="698" alt="Screenshot 2024-11-26 at 4 48 01 PM" src="https://github.com/user-attachments/assets/4040ed2d-5d9a-4f2a-9e4a-5c269d08330d">

**After fix**
<img width="474" alt="Screenshot 2024-11-26 at 4 47 32 PM" src="https://github.com/user-attachments/assets/6bd303a0-3439-4916-b769-4c9e4f5f538a">


## Rollback procedure

`default rollback procedure`
