### PR TITLE
Fix TrueMoney not show up using short code for checkout

### DIFF
--- a/includes/class-omise-capabilities.php
+++ b/includes/class-omise-capabilities.php
@@ -98,6 +98,10 @@ class Omise_Capabilities {
 			return false;
 		}
 
+		if (wp_doing_ajax() && $_GET['wc-ajax'] == 'update_order_review') {
+			return true;
+		}
+		
 		$endpoints = ['checkout', 'batch', 'cart', 'cart/select-shipping-rate'];
 
 		foreach($endpoints as $endpoint) {

--- a/tests/unit/includes/class-omise-capabilities-test.php
+++ b/tests/unit/includes/class-omise-capabilities-test.php
@@ -124,6 +124,8 @@ class Omise_Capabilities_Test extends Bootstrap_Test_Setup
 		}
 		Brain\Monkey\Functions\expect('home_url')
 			->andReturn('/');
+		Brain\Monkey\Functions\expect('wp_doing_ajax')
+			->andReturn(false);
 
 		$_SERVER['REQUEST_URI'] = '/';
 		if ($server_request_uri) {


### PR DESCRIPTION
## Description

Fix TrueMoney not show up using short code for checkout.

<img width="917" alt="Screenshot 2025-01-15 at 3 48 28 PM" src="https://github.com/user-attachments/assets/559183a3-13f4-4585-8f4f-39c44149f76a" />

 
## Rollback procedure

`default rollback procedure`
