### PR TITLE
Update deprecated github actions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Trigger Buildkite Pipeline & Deploy On Staging
         run: sh .github/workflows/trigger-buildkite-pipeline.sh ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -37,7 +37,7 @@ jobs:
       tag: ${{ steps.release-version.outputs.tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Get release version
       id: release-version
       run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -c 12-)
@@ -50,7 +50,7 @@ jobs:
     needs: [build, validate]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install SVN
       run: |
         sudo apt-get update


### PR DESCRIPTION
## Description

Upgrade Github Actions' version

- `actions/checkout@v2` -> `actions/checkout@v4`
- `actions/cache@v2` -> `actions/cache@v4`

## Decision(s)

actions/cache@v2 are deprecated since February 1st, 2025

<img width="500" alt="Screenshot 2025-03-17 at 1 22 36 PM" src="https://github.com/user-attachments/assets/917f8adb-ee2a-4b5b-9e5b-e69a2b613757" />
 
## Rollback procedure

`default rollback procedure`
