### PR TITLE
[MIT-3307] Fix mobile banking not working on Shortcode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "phpunit/phpunit": "^5.7 || ^9.5",
         "mockery/mockery": "^1.6",
         "brain/monkey": "^2.6",
-        "woocommerce/woocommerce-blocks": "^11.7"
+        "woocommerce/woocommerce-blocks": "^11.7",
+        "voku/simple_html_dom": "^4.8"
     },
     "scripts": {
         "test": "vendor/bin/phpunit --testdox --colors",

--- a/templates/payment/form-mobilebanking.php
+++ b/templates/payment/form-mobilebanking.php
@@ -4,14 +4,14 @@
 			<?php foreach ( $viewData['mobile_banking_backends'] as $backend ) : ?>
 				<li class="item mobile-banking">
 					<div>
-						<input id="<?php echo $backend->_id; ?>" type="radio" name="omise-offsite" value="<?php echo $backend->_id; ?>" />
-						<label for="<?php echo $backend->_id; ?>">
+						<input id="<?php echo $backend->name; ?>" type="radio" name="omise-offsite" value="<?php echo $backend->name; ?>" />
+						<label for="<?php echo $backend->name; ?>">
 							<div class="mobile-banking-logo <?php echo $backend->provider_logo; ?>"></div>
 							<div class="mobile-banking-label">
 								<span class="title"><?php echo $backend->provider_name; ?></span><br/>
 							</div>
 						</label>
-					</div>	
+					</div>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/tests/unit/includes/class-omise-capability-test.php
+++ b/tests/unit/includes/class-omise-capability-test.php
@@ -391,7 +391,7 @@ class Omise_Capability_Test extends Bootstrap_Test_Setup
 		];
 	}
 
-	public function mockOmiseSetting($pkey, $skey)
+	protected function mockOmiseSetting($pkey, $skey)
 	{
 		$omiseSettingMock = Mockery::mock('alias:Omise_Setting');
 

--- a/tests/unit/includes/class-omise-capability-test.php
+++ b/tests/unit/includes/class-omise-capability-test.php
@@ -391,7 +391,7 @@ class Omise_Capability_Test extends Bootstrap_Test_Setup
 		];
 	}
 
-	private function mockOmiseSetting($pkey, $skey)
+	public function mockOmiseSetting($pkey, $skey)
 	{
 		$omiseSettingMock = Mockery::mock('alias:Omise_Setting');
 
@@ -404,38 +404,6 @@ class Omise_Capability_Test extends Bootstrap_Test_Setup
 
 	private function mockCapabilityRetrieve()
 	{
-		$this->mockOmiseSetting(['pkey_xxx'], skey: ['skey_xxx']);
-		$this->enableApiCall(true);
-
-		$omiseHttpExecutorMock = $this->mockOmiseHttpExecutor();
-		$omiseHttpExecutorMock
-			->shouldReceive('execute')
-			->once()
-			->andReturn(load_fixture('omise-capability-get'));
-	}
-
-	private function mockOmiseHttpExecutor()
-	{
-		require_once __DIR__ . '/../../../includes/libraries/omise-php/lib/omise/OmiseCapability.php';
-
-		return Mockery::mock('overload:' . OmiseHttpExecutor::class);
-	}
-
-	/**
-	 * Allow test to call the APIs
-	 * @param bool $isEnabled
-	 * @return void
-	 */
-	private function enableApiCall($isEnabled)
-	{
-		if (!$isEnabled) {
-			Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
-			Brain\Monkey\Functions\expect('is_checkout')->andReturn(false);
-			Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
-		} else {
-			Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
-			Brain\Monkey\Functions\expect('is_checkout')->andReturn(true);
-			Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
-		}
+		$this->mockApiCall('omise-capability-get');
 	}
 }

--- a/tests/unit/includes/gateway/bootstrap-test-setup.php
+++ b/tests/unit/includes/gateway/bootstrap-test-setup.php
@@ -105,5 +105,48 @@ abstract class Bootstrap_Test_Setup extends TestCase
         $this->assertEquals($expectedAmount, $result['amount']);
         $this->assertEquals($expectedCurrency, $result['currency']);
     }
