### PR TITLE
[MIT-3307] Fix mobile banking not working on Shortcode

### DIFF
--- a/templates/payment/form-mobilebanking.php
+++ b/templates/payment/form-mobilebanking.php
@@ -4,14 +4,14 @@
 			<?php foreach ( $viewData['mobile_banking_backends'] as $backend ) : ?>
 				<li class="item mobile-banking">
 					<div>
-						<input id="<?php echo $backend->_id; ?>" type="radio" name="omise-offsite" value="<?php echo $backend->_id; ?>" />
-						<label for="<?php echo $backend->_id; ?>">
+						<input id="<?php echo $backend->name; ?>" type="radio" name="omise-offsite" value="<?php echo $backend->name; ?>" />
+						<label for="<?php echo $backend->name; ?>">
 							<div class="mobile-banking-logo <?php echo $backend->provider_logo; ?>"></div>
 							<div class="mobile-banking-label">
 								<span class="title"><?php echo $backend->provider_name; ?></span><br/>
 							</div>
 						</label>
-					</div>	
+					</div>
 				</li>
 			<?php endforeach; ?>
 		</ul>


### PR DESCRIPTION
## Description

Fix mobile banking payment not working on Shortcode

### More information (if any)  

Need to update the Shortcode view to access the new properties - `name`

After update, the method is back to work.

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3307
- Related fix for Block - https://github.com/omise/omise-woocommerce/pull/518

## Rollback procedure

`default rollback procedure`
