### PR TITLE
Fix Github release workflow as latest ubuntu not install svn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Install SVN
+      run: |
+        sudo apt-get update
+        sudo apt-get install subversion
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
## Description

There was an error during Github publish release -> `svn: command not found`
<img width="1094" alt="Screenshot 2025-01-14 at 3 25 48 PM" src="https://github.com/user-attachments/assets/fe372e83-031d-407b-b204-497002adb1ae" />

After investigating, found that `ubuntu-latest` has no longer comes with SVN installed. And we need to add new step as followings in workflow refer to this [example](https://github.com/10up/action-wordpress-plugin-deploy/blob/develop/examples/deploy-on-pushing-a-new-tag.yml#L16C7-L19C40).



## Rollback procedure

`default rollback procedure`