+
+    protected function mockOmiseHttpExecutor()
+	{
+		require_once __DIR__ . '/../../../../includes/libraries/omise-php/lib/omise/OmiseCapability.php';
+
+		return Mockery::mock('overload:' . OmiseHttpExecutor::class);
+	}
+
+    protected function mockOmiseSetting($pkey, $skey)
+	{
+		$omiseSettingMock = Mockery::mock('alias:Omise_Setting');
+
+		$omiseSettingMock->shouldReceive('instance')->andReturn($omiseSettingMock);
+		$omiseSettingMock->shouldReceive('public_key')->andReturn($pkey);
+		$omiseSettingMock->shouldReceive('secret_key')->andReturn($skey);
+
+		return $omiseSettingMock;
+	}
+
+	protected function mockApiCall($fixture)
+	{
+		$this->mockOmiseSetting(['pkey_xxx'], skey: ['skey_xxx']);
+		$this->enableApiCall(true);
+
+		$omiseHttpExecutorMock = $this->mockOmiseHttpExecutor();
+		$omiseHttpExecutorMock
+			->shouldReceive('execute')
+			->once()
+			->andReturn(load_fixture($fixture));
+	}
+
+    protected function enableApiCall($isEnabled)
+	{
+		if (!$isEnabled) {
+			Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
+			Brain\Monkey\Functions\expect('is_checkout')->andReturn(false);
+			Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
+		} else {
+			Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
+			Brain\Monkey\Functions\expect('is_checkout')->andReturn(true);
+			Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
+		}
+	}
 }
 

--- a/tests/unit/includes/gateway/bootstrap-test-setup.php
+++ b/tests/unit/includes/gateway/bootstrap-test-setup.php
@@ -107,46 +107,46 @@ abstract class Bootstrap_Test_Setup extends TestCase
     }
 
     protected function mockOmiseHttpExecutor()
-	{
-		require_once __DIR__ . '/../../../../includes/libraries/omise-php/lib/omise/OmiseCapability.php';
+    {
+        require_once __DIR__ . '/../../../../includes/libraries/omise-php/lib/omise/OmiseCapability.php';
 
-		return Mockery::mock('overload:' . OmiseHttpExecutor::class);
-	}
+        return Mockery::mock('overload:' . OmiseHttpExecutor::class);
+    }
 
     protected function mockOmiseSetting($pkey, $skey)
-	{
-		$omiseSettingMock = Mockery::mock('alias:Omise_Setting');
+    {
+        $omiseSettingMock = Mockery::mock('alias:Omise_Setting');
 
-		$omiseSettingMock->shouldReceive('instance')->andReturn($omiseSettingMock);
-		$omiseSettingMock->shouldReceive('public_key')->andReturn($pkey);
-		$omiseSettingMock->shouldReceive('secret_key')->andReturn($skey);
+        $omiseSettingMock->shouldReceive('instance')->andReturn($omiseSettingMock);
+        $omiseSettingMock->shouldReceive('public_key')->andReturn($pkey);
+        $omiseSettingMock->shouldReceive('secret_key')->andReturn($skey);
 
-		return $omiseSettingMock;
-	}
+        return $omiseSettingMock;
+    }
 
-	protected function mockApiCall($fixture)
-	{
-		$this->mockOmiseSetting(['pkey_xxx'], skey: ['skey_xxx']);
-		$this->enableApiCall(true);
+    protected function mockApiCall($fixture)
+    {
+        $this->mockOmiseSetting(['pkey_xxx'], skey: ['skey_xxx']);
+        $this->enableApiCall(true);
 
-		$omiseHttpExecutorMock = $this->mockOmiseHttpExecutor();
-		$omiseHttpExecutorMock
-			->shouldReceive('execute')
-			->once()
-			->andReturn(load_fixture($fixture));
-	}
+        $omiseHttpExecutorMock = $this->mockOmiseHttpExecutor();
+        $omiseHttpExecutorMock
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturn(load_fixture($fixture));
+    }
 
     protected function enableApiCall($isEnabled)
-	{
-		if (!$isEnabled) {
-			Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
-			Brain\Monkey\Functions\expect('is_checkout')->andReturn(false);
-			Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
-		} else {
-			Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
-			Brain\Monkey\Functions\expect('is_checkout')->andReturn(true);
-			Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
-		}
-	}
+    {
+        if (!$isEnabled) {
+            Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
+            Brain\Monkey\Functions\expect('is_checkout')->andReturn(false);
+            Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
+        } else {
+            Brain\Monkey\Functions\expect('is_admin')->andReturn(false);
+            Brain\Monkey\Functions\expect('is_checkout')->andReturn(true);
+            Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
+        }
+    }
 }
 

--- a/tests/unit/includes/gateway/class-omise-offsite-test.php
+++ b/tests/unit/includes/gateway/class-omise-offsite-test.php
@@ -17,6 +17,7 @@ abstract class Omise_Offsite_Test extends Bootstrap_Test_Setup
         $offsite->shouldReceive('init_settings');
         $offsite->shouldReceive('get_option');
         $offsite->shouldReceive('get_provider');
