### PR TITLE
[APM-9272] Fix issue TrueMoney source type is missing

### DIFF
--- a/includes/gateway/class-omise-payment-truemoney.php
+++ b/includes/gateway/class-omise-payment-truemoney.php
@@ -33,7 +33,7 @@ class Omise_Payment_Truemoney extends Omise_Payment_Offsite
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );
 		$this->restricted_countries = array( 'TH' );
-		$this->source_type          = null;
+		$this->source_type          = $this->get_source();
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_api_' . $this->id . '_callback', 'Omise_Callback::execute' );

--- a/tests/unit/includes/gateway/class-omise-payment-truemoney-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-truemoney-test.php
@@ -29,6 +29,7 @@ class Omise_Payment_Truemoney_Test extends Omise_Offsite_Test
 
     public function test_get_charge_request()
     {
+        $this->omise_capability_mock->shouldReceive('retrieve')->once();
         // set source type to truemoney wallet
         $obj = new Omise_Payment_Truemoney();
         $obj->source_type = 'truemoney';


### PR DESCRIPTION
## Description

Fix the issue of TrueMoney source type is missing.

**Issue:**

![image](https://github.com/user-attachments/assets/694e288d-eb8b-46fc-ab6d-8c622a71514a)

**After fix:**

<img width="1347" alt="Screenshot 2025-01-13 at 10 06 03 AM" src="https://github.com/user-attachments/assets/654a039f-9473-4789-a4bf-49e0e24f192b" />

### Related links:

Task: https://opn-ooo.atlassian.net/browse/APM-9272
 
## Rollback procedure
 `default rollback procedure`
