### PR TITLE
Release v6.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [v6.0.3 _(Nov 27, 2024)_](https://github.com/omise/omise-woocommerce/releases/tag/v6.0.3)
+- Fix the issue of GooglePay not showing in shortcode. (PR: [#493](https://github.com/omise/omise-woocommerce/pull/493))
+
 ## [v6.0.2 _(Nov 20, 2024)_](https://github.com/omise/omise-woocommerce/releases/tag/v6.0.2)
 - Resolved installment issue when card is saved in shortcode setup. (PR: [#490](https://github.com/omise/omise-woocommerce/pull/490))
 

--- a/includes/gateway/class-omise-payment-googlepay.php
+++ b/includes/gateway/class-omise-payment-googlepay.php
@@ -219,7 +219,7 @@ class Omise_Payment_GooglePay extends Omise_Payment_Base_Card {
                         merchantId: '" . $this->googlepay_config['merchant_id'] . "',
                     },
                     transactionInfo: {
-                        totalPriceStatus: " . $this->googlepay_config['price_status'] . ",
+                        totalPriceStatus: '" . $this->googlepay_config['price_status'] . "',
                         currencyCode: '" . $this->googlepay_config['currency'] . "',
                     },
                 }

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Opn Payments
  * Plugin URI:  https://www.omise.co/woocommerce
  * Description: Opn Payments is a WordPress plugin designed specifically for WooCommerce. The plugin adds support for Opn Payments Payment Gateway's payment methods to WooCommerce.
- * Version:     6.0.2
+ * Version:     6.0.3
  * Author:      Opn Payments and contributors
  * Author URI:  https://github.com/omise/omise-woocommerce/graphs/contributors
  * Text Domain: omise
@@ -23,7 +23,7 @@ class Omise
 	 *
 	 * @var string
 	 */
-	public $version = '6.0.2';
+	public $version = '6.0.3';
 
 	/**
 	 * The Omise Instance.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Opn Payments
 Tags: opn payments, payment, payment gateway, woocommerce plugin, omise, opn, installment, internet banking, alipay, paynow, truemoney, woocommerce payment
 Requires at least: 4.3.1
 Tested up to: 6.6.2
-Stable tag: 6.0.2
+Stable tag: 6.0.3
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -33,6 +33,10 @@ From there:
 3. Opn Payments Checkout Form
 
 == Changelog ==
+
+= 6.0.3 =
+
+- Fix the issue of GooglePay not showing in shortcode. (PR: [#493](https://github.com/omise/omise-woocommerce/pull/493))
 
 = 6.0.2 =
 

--- a/tests/unit/includes/gateway/class-omise-payment-googlepay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-googlepay-test.php
@@ -129,7 +129,7 @@ class Omise_Payment_GooglePay_Test extends TestCase
                         merchantId: '',
                     },
                     transactionInfo: {
-                        totalPriceStatus: NOT_CURRENTLY_KNOWN,
+                        totalPriceStatus: 'NOT_CURRENTLY_KNOWN',
                         currencyCode: 'thb',
                     },
                 }


### PR DESCRIPTION
## Description

Release v6.0.3

**What's changed**
- Fix the issue of GooglePay not showing in shortcode. (PR: [#493](https://github.com/omise/omise-woocommerce/pull/493))

## Rollback procedure

`default rollback procedure`
