### PR TITLE
Fix TrueMoney OTP payment method is missing from checkout page.

### DIFF
--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -106,6 +106,18 @@ class Omise_Capabilities {
 				if (strpos($wp->request, $endpoint) === $len - strlen($endpoint)) {
 					return true;
 				}
+			} else {
+				$request_uri = $_SERVER['REQUEST_URI'];
+				$home_url = home_url();
+
+				$request_uri = strtok($request_uri, '?');
+				$home_url_path = rtrim(parse_url($home_url, PHP_URL_PATH), '/');
+				$path = trim(str_replace($home_url_path, '', $request_uri), '/');
+
+				$len = strlen($path);
+				if (strpos($path, $endpoint) === $len - strlen($endpoint)) {
+					return true;
+				}
 			}
 
 			if (isset($wp->query_vars['rest_route'])) {

--- a/tests/unit/includes/class-omise-capabilities-test.php
+++ b/tests/unit/includes/class-omise-capabilities-test.php
@@ -114,13 +114,20 @@ class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 	 * @dataProvider ajax_call_to_store_api_provider
 	 * @covers Omise_Capabilities
 	 */
-	public function test_ajax_call_to_store_api_calls_omise_capability_api($request, $query_vars, $expected)
+	public function test_ajax_call_to_store_api_calls_omise_capability_api($request, $query_vars, $server_request_uri, $expected)
 	{
-		if ($request || $query_vars) {
+		if ($request || $query_vars || $server_request_uri) {
 			$wp = new stdClass();
 			$wp->request = $request;
 			$wp->query_vars = $query_vars;
 			$GLOBALS['wp'] = $wp;
+		}
+		Brain\Monkey\Functions\expect('home_url')
+			->andReturn('/');
+
+		$_SERVER['REQUEST_URI'] = '/';
+		if ($server_request_uri) {
+			$_SERVER['REQUEST_URI'] = $server_request_uri;
 		}
 
 		$capabilities = new Omise_Capabilities;
@@ -131,11 +138,13 @@ class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 	public function ajax_call_to_store_api_provider()
 	{
 		return [
-			[null, null, false], // empty to test empty wp
-			['wp-json/wc/store/v1/batch', [], true],
-			['wp-json/wc/store/v1/batch', ['rest_route' => '/wc/store/v1/batch'], true],
-			['', ['rest_route' => '/wc/store/v1/batch'], true],
-			['', '', false]
+			[null, null, null, false], // empty to test empty wp
+			['wp-json/wc/store/v1/batch', [], null, true],
+			['wp-json/wc/store/v1/batch', ['rest_route' => '/wc/store/v1/batch'], null, true],
+			['', ['rest_route' => '/wc/store/v1/batch'], null, true],
+			['', '', '/other/checkout', true],
+			['', '', '/checkout/other', false],
+			['', '', '/checkout?ewe=323', true],
 		];
 	}
 }


### PR DESCRIPTION
## Description

Fix `TrueMoneyOTP` payment method is missing from checkout page.

**Root cause:** It did not call capability api for TrueMoney block ([code](https://github.com/omise/omise-woocommerce/blob/develop/includes/gateway/class-omise-payment-truemoney.php#L129C2-L141C1)) because `$wp->request` is empty, 
also `wp->query_vars['rest_route']` is null for Checkout page. Then, this only return default source as `TrueMoneyJumpApp`.

## Rollback procedure

`default rollback procedure`
