### PR TITLE
[MIT-3131] Fix PHP error when fetch capability

### DIFF
--- a/includes/class-omise-capability.php
+++ b/includes/class-omise-capability.php
@@ -97,27 +97,17 @@ class Omise_Capability {
 		if (!$wp) {
 			return false;
 		}
+
 		$ajaxActions = ['update_order_review', 'checkout'];
 		if (wp_doing_ajax() && in_array($_GET['wc-ajax'], $ajaxActions)) {
 			return true;
 		}
 
+		$path = self::getRequestPath();
 		$endpoints = ['checkout', 'batch', 'cart', 'cart/select-shipping-rate'];
 
 		foreach($endpoints as $endpoint) {
-			if (trim($wp->request) !== '') {
-				$len = strlen($wp->request);
-				if (strpos($wp->request, $endpoint) === $len - strlen($endpoint)) {
-					return true;
-				}
-			} else {
-				$request_uri = $_SERVER['REQUEST_URI'];
-				$home_url = home_url();
-
-				$request_uri = strtok($request_uri, '?');
-				$home_url_path = rtrim(parse_url($home_url, PHP_URL_PATH), '/');
-				$path = trim(str_replace($home_url_path, '', $request_uri), '/');
-
+			if ($path !== '') {
 				$len = strlen($path);
 				if (strpos($path, $endpoint) === $len - strlen($endpoint)) {
 					return true;
@@ -134,6 +124,28 @@ class Omise_Capability {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get current request path
+	 * It could be retrieve from `$wp->request`.
+	 * In case if it returns nothing, extract path from `$_SERVER['REQUEST_URI']` instead.
+	 *
+	 * @return string returns current path, otherwise empty string is returned if it can't be resolved.
+	 */
+	private static function getRequestPath()
+	{
+		global $wp;
+		$path = $wp ? trim($wp->request) : '';
+
+		if (empty($path)) {
+			$serverRequestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+			if (is_string($serverRequestPath)) {
+				$path = trim($serverRequestPath, '/');
+			}
+		}
+
+		return $path;
 	}
 
 	/**

--- a/includes/class-omise-capability.php
+++ b/includes/class-omise-capability.php
@@ -99,8 +99,9 @@ class Omise_Capability {
 		}
 
 		$ajaxActions = ['update_order_review', 'checkout'];
-		if (wp_doing_ajax() && in_array($_GET['wc-ajax'], $ajaxActions)) {
-			return true;
+		if (wp_doing_ajax()) {
+			$action = isset($_GET['wc-ajax']) ? $_GET['wc-ajax'] : '';
+			return in_array($action, $ajaxActions);
 		}
 
 		$path = self::getRequestPath();

--- a/includes/class-omise-capability.php
+++ b/includes/class-omise-capability.php
@@ -132,8 +132,8 @@ class Omise_Capability {
 
 	/**
 	 * Get current request path
-	 * It could be retrieve from `$wp->request`.
-	 * In case if it returns nothing, extract path from `$_SERVER['REQUEST_URI']` instead.
+	 * The current path can be retrieved from `$wp->request`.
+	 * In case if it returns nothing, extract the path from `$_SERVER['REQUEST_URI']` instead.
 	 *
 	 * @return string returns current path, otherwise empty string is returned if it can't be resolved.
 	 */

--- a/includes/class-omise-capability.php
+++ b/includes/class-omise-capability.php
@@ -98,13 +98,16 @@ class Omise_Capability {
 			return false;
 		}
 
+		/**
+		 * Check Ajax actions to handle the capability call on shortcode component.
+		 */
 		$ajaxActions = ['update_order_review', 'checkout'];
 		if (wp_doing_ajax()) {
 			$action = isset($_GET['wc-ajax']) ? $_GET['wc-ajax'] : '';
 			return in_array($action, $ajaxActions);
 		}
 
-		$path = self::getRequestPath();
+		$path = self::getRequestPath($wp);
 		$endpoints = ['checkout', 'batch', 'cart', 'cart/select-shipping-rate'];
 
 		foreach($endpoints as $endpoint) {
@@ -134,13 +137,13 @@ class Omise_Capability {
 	 *
 	 * @return string returns current path, otherwise empty string is returned if it can't be resolved.
 	 */
-	private static function getRequestPath()
+	private static function getRequestPath($wp)
 	{
-		global $wp;
-		$path = $wp ? trim($wp->request) : '';
+		$path = trim($wp->request);
 
 		if (empty($path)) {
 			$serverRequestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
 			if (is_string($serverRequestPath)) {
 				$path = trim($serverRequestPath, '/');
 			}

--- a/tests/unit/includes/class-omise-capability-test.php
+++ b/tests/unit/includes/class-omise-capability-test.php
@@ -352,10 +352,10 @@ class Omise_Capability_Test extends Bootstrap_Test_Setup
 	}
 
 	/**
-	 * @dataProvider ajax_call_to_store_api_provider
+	 * @dataProvider request_to_store_api_provider
 	 * @covers Omise_Capability
 	 */
-	public function test_ajax_call_to_store_api_calls_omise_capability_api($request, $query_vars, $server_request_uri, $expected)
+	public function test_request_to_store_api_calls_omise_capability_api($request, $query_vars, $server_request_uri, $expected)
 	{
 		if ($request || $query_vars || $server_request_uri) {
 			$wp = new stdClass();
@@ -363,8 +363,7 @@ class Omise_Capability_Test extends Bootstrap_Test_Setup
 			$wp->query_vars = $query_vars;
 			$GLOBALS['wp'] = $wp;
 		}
-		Brain\Monkey\Functions\expect('home_url')
-			->andReturn('/');
+
 		Brain\Monkey\Functions\expect('wp_doing_ajax')
 			->andReturn(false);
 
@@ -378,7 +377,7 @@ class Omise_Capability_Test extends Bootstrap_Test_Setup
 		$this->assertEquals($expected, $result);
 	}
 
-	public function ajax_call_to_store_api_provider()
+	public function request_to_store_api_provider()
 	{
 		return [
 			[null, null, null, false], // empty to test empty wp
@@ -388,6 +387,35 @@ class Omise_Capability_Test extends Bootstrap_Test_Setup
 			['', '', '/other/checkout', true],
 			['', '', '/checkout/other', false],
 			['', '', '/checkout?ewe=323', true],
+		];
+	}
+
+	/**
+	 * @dataProvider ajax_call_to_store_api_provider
+	 */
+	public function test_ajax_call_to_store_api_calls_omise_capability_api($query_vars, $expected)
+	{
+		$wp = new stdClass();
+		$GLOBALS['wp'] = $wp;
+		foreach ($query_vars as $key => $value) {
+			$_GET[$key] = $value;
+		}
+
+		Brain\Monkey\Functions\expect('wp_doing_ajax')
+			->andReturn(true);
+
+		$result = Omise_Capability::isFromCheckoutPage();
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function ajax_call_to_store_api_provider()
+	{
+		return [
+			[['wc-ajax' => 'update_order_review'], true],
+			[['wc-ajax' => 'checkout'], true],
+			[['wc-ajax' => 'remove_from_cart'], false],
+			[[], false],
 		];
 	}
 


### PR DESCRIPTION
## Description

Fix the errors when fetch capability
- Deprecated: rtrim(): Passing null to parameter `#1` ($string) of type string is deprecated
- Warning: Undefined array key `wc-ajax`

### More information

#### Deprecated: rtrim(): Passing null to parameter `#1` ($string) of type string is deprecated

This error occurs on **PHP 8.1**. In the previous version, it would be cast to empty string automatically.

Previously, we try to get the request path from `home_url`, which returned null since home is the root path.
Then, when we try to trim that null value, the error is thrown.

🛠️ Here we refactor a bit of how we get the current path and add a safe-check before doing trim. (Do not need to check home url since the check condition already check if the path ends with what we're looking for)

#### Warning: Undefined array key `wc-ajax`

There are other Ajax requests that are not sending `wc-ajax` query (`?wc-ajax=xxxx`).
For those, we just need to add a safe check before accessing the query.

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3131
- https://opn-ooo.atlassian.net/browse/MIT-3267

## Rollback procedure

`default rollback procedure`