+        $offsite->shouldReceive('payment_fields');
         $offsite->shouldReceive('public_key')
             ->andReturn('pkey_test_123');
         $offsite->shouldReceive('is_available')

--- a/tests/unit/includes/gateway/class-omise-payment-mobilebanking-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-mobilebanking-test.php
@@ -55,8 +55,6 @@ class Omise_Payment_Mobilebanking_Test extends Omise_Offsite_Test
         $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_kbank]'));
         $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_ktb]'));
         $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_scb]'));
-
-        $this->assertEquals('t', 't');
     }
 
     public function testCharge()

--- a/tests/unit/includes/gateway/class-omise-payment-mobilebanking-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-mobilebanking-test.php
@@ -2,24 +2,68 @@
 
 use Brain\Monkey;
 
+require_once __DIR__ . '/../../class-omise-unit-test.php';
 require_once __DIR__ . '/class-omise-offsite-test.php';
 
+use voku\helper\HtmlDomParser;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class Omise_Payment_Mobilebanking_Test extends Omise_Offsite_Test
 {
     protected function setUp(): void
     {
         parent::setUp();
+        // Capability API
+        require_once __DIR__ . '/../../../../includes/libraries/omise-php/lib/omise/res/obj/OmiseObject.php';
+        require_once __DIR__ . '/../../../../includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php';
+        require_once __DIR__ . '/../../../../includes/class-omise-capability.php';
+        // Mobile Banking Payment
+        require_once __DIR__ . '/../../../../includes/backends/class-omise-backend.php';
         require_once __DIR__ . '/../../../../includes/backends/class-omise-backend-mobile-banking.php';
         require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-mobilebanking.php';
+        require_once __DIR__ . '/../../../../omise-util.php';
+
+        Monkey\Functions\stubs([
+            'add_action' => true,
+            'wp_kses' => null,
+            'sanitize_text_field' => null,
+            'plugin_dir_path' => __DIR__ . '/../../../../',
+        ]);
+    }
+
+    public function testPaymentFieldsRendersMobileBankingForm()
+    {
+        ob_start();
+
+        $mobileBanking = new Omise_Payment_Mobilebanking();
+
+        Monkey\Functions\expect('get_woocommerce_currency')
+            ->andReturn('THB');
+        $this->mockApiCall('omise-capability-get');
+
+        $mobileBanking->payment_fields();
+        $output = ob_get_clean();
+        $page = HtmlDomParser::str_get_html($output);
+
+        $optionList = $page->find('.omise-banks-list .item');
+        $this->assertCount(5, $optionList);
+        $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_bay]'));
+        $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_bbl]'));
+        $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_kbank]'));
+        $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_ktb]'));
+        $this->assertNotFalse($optionList->findOneOrFalse('input[value=mobile_banking_scb]'));
+
+        $this->assertEquals('t', 't');
     }
 
     public function testCharge()
     {
         Monkey\Functions\expect('wc_get_user_agent')
-			->with('123')
-			->andReturn('Chrome Web');
-        Monkey\Functions\expect('wp_kses');
-        Monkey\Functions\expect('add_action');
+            ->with('123')
+            ->andReturn('Chrome Web');
         $_POST['omise-offsite'] = 'mobile_banking_bbl';
         $obj = new Omise_Payment_Mobilebanking();
         $this->getChargeTest($obj);

--- a/tests/unit/includes/gateway/class-omise-payment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-test.php
@@ -203,13 +203,9 @@ class Omise_Payment_Test extends Bootstrap_Test_Setup
     $this->assertEquals('Alipay_plus', $provider);
   }
 
-  private function mockOmiseSetting($pkey, $skey)
+  protected function mockOmiseSetting($pkey, $skey)
   {
-    $omiseSettingMock = Mockery::mock('alias:' . Omise_Setting::class);
-
-    $omiseSettingMock->shouldReceive('instance')->andReturn($omiseSettingMock);
-    $omiseSettingMock->shouldReceive('public_key')->andReturn($pkey);
-    $omiseSettingMock->shouldReceive('secret_key')->andReturn($skey);
+    $omiseSettingMock = parent::mockOmiseSetting($pkey, $skey);
     $omiseSettingMock->shouldReceive('get_settings')->andReturn([])->byDefault();
 
     return $omiseSettingMock;


### PR DESCRIPTION
## Description

Fix mobile banking payment not working on Shortcode

### More information (if any)  

Need to update the Shortcode view to access the new properties - `name`

After update, the method is back to work.

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3307
- Related fix for Block - https://github.com/omise/omise-woocommerce/pull/518

## Rollback procedure

`default rollback procedure`
