### PR TITLE
[MIT-3029][WooCommerce 9.5.0] Credit Card Form not showing up in WooCommerce Block

### DIFF
--- a/includes/blocks/gateways/omise-block-credit-card.php
+++ b/includes/blocks/gateways/omise-block-credit-card.php
@@ -54,7 +54,7 @@ class Omise_Block_Credit_Card extends AbstractPaymentMethodType {
             if (is_checkout()) {
                 wp_enqueue_script(
                     'embedded-js',
-                    plugins_url( '../../assets/javascripts/omise-embedded-card.js', __FILE__ ),
+                    plugins_url( '../../../assets/javascripts/omise-embedded-card.js', __FILE__ ),
                     ['omise-js'],
                     OMISE_WOOCOMMERCE_PLUGIN_VERSION,
                     true


### PR DESCRIPTION
## Description

Fix credit card form now showing up on WooCommerce 9.5.0

#### Issue:

The asset path is incorrect causing the site to not be able to load the script

<img width="400" alt="Screenshot 2025-03-07 at 2 33 41 PM" src="https://github.com/user-attachments/assets/c5a1ac8e-f49a-404d-aa6b-b3c707933bb7" />
<img width="400" alt="Screenshot 2025-03-07 at 2 33 41 PM" src="https://github.com/user-attachments/assets/77d99061-b8dc-43e7-a78c-7792e2ae7bf2" />

After fixing the path, the form is back to work. (Tested on WooCommerce 9.5.2 and 9.2.3)

<img width="400" alt="Screenshot 2025-03-07 at 2 33 41 PM" src="https://github.com/user-attachments/assets/5b363078-20cc-4c52-9eb5-cd11da43e568" />

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3092
 
## Rollback procedure

`default rollback procedure`
