### PR TITLE
[MIT-3479] Fix payment form on Pay for Order page

### DIFF
--- a/assets/javascripts/omise-payment-atome.js
+++ b/assets/javascripts/omise-payment-atome.js
@@ -55,7 +55,7 @@
 	}
 
 	$(function () {
-		$('form.checkout, form#order_review').on('checkout_place_order', function (e) {
+		$('form.checkout, form#order_review').on('checkout_place_order', function () {
 			return omiseFormHandler();
 		});
 	})

--- a/assets/javascripts/omise-payment-atome.js
+++ b/assets/javascripts/omise-payment-atome.js
@@ -38,7 +38,7 @@
             }
 
             const phoneNumber = $('#omise_atome_phone_number').val();
-			
+
             if (!phoneNumber) {
                 return omiseHandleError('Phone number is required in Atome');
             }
@@ -55,7 +55,7 @@
 	}
 
 	$(function () {
-		$('form.checkout').on('checkout_place_order', function (e) {
+		$('form.checkout, form#order_review').on('checkout_place_order', function (e) {
 			return omiseFormHandler();
 		});
 	})

--- a/assets/javascripts/omise-payment-form-handler.js
+++ b/assets/javascripts/omise-payment-form-handler.js
@@ -1,5 +1,7 @@
 (function ($) {
 	const $form = $('form.checkout, form#order_review');
+	const $formCheckout = $('form.checkout'); // Form in Normal Checkout Page
+	const $formOrderReview = $('form#order_review'); // Form in Pay for Order Page
 
 	function hideError() {
 		$(".woocommerce-error").remove();
@@ -275,27 +277,34 @@
 			$('.omise_source').remove();
 		});
 
-		$('form.checkout').unbind('checkout_place_order_omise');
-		$('form.checkout').on('checkout_place_order_omise', function () {
+		$($formCheckout).unbind('checkout_place_order_omise');
+		$($formCheckout).on('checkout_place_order_omise', function () {
 			return omiseFormHandler();
 		});
-		$('form.checkout').unbind('checkout_place_order_omise_installment');
-		$('form.checkout').on('checkout_place_order_omise_installment', function () {
+		$($formCheckout).unbind('checkout_place_order_omise_installment');
+		$($formCheckout).on('checkout_place_order_omise_installment', function () {
 			return omiseInstallmentFormHandler();
 		});
 
-		/* Pay Page Form */
-		$('form#order_review').on('submit', function () {
-			return omiseFormHandler();
+		/* Pay for Order Page Form */
+		$($formOrderReview).on('submit', function () {
+			var selectedPaymentMethod = $('input[name="payment_method"]:checked').val();
+
+			switch (selectedPaymentMethod) {
+				case 'omise':
+					return omiseFormHandler();
+				case 'omise_installment':
+					return omiseInstallmentFormHandler();
+			}
 		});
 
 		/* Both Forms */
-		$('form.checkout, form#order_review').on('change', '#omise_cc_form input', function() {
+		$($form).on('change', '#omise_cc_form input', function() {
 			$('.omise_token').remove();
 			$('.omise_source').remove();
 		});
 
-		$('form.checkout').on('change', 'input[name="payment_method"]', function() {
+		$($form).on('change', 'input[name="payment_method"]', function() {
 			setupOmiseForm();
 		});
 

--- a/includes/gateway/abstract-omise-payment-offsite.php
+++ b/includes/gateway/abstract-omise-payment-offsite.php
@@ -13,6 +13,13 @@ abstract class Omise_Payment_Offsite extends Omise_Payment
 	/**
 	 * @inheritdoc
 	 */
+	public function payment_fields() {
+		parent::payment_fields();
+	}
+
+	/**
+	 * @inheritdoc
+	 */
 	public function result($order_id, $order, $charge)
 	{
 		if (self::STATUS_FAILED === $charge['status']) {

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -105,64 +105,64 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
         $cart = WC()->cart;
         $cart_subtotal = $cart->subtotal;
         $cart_total = $cart->total;
-        $cart_currency = strtolower(get_woocommerce_currency());
+        $cart_currency = strtolower( get_woocommerce_currency() );
 
         // For Pay for Order Page
-        if (is_checkout_pay_page()) {
+        if ( is_checkout_pay_page() ) {
             global $wp_query;
             $order_id = $wp_query->query_vars['order-pay'];
-            if (!$order_id) {
+            if ( ! $order_id ) {
                 return [
                     'status' => false,
-                    'message' => 'Invalid order ID.'
+                    'message' => 'Invalid order ID.',
                 ];
             }
-            $order = wc_get_order($order_id);
+            $order = wc_get_order( $order_id );
 
             $cart_subtotal = $order->get_subtotal();
             $cart_total = $order->get_total();
-            $cart_currency = strtolower($order->get_currency());
+            $cart_currency = strtolower( $order->get_currency() );
         }
 
-        if ($cart_subtotal === 0) {
+        if ( $cart_subtotal === 0 ) {
             return [
                 'status' => false,
-                'message' => 'Complimentary products cannot be billed.'
+                'message' => 'Complimentary products cannot be billed.',
             ];
         }
 
-        if (!isset($limits[$cart_currency])) {
+        if ( ! isset( $limits[ $cart_currency ] ) ) {
             return [
                 'status' => false,
-                'message' => 'Currency not supported'
+                'message' => 'Currency not supported',
             ];
         }
 
-        $limit = $limits[$cart_currency];
+        $limit = $limits[ $cart_currency ];
 
-        if ($cart_total < $limit['min']) {
+        if ( $cart_total < $limit['min'] ) {
             return [
                 'status' => false,
                 'message' => sprintf(
-                    "Amount must be greater than %u %s",
-                    number_format($limit['min'], 2),
-                    strtoupper($cart_currency)
-                )
+                    'Amount must be greater than %u %s',
+                    number_format( $limit['min'], 2 ),
+                    strtoupper($cart_currency),
+                ),
             ];
         }
 
-        if ($cart_total > $limit['max']) {
+        if ( $cart_total > $limit['max'] ) {
             return [
                 'status' => false,
                 'message' => sprintf(
                     'Amount must be less than %1 %2',
-                    number_format($limit['max'], 2),
-                    strtoupper($cart_currency)
-                )
+                    number_format( $limit['max'], 2 ),
+                    strtoupper( $cart_currency ),
+                ),
             ];
         }
 
-        return ['status' => true];
+        return [ 'status' => true ];
     }
 
     /**
@@ -194,6 +194,8 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             'shipping' => $this->getAddress($order),
             'items' => $this->getItems($order, $order->get_currency())
 		]);
+
+        error_log(print_r($requestData, true));
 
         return $requestData;
     }

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -111,13 +111,10 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
         if ( is_checkout_pay_page() ) {
             global $wp_query;
             $order_id = $wp_query->query_vars['order-pay'];
-            if ( ! $order_id ) {
-                return [
-                    'status' => false,
-                    'message' => 'Invalid order ID.',
-                ];
-            }
             $order = wc_get_order( $order_id );
+            if ( ! $order ) {
+                throw new Exception( 'Order not found.' );
+            }
 
             $cart_subtotal = $order->get_subtotal();
             $cart_total = $order->get_total();
@@ -144,7 +141,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             return [
                 'status' => false,
                 'message' => sprintf(
-                    'Amount must be greater than %u %s',
+                    'Amount must be greater than %s %s',
                     number_format( $limit['min'], 2 ),
                     strtoupper($cart_currency),
                 ),
@@ -155,7 +152,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             return [
                 'status' => false,
                 'message' => sprintf(
-                    'Amount must be less than %1 %2',
+                    'Amount must be less than %s %s',
                     number_format( $limit['max'], 2 ),
                     strtoupper( $cart_currency ),
                 ),

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -109,8 +109,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
 
         // For Pay for Order Page
         if ( is_checkout_pay_page() ) {
-            global $wp_query;
-            $order_id = $wp_query->query_vars['order-pay'];
+            $order_id = get_query_var('order-pay');
             $order = wc_get_order( $order_id );
             if ( ! $order ) {
                 throw new Exception( 'Order not found.' );

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -102,43 +102,62 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             ]
         ];
 
-        $currency = strtolower(get_woocommerce_currency());
         $cart = WC()->cart;
+        $cart_subtotal = $cart->subtotal;
+        $cart_total = $cart->total;
+        $cart_currency = strtolower(get_woocommerce_currency());
 
-        if ($cart->subtotal === 0) {
+        // For Pay for Order Page
+        if (is_checkout_pay_page()) {
+            global $wp_query;
+            $order_id = $wp_query->query_vars['order-pay'];
+            if (!$order_id) {
+                return [
+                    'status' => false,
+                    'message' => 'Invalid order ID.'
+                ];
+            }
+            $order = wc_get_order($order_id);
+
+            $cart_subtotal = $order->get_subtotal();
+            $cart_total = $order->get_total();
+            $cart_currency = strtolower($order->get_currency());
+        }
+
+        if ($cart_subtotal === 0) {
             return [
                 'status' => false,
                 'message' => 'Complimentary products cannot be billed.'
             ];
         }
 
-        if (!isset($limits[$currency])) {
+        if (!isset($limits[$cart_currency])) {
             return [
                 'status' => false,
                 'message' => 'Currency not supported'
             ];
         }
 
-        $limit = $limits[$currency];
+        $limit = $limits[$cart_currency];
 
-        if ($cart->total < $limit['min']) {
+        if ($cart_total < $limit['min']) {
             return [
                 'status' => false,
                 'message' => sprintf(
                     "Amount must be greater than %u %s",
                     number_format($limit['min'], 2),
-                    strtoupper($currency)
+                    strtoupper($cart_currency)
                 )
             ];
         }
 
-        if ($cart->total > $limit['max']) {
+        if ($cart_total > $limit['max']) {
             return [
                 'status' => false,
-                'message' => __(
+                'message' => sprintf(
                     'Amount must be less than %1 %2',
                     number_format($limit['max'], 2),
-                    strtoupper($currency)
+                    strtoupper($cart_currency)
                 )
             ];
         }
@@ -163,7 +182,7 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
 			$this->source_type,
 			$this->id . "_callback"
 		);
-        
+
         $default_phone_selected = isset($_POST['omise_atome_phone_default']) ?
             $_POST['omise_atome_phone_default']
             : false;

--- a/includes/gateway/class-omise-payment-atome.php
+++ b/includes/gateway/class-omise-payment-atome.php
@@ -195,8 +195,6 @@ class Omise_Payment_Atome extends Omise_Payment_Offsite
             'items' => $this->getItems($order, $order->get_currency())
 		]);
 
-        error_log(print_r($requestData, true));
-
         return $requestData;
     }
 

--- a/includes/gateway/class-omise-payment.php
+++ b/includes/gateway/class-omise-payment.php
@@ -116,6 +116,13 @@ abstract class Omise_Payment extends WC_Payment_Gateway {
     }
 
     /**
+     * Displayed payment fields.
+     */
+    public function payment_fields() {
+        parent::payment_fields();
+    }
+
+    /**
      * Protect the metadata that is included in the return URI. The token is used to
      * validate the session for the order.
      *

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.1/phpunit.xsd"
 	backupGlobals="true"
 	backupStaticAttributes="false"
+	bootstrap="tests/unit/bootstrap.php"
 	colors="true"
 	stopOnError="false"
 	stopOnFailure="false"

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,0 +1,74 @@
+<?php
+
+define( 'ABSPATH', '' );
+define( 'WC_VERSION', '1.0.0' );
+define( 'OMISE_PUBLIC_KEY', 'pkey_test_12345' );
+define( 'OMISE_SECRET_KEY', 'skey_test_12345' );
+
+/**
+ * Mock abstract WooCommerce's gateway
+ */
+abstract class WC_Payment_Gateway {
+
+	public static $is_available = true;
+
+	public function is_available() {
+		return self::$is_available;
+	}
+}
+
+/**
+ * Temporary mock for WP_* class
+ * In the future, we should move to use WP_UnitTestCase
+ */
+class WP_Error {
+
+	public function __construct(
+		public $code = '',
+		public $message = '',
+		public $data = ''
+	) {
+	}
+}
+class WP_REST_Server_Stub {
+
+	const EDITABLE = 'POST';
+	const READABLE = 'GET';
+}
+
+const PLUGIN_PATH = __DIR__ . '/../..';
+
+// Omise WooCommerce
+// FIXME: Start including payment gateway here for better test organization.
+// In the future, we can move to PSR-4 autoloading.
+require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/charge.php';
+require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/wc_order.php';
+require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/mailer.php';
+require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/request.php';
+require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/token.php';
+require_once PLUGIN_PATH . '/includes/class-omise-ajax-actions.php';
+require_once PLUGIN_PATH . '/includes/class-omise-callback.php';
+require_once PLUGIN_PATH . '/includes/class-omise-events.php';
+require_once PLUGIN_PATH . '/includes/class-omise-localization.php';
+require_once PLUGIN_PATH . '/includes/class-omise-money.php';
+require_once PLUGIN_PATH . '/includes/class-omise-payment-factory.php';
+require_once PLUGIN_PATH . '/includes/class-omise-rest-webhooks-controller.php';
+require_once PLUGIN_PATH . '/includes/class-omise-wc-myaccount.php';
+require_once PLUGIN_PATH . '/omise-util.php';
+// Exclude classes that might conflict with test `alias` mocks.
+// To avoid this, we might need to refactor actual classes or tests to remove existing alias mocks.
+// require_once PLUGIN_PATH . '/includes/class-omise-setting.php';
+// require_once PLUGIN_PATH . '/includes/class-omise-capability.php';
+// require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/WcOrderNote.php';
+// require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/RedirectUrl.php';
+// require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/file_get_contents_wrapper.php';
+
+// Omise PHP
+require_once PLUGIN_PATH . '/includes/libraries/omise-php/lib/omise/res/obj/OmiseObject.php';
+require_once PLUGIN_PATH . '/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php';
+
+// Test helpers
+require_once __DIR__ . '/class-omise-test-case.php';
+require_once __DIR__ . '/class-omise-unit-test.php';
+require_once __DIR__ . '/class-omise-util-test.php';
+require_once __DIR__ . '/includes/gateway/class-omise-offsite-test.php';

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -15,6 +15,8 @@ abstract class WC_Payment_Gateway {
 	public function is_available() {
 		return self::$is_available;
 	}
+
+	public function payment_fields() {}
 }
 
 /**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -38,9 +38,12 @@ class WP_REST_Server_Stub {
 
 const PLUGIN_PATH = __DIR__ . '/../..';
 
-// Omise WooCommerce
-// FIXME: Start including payment gateway here for better test organization.
+// ========================//
+// == Omise WooCommerce == //
+// ======================= //
+// FIXME: Start including payment gateway classes here for better test organization.
 // In the future, we can move to PSR-4 autoloading.
+// Helpers
 require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/charge.php';
 require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/wc_order.php';
 require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/mailer.php';
@@ -63,12 +66,24 @@ require_once PLUGIN_PATH . '/omise-util.php';
 // require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/RedirectUrl.php';
 // require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/file_get_contents_wrapper.php';
 
-// Omise PHP
+// =============== //
+// == Omise PHP == //
+// =============== //
 require_once PLUGIN_PATH . '/includes/libraries/omise-php/lib/omise/res/obj/OmiseObject.php';
 require_once PLUGIN_PATH . '/includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php';
 
-// Test helpers
+// ================== //
+// == Test Helpers == //
+// ================== //
 require_once __DIR__ . '/class-omise-test-case.php';
 require_once __DIR__ . '/class-omise-unit-test.php';
 require_once __DIR__ . '/class-omise-util-test.php';
 require_once __DIR__ . '/includes/gateway/class-omise-offsite-test.php';
+require_once __DIR__ . '/includes/gateway/abstract-omise-payment-offsite-test.php';
+
+function load_plugin() {
+	// This function is used to load the plugin in the test environment.
+	// It can be used to set up any necessary configurations or initializations.
+	// For example, you might want to set up mock functions or load specific classes.
+	require_once PLUGIN_PATH . '/omise-woocommerce.php';
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -44,7 +44,7 @@ const PLUGIN_PATH = __DIR__ . '/../..';
 // == Omise WooCommerce == //
 // ======================= //
 // FIXME: Start including payment gateway classes here for better test organization.
-// In the future, we can move to PSR-4 autoloading.
+// In the future, we can check if it is possible to use autoloader.
 // Helpers
 require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/charge.php';
 require_once PLUGIN_PATH . '/includes/libraries/omise-plugin/helpers/wc_order.php';

--- a/tests/unit/class-omise-test-case.php
+++ b/tests/unit/class-omise-test-case.php
@@ -12,5 +12,6 @@ abstract class Omise_Test_Case extends TestCase {
 	protected function tearDown(): void {
 		Brain\Monkey\tearDown();
 		Mockery::close();
+		parent::tearDown();
 	}
 }

--- a/tests/unit/class-omise-test-case.php
+++ b/tests/unit/class-omise-test-case.php
@@ -1,0 +1,16 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+abstract class Omise_Test_Case extends TestCase {
+	use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Brain\Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Brain\Monkey\tearDown();
+		Mockery::close();
+	}
+}

--- a/tests/unit/class-omise-unit-test.php
+++ b/tests/unit/class-omise-unit-test.php
@@ -26,6 +26,16 @@ function _x( $text, $context, $domain = 'default' ) {
 	return $text;
 }
 
+/**
+ * Mock WordPress _e() function.
+ *
+ * @see wp-includes/l10n.php
+ * @see https://developer.wordpress.org/reference/functions/_e
+ */
+function _e( $text, $context, $domain = 'default' ) {
+	echo $text;
+}
+
 function load_fixture($name) {
 	return file_get_contents(__DIR__ . "/../fixtures/{$name}.json");
 }

--- a/tests/unit/class-omise-unit-test.php
+++ b/tests/unit/class-omise-unit-test.php
@@ -1,9 +1,5 @@
 <?php
 
-define( 'ABSPATH', value: '' );
-define( 'OMISE_PUBLIC_KEY', 'pkey_test_12345');
-define( 'OMISE_SECRET_KEY', 'skey_test_12345');
-
 class Omise_Unit_Test {
 	public static function include_class( $path ): void {
 		require_once __DIR__ . '/../../includes/' . $path;

--- a/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
+++ b/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
@@ -27,6 +27,7 @@ abstract class Omise_Payment_Offsite_Test extends Bootstrap_Test_Setup {
 				'wp_kses',
 				'plugins_url',
 				'add_action',
+				'plugin_dir_path' => __DIR__ . '/../../../../',
 			]
 		);
 
@@ -35,7 +36,7 @@ abstract class Omise_Payment_Offsite_Test extends Bootstrap_Test_Setup {
 		load_plugin();
 	}
 
-	public function testCharge( $instance ) {
+	public function performChargeTest( $instance ) {
 		$expected_amount = 999999;
 		$expected_currency = 'thb';
 

--- a/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
+++ b/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
@@ -6,7 +6,7 @@ use Brain\Monkey;
 
 abstract class Omise_Payment_Offsite_Test extends Bootstrap_Test_Setup {
 
-	public $sourceType;
+	protected $return_uri = 'https://abc.com/order/complete';
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -31,39 +31,35 @@ abstract class Omise_Payment_Offsite_Test extends Bootstrap_Test_Setup {
 		);
 
 		$this->mockOmiseSetting( 'pkey_xxx', 'skey_xxx' );
-		$this->mockRedirectUrl( 'https://abc.com/order/complete' );
+		$this->mockRedirectUrl( $this->return_uri );
 		load_plugin();
 	}
 
-	// TODO: Update this test steps
-	public function getChargeTest( $classObj ) {
-		$expectedAmount = 999999;
-		$expectedCurrency = 'thb';
+	public function testCharge( $instance ) {
+		$expected_amount = 999999;
+		$expected_currency = 'thb';
 
-		Monkey\Functions\expect( 'wc_clean' )->andReturn( $expectedAmount );
-
-		$expectedRequest = [
+		$charge = [
 			'object' => 'charge',
 			'id' => 'chrg_test_no1t4tnemucod0e51mo',
 			'location' => '/charges/chrg_test_no1t4tnemucod0e51mo',
-			'amount' => $expectedAmount,
-			'currency' => $expectedCurrency,
+			'amount' => $expected_amount,
+			'currency' => $expected_currency,
 		];
+		$order = $this->getOrderMock( $expected_amount, $expected_currency );
 
 		// Create a mock for OmiseCharge
-		$chargeMock = Mockery::mock( 'overload:OmiseCharge' );
-		$chargeMock->shouldReceive( 'create' )->once()->andReturn( $expectedRequest );
+		$charge_api_mock = Mockery::mock( 'overload:OmiseCharge' );
+		$charge_api_mock->shouldReceive( 'create' )->once()->andReturn( $charge );
 
-		$orderMock = $this->getOrderMock( $expectedAmount, $expectedCurrency );
-
-		$wcProduct = Mockery::mock( 'overload:WC_Product' );
-		$wcProduct->shouldReceive( 'get_sku' )
+		// Create a mock for WC_Product
+		$wc_product = Mockery::mock( 'overload:WC_Product' );
+		$wc_product->shouldReceive( 'get_sku' )
 			->once()
 			->andReturn( 'sku_1234' );
 
-		$orderId = 'order_123';
-		$result = $classObj->charge( $orderId, $orderMock );
-		$this->assertEquals( $expectedAmount, $result['amount'] );
-		$this->assertEquals( $expectedCurrency, $result['currency'] );
+		$result = $instance->charge( 'order_123', $order );
+
+		$this->assertEquals( $charge, $result );
 	}
 }

--- a/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
+++ b/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
@@ -1,0 +1,69 @@
+<?php
+
+require_once __DIR__ . '/bootstrap-test-setup.php';
+
+use Brain\Monkey;
+
+abstract class Omise_Payment_Offsite_Test extends Bootstrap_Test_Setup {
+
+	public $sourceType;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		/**
+		 * FIXME: After all offsite tests are moved to use this class:
+		 *  * Move this to the bootstrap.php file.
+		 *  * Remove @runTestsInSeparateProcesses from all offsite tests.
+		 */
+		require_once __DIR__ . '/../../../../includes/gateway/traits/charge-request-builder-trait.php';
+		require_once __DIR__ . '/../../../../includes/gateway/traits/sync-order-trait.php';
+		require_once __DIR__ . '/../../../../includes/gateway/abstract-omise-payment-offsite.php';
+		require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-atome.php';
+
+		Monkey\Functions\stubs(
+			[
+				'wp_enqueue_script',
+				'wp_kses',
+				'plugins_url',
+				'add_action',
+			]
+		);
+
+		$this->mockOmiseSetting( 'pkey_xxx', 'skey_xxx' );
+		$this->mockRedirectUrl( 'https://abc.com/order/complete' );
+		load_plugin();
+	}
+
+	// TODO: Update this test steps
+	public function getChargeTest( $classObj ) {
+		$expectedAmount = 999999;
+		$expectedCurrency = 'thb';
+
+		Monkey\Functions\expect( 'wc_clean' )->andReturn( $expectedAmount );
+
+		$expectedRequest = [
+			'object' => 'charge',
+			'id' => 'chrg_test_no1t4tnemucod0e51mo',
+			'location' => '/charges/chrg_test_no1t4tnemucod0e51mo',
+			'amount' => $expectedAmount,
+			'currency' => $expectedCurrency,
+		];
+
+		// Create a mock for OmiseCharge
+		$chargeMock = Mockery::mock( 'overload:OmiseCharge' );
+		$chargeMock->shouldReceive( 'create' )->once()->andReturn( $expectedRequest );
+
+		$orderMock = $this->getOrderMock( $expectedAmount, $expectedCurrency );
+
+		$wcProduct = Mockery::mock( 'overload:WC_Product' );
+		$wcProduct->shouldReceive( 'get_sku' )
+			->once()
+			->andReturn( 'sku_1234' );
+
+		$orderId = 'order_123';
+		$result = $classObj->charge( $orderId, $orderMock );
+		$this->assertEquals( $expectedAmount, $result['amount'] );
+		$this->assertEquals( $expectedCurrency, $result['currency'] );
+	}
+}

--- a/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
+++ b/tests/unit/includes/gateway/abstract-omise-payment-offsite-test.php
@@ -27,6 +27,7 @@ abstract class Omise_Payment_Offsite_Test extends Bootstrap_Test_Setup {
 				'wp_kses',
 				'plugins_url',
 				'add_action',
+        'sanitize_text_field' => null,
 				'plugin_dir_path' => __DIR__ . '/../../../../',
 			]
 		);
@@ -36,7 +37,7 @@ abstract class Omise_Payment_Offsite_Test extends Bootstrap_Test_Setup {
 		load_plugin();
 	}
 
-	public function performChargeTest( $instance ) {
+	public function perform_charge_test( $instance ) {
 		$expected_amount = 999999;
 		$expected_currency = 'thb';
 

--- a/tests/unit/includes/gateway/bootstrap-test-setup.php
+++ b/tests/unit/includes/gateway/bootstrap-test-setup.php
@@ -1,64 +1,6 @@
 <?php
-
-use PHPUnit\Framework\TestCase;
-use Brain\Monkey;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
-/**
- * Mock abstract WooCommerce's gateway
- */
-abstract class WC_Payment_Gateway
+abstract class Bootstrap_Test_Setup extends Omise_Test_Case
 {
-    public static $is_available = true;
-
-    public function is_available()
-    {
-        return self::$is_available;
-    }
-}
-
-/**
- * Temporary mock for WP_* class
- * In the future, we should move to use WP_UnitTestCase
- */
-class WP_Error
-{
-    public function __construct(
-        public $code = '',
-        public $message = '',
-        public $data = ''
-    ) {
-    }
-}
-class WP_REST_Server_Stub
-{
-    const EDITABLE = 'POST';
-    const READABLE = 'GET';
-}
-
-abstract class Bootstrap_Test_Setup extends TestCase
-{
-    // Adds Mockery expectations to the PHPUnit assertions count.
-    use MockeryPHPUnitIntegration;
-
-    public $sourceType;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        Monkey\setUp();
-    }
-
-    /**
-     * close mockery after tests are done
-     */
-    protected function tearDown(): void
-    {
-        Monkey\tearDown();
-        Mockery::close();
-        parent::tearDown();
-    }
-
     public function getOrderMock($expectedAmount, $expectedCurrency)
     {
         // Create a mock of the $order object

--- a/tests/unit/includes/gateway/bootstrap-test-setup.php
+++ b/tests/unit/includes/gateway/bootstrap-test-setup.php
@@ -83,6 +83,7 @@ abstract class Bootstrap_Test_Setup extends Omise_Test_Case
             'instance' => $omiseSettingMock,
             'public_key' => $pkey,
             'secret_key' => $skey,
+            'is_dynamic_webhook_enabled' => false,
         ]);
         $omiseSettingMock->shouldReceive('get_settings')->andReturn([])->byDefault();
 
@@ -125,6 +126,14 @@ abstract class Bootstrap_Test_Setup extends Omise_Test_Case
             Brain\Monkey\Functions\expect('is_checkout')->andReturn(true);
             Brain\Monkey\Functions\expect('is_wc_endpoint_url')->andReturn(false);
         }
+    }
+
+    protected function mockRedirectUrl($redirectUrl = 'https://abc.com/order/complete') {
+        $redirectUrlMock = Mockery::mock('alias:RedirectUrl');
+        $redirectUrlMock->shouldReceive('create')->andReturn($redirectUrl);
+        $redirectUrlMock->shouldReceive('getToken')->andReturn('token123');
+
+        return $redirectUrlMock;
     }
 }
 

--- a/tests/unit/includes/gateway/bootstrap-test-setup.php
+++ b/tests/unit/includes/gateway/bootstrap-test-setup.php
@@ -35,7 +35,24 @@ abstract class Bootstrap_Test_Setup extends Omise_Test_Case
         return $orderMock;
     }
 
+    public function getCartMock($cartProperties = []) {
+        $cart = Mockery::mock('WC_Cart');
+        $cart->subtotal = $cartProperties['subtotal'] ?? 0;
+        $cart->total = $cartProperties['total'] ?? 0;
+
+        return $cart;
+    }
+
+    public function getWcMock($cart = null) {
+        $wc = Mockery::mock('WooCommerce');
+        $wc->cart = $cart ? $cart : $this->getCartMock();
+
+        return $wc;
+    }
+
     /**
+     * FIXME: Only used in Omise_Payment_Konbini_Test.
+     * We can refactor this into offline payment test class or the test itself.
      * @runInSeparateProcess
      */
     public function getChargeTest($classObj)

--- a/tests/unit/includes/gateway/class-omise-offsite-test.php
+++ b/tests/unit/includes/gateway/class-omise-offsite-test.php
@@ -4,6 +4,9 @@ require_once __DIR__ . '/bootstrap-test-setup.php';
 
 use Brain\Monkey;
 
+/**
+ * @deprecated Please use Omise_Payment_Offsite_Test instead.
+ */
 abstract class Omise_Offsite_Test extends Bootstrap_Test_Setup
 {
     public $sourceType;

--- a/tests/unit/includes/gateway/class-omise-payment-atome-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-atome-test.php
@@ -1,5 +1,8 @@
 <?php
 
+use Brain\Monkey;
+use voku\helper\HtmlDomParser;
+
 /**
  * @runTestsInSeparateProcesses
  */
@@ -43,18 +46,18 @@ class Omise_Payment_Atome_Test extends Omise_Payment_Offsite_Test {
 			'items' => [
 				[
 					'name' => 'T Shirt',
-          'amount' => 60000,
-          'quantity' => 1,
+					'amount' => 60000,
+					'quantity' => 1,
 					'sku' => 'sku_1234',
-				]
+				],
 			],
 			'shipping' => [
 				'country' => 'Thailand',
 				'city' => 'Bangkok',
 				'postal_code' => '10110',
 				'state' => 'Bangkok',
-				'street1' => 'Sukumvit Road'
-			]
+				'street1' => 'Sukumvit Road',
+			],
 		];
 		$this->assertEquals( $expected_source, $result['source'] );
 	}
@@ -62,6 +65,147 @@ class Omise_Payment_Atome_Test extends Omise_Payment_Offsite_Test {
 	public function test_atome_charge() {
 		$_POST['omise_atome_phone_default'] = true;
 
-		$this->testCharge( $this->omise_atome );
+		$this->performChargeTest( $this->omise_atome );
+	}
+
+	public function test_atome_payment_fields_renders_atome_form_on_checkout_page() {
+		$cart = $this->getCartMock(
+			[
+				'subtotal' => 300,
+				'total' => 380,
+			]
+		);
+		$wc = $this->getWcMock( $cart );
+
+		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
+		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'THB' );
+		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( false );
+
+		ob_start();
+		$this->omise_atome->payment_fields();
+		$output = ob_get_clean();
+
+		$page = HtmlDomParser::str_get_html( $output );
+		$this->assertMatchesRegularExpression( '/Atome phone number/', $page->findOne( '#omise-form-atome' )->innertext );
+	}
+
+	public function test_atome_payment_fields_renders_atome_form_on_pay_for_order_page() {
+		$wc = $this->getWcMock();
+		$order_mock = $this->getOrderMock( 380, 'THB' );
+		$order_mock->shouldReceive( 'get_subtotal' )->andReturn( 300 );
+
+		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
+		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'THB' );
+		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( true );
+		Monkey\Functions\expect( 'wc_get_order' )->with( 456 )->andReturn( $order_mock );
+
+		$wp_query = new stdClass();
+		$wp_query->query_vars = [ 'order-pay' => 456 ];
+		$GLOBALS['wp_query'] = $wp_query;
+
+		ob_start();
+		$this->omise_atome->payment_fields();
+		$output = ob_get_clean();
+
+		$page = HtmlDomParser::str_get_html( $output );
+		$this->assertMatchesRegularExpression( '/Atome phone number/', $page->findOne( '#omise-form-atome' )->innertext );
+	}
+
+	public function test_atome_payment_fields_returns_error_if_subtotal_is_zero() {
+		$cart = $this->getCartMock(
+			[
+				'subtotal' => 0,
+				'total' => 100,
+			]
+		);
+		$wc = $this->getWcMock( $cart );
+
+		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
+		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'THB' );
+		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( false );
+
+		ob_start();
+		$this->omise_atome->payment_fields();
+		$output = ob_get_clean();
+
+		$this->assertEquals( 'Complimentary products cannot be billed.', trim( $output ) );
+	}
+
+	public function test_atome_payment_fields_returns_error_if_currency_not_support() {
+		$cart = $this->getCartMock(
+			[
+				'subtotal' => 100,
+				'total' => 100,
+			]
+		);
+		$wc = $this->getWcMock( $cart );
+
+		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
+		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'USD' );
+		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( false );
+
+		ob_start();
+		$this->omise_atome->payment_fields();
+		$output = ob_get_clean();
+
+		$this->assertEquals( 'Currency not supported', trim( $output ) );
+	}
+
+	public function test_atome_payment_fields_returns_error_if_amount_less_than_min_limit() {
+		$cart = $this->getCartMock(
+			[
+				'subtotal' => 1.4,
+				'total' => 1.4,
+			]
+		);
+		$wc = $this->getWcMock( $cart );
+
+		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
+		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'SGD' );
+		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( false );
+
+		ob_start();
+		$this->omise_atome->payment_fields();
+		$output = ob_get_clean();
+
+		$this->assertEquals( 'Amount must be greater than 1.50 SGD', trim( $output ) );
+	}
+
+	public function test_atome_payment_fields_returns_error_if_amount_greater_than_max_limit() {
+		$cart = $this->getCartMock(
+			[
+				'subtotal' => 20001,
+				'total' => 20001,
+			]
+		);
+		$wc = $this->getWcMock( $cart );
+
+		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
+		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'SGD' );
+		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( false );
+
+		ob_start();
+		$this->omise_atome->payment_fields();
+		$output = ob_get_clean();
+
+		$this->assertEquals( 'Amount must be less than 20,000.00 SGD', trim( $output ) );
+	}
+
+	public function test_atome_payment_fields_throws_exception_if_pay_for_order_not_found() {
+		$wc = $this->getWcMock();
+
+		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
+		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'THB' );
+		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( true );
+		Monkey\Functions\expect( 'wc_get_order' )->with( 456 )->andReturn( false );
+
+		$wp_query = new stdClass();
+		$wp_query->query_vars = [ 'order-pay' => 456 ];
+		$GLOBALS['wp_query'] = $wp_query;
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Order not found.' );
+
+		$this->omise_atome->payment_fields();
 	}
 }

--- a/tests/unit/includes/gateway/class-omise-payment-atome-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-atome-test.php
@@ -119,11 +119,8 @@ class Omise_Payment_Atome_Test extends Omise_Payment_Offsite_Test {
 		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
 		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'THB' );
 		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( true );
+		Monkey\Functions\expect( 'get_query_var' )->with( 'order-pay' )->andReturn( 456 );
 		Monkey\Functions\expect( 'wc_get_order' )->with( 456 )->andReturn( $order_mock );
-
-		$wp_query = new stdClass();
-		$wp_query->query_vars = [ 'order-pay' => 456 ];
-		$GLOBALS['wp_query'] = $wp_query;
 
 		ob_start();
 		$this->omise_atome->payment_fields();
@@ -219,11 +216,8 @@ class Omise_Payment_Atome_Test extends Omise_Payment_Offsite_Test {
 		Monkey\Functions\expect( 'WC' )->andReturn( $wc );
 		Monkey\Functions\expect( 'get_woocommerce_currency' )->andReturn( 'THB' );
 		Monkey\Functions\expect( 'is_checkout_pay_page' )->andReturn( true );
+		Monkey\Functions\expect( 'get_query_var' )->with( 'order-pay' )->andReturn( 456 );
 		Monkey\Functions\expect( 'wc_get_order' )->with( 456 )->andReturn( false );
-
-		$wp_query = new stdClass();
-		$wp_query->query_vars = [ 'order-pay' => 456 ];
-		$GLOBALS['wp_query'] = $wp_query;
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Order not found.' );

--- a/tests/unit/includes/gateway/class-omise-payment-atome-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-atome-test.php
@@ -1,52 +1,44 @@
 <?php
 
-require_once __DIR__ . '/class-omise-offsite-test.php';
+/**
+ * @runTestsInSeparateProcesses
+ */
+class Omise_Payment_Atome_Test extends Omise_Payment_Offsite_Test {
 
-use Brain\Monkey;
+	private $omise_atome;
 
-class Omise_Payment_Atome_Test extends Omise_Offsite_Test
-{
-    protected function setUp(): void
-    {
-        $this->sourceType = 'atome';
-        parent::setUp();
-        require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-atome.php';
+	protected function setUp(): void {
+		$this->sourceType = 'atome';
+		parent::setUp();
 
-        Monkey\Functions\expect('wp_enqueue_script');
-        Monkey\Functions\expect('wp_kses');
-        Monkey\Functions\expect('plugins_url');
-        Monkey\Functions\expect('add_action');
+		$this->omise_atome = Mockery::mock( Omise_Payment_Atome::class )->makePartial();
+		$this->omise_atome->shouldReceive( 'init_settings' );
+		$this->omise_atome->shouldReceive( 'get_option' );
+		$this->omise_atome->__construct();
+	}
 
-        // dummy version
-        if (!defined('WC_VERSION')) {
-            define('WC_VERSION', '1.0.0');
-        }
-    }
+	public function test_atome_get_charge_request() {
+		$expectedAmount = 999999;
+		$expectedCurrency = 'thb';
+		$orderId = 'order_123';
+		$orderMock = $this->getOrderMock( $expectedAmount, $expectedCurrency );
 
-    public function testGetChargeRequest()
-    {
-        $expectedAmount = 999999;
-        $expectedCurrency = 'thb';
-        $orderId = 'order_123';
-        $orderMock = $this->getOrderMock($expectedAmount, $expectedCurrency);
+		$wcProduct = Mockery::mock( 'overload:WC_Product' );
+		$wcProduct->shouldReceive( 'get_sku' )
+			->once()
+			->andReturn( 'sku_1234' );
 
-        $wcProduct = Mockery::mock('overload:WC_Product');
-        $wcProduct->shouldReceive('get_sku')
-            ->once()
-            ->andReturn('sku_1234');
+		$_POST['omise_atome_phone_default'] = true;
 
-        $_POST['omise_atome_phone_default'] = true;
+		$result = $this->omise_atome->get_charge_request( $orderId, $orderMock );
 
-        $obj = new Omise_Payment_Atome();
-        $result = $obj->get_charge_request($orderId, $orderMock);
+		// TODO: Update this assertion
+		$this->assertEquals( $this->sourceType, $result['source']['type'] );
+	}
 
-        $this->assertEquals($this->sourceType, $result['source']['type']);
-    }
-
-    public function testCharge()
-    {
-        $_POST['omise_atome_phone_default'] = true;
-        $obj = new Omise_Payment_Atome();
-        $this->getChargeTest($obj);
-    }
+	public function test_atome_charge() {
+		$_POST['omise_atome_phone_default'] = true;
+		$obj = new Omise_Payment_Atome();
+		$this->getChargeTest( $obj );
+	}
 }

--- a/tests/unit/includes/gateway/class-omise-payment-atome-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-atome-test.php
@@ -62,10 +62,32 @@ class Omise_Payment_Atome_Test extends Omise_Payment_Offsite_Test {
 		$this->assertEquals( $expected_source, $result['source'] );
 	}
 
+	public function test_atome_get_charge_request_with_custom_phone_number() {
+		$order_amount = 4566;
+		$order_currency = 'thb';
+		$order_id = 'order_123';
+		$order_mock = $this->getOrderMock( $order_amount, $order_currency );
+
+		$wc_product = Mockery::mock( 'overload:WC_Product' );
+		$wc_product->shouldReceive( 'get_sku' )
+			->once()
+			->andReturn( 'sku_1234' );
+
+		$_POST['omise_atome_phone_default'] = false;
+		$_POST['omise_atome_phone_number'] = '+66123456789';
+
+		$result = $this->omise_atome->get_charge_request( $order_id, $order_mock );
+
+		$this->assertEquals( 456600, $result['amount'] );
+		$this->assertEquals( $order_currency, $result['currency'] );
+		$this->assertEquals( 'atome', $result['source']['type'] );
+		$this->assertEquals( '+66123456789', $result['source']['phone_number'] );
+	}
+
 	public function test_atome_charge() {
 		$_POST['omise_atome_phone_default'] = true;
 
-		$this->performChargeTest( $this->omise_atome );
+		$this->perform_charge_test( $this->omise_atome );
 	}
 
 	public function test_atome_payment_fields_renders_atome_form_on_checkout_page() {

--- a/tests/unit/includes/gateway/class-omise-payment-atome-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-atome-test.php
@@ -18,27 +18,50 @@ class Omise_Payment_Atome_Test extends Omise_Payment_Offsite_Test {
 	}
 
 	public function test_atome_get_charge_request() {
-		$expectedAmount = 999999;
-		$expectedCurrency = 'thb';
-		$orderId = 'order_123';
-		$orderMock = $this->getOrderMock( $expectedAmount, $expectedCurrency );
+		$order_amount = 4566;
+		$order_currency = 'thb';
+		$order_id = 'order_123';
+		$order_mock = $this->getOrderMock( $order_amount, $order_currency );
 
-		$wcProduct = Mockery::mock( 'overload:WC_Product' );
-		$wcProduct->shouldReceive( 'get_sku' )
+		$wc_product = Mockery::mock( 'overload:WC_Product' );
+		$wc_product->shouldReceive( 'get_sku' )
 			->once()
 			->andReturn( 'sku_1234' );
 
 		$_POST['omise_atome_phone_default'] = true;
 
-		$result = $this->omise_atome->get_charge_request( $orderId, $orderMock );
+		$result = $this->omise_atome->get_charge_request( $order_id, $order_mock );
 
-		// TODO: Update this assertion
-		$this->assertEquals( $this->sourceType, $result['source']['type'] );
+		$this->assertEquals( 456600, $result['amount'] );
+		$this->assertEquals( $order_currency, $result['currency'] );
+		$this->assertEquals( $order_id, $result['metadata']['order_id'] );
+		$this->assertEquals( $this->return_uri, $result['return_uri'] );
+
+		$expected_source = [
+			'type' => 'atome',
+			'phone_number' => $order_mock->get_billing_phone(),
+			'items' => [
+				[
+					'name' => 'T Shirt',
+          'amount' => 60000,
+          'quantity' => 1,
+					'sku' => 'sku_1234',
+				]
+			],
+			'shipping' => [
+				'country' => 'Thailand',
+				'city' => 'Bangkok',
+				'postal_code' => '10110',
+				'state' => 'Bangkok',
+				'street1' => 'Sukumvit Road'
+			]
+		];
+		$this->assertEquals( $expected_source, $result['source'] );
 	}
 
 	public function test_atome_charge() {
 		$_POST['omise_atome_phone_default'] = true;
-		$obj = new Omise_Payment_Atome();
-		$this->getChargeTest( $obj );
+
+		$this->testCharge( $this->omise_atome );
 	}
 }

--- a/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
@@ -7,7 +7,6 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
     public $mockOrder;
     public $mockWcDateTime;
     public $mockLocalizeScript;
-    public $mockOmisePluginHelper;
     public $mockOmisePaymentOffline;
     public $mockOmiseCharge;
     public $mockFileGetContent;
@@ -22,7 +21,6 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
         $this->mockOrder = Mockery::mock();
         $this->mockLocalizeScript = Mockery::mock();
         $this->mockWcDateTime = Mockery::mock('overload:WC_DateTime');
-        $this->mockOmisePluginHelper = Mockery::mock('overload:OmisePluginHelperWcOrder')->shouldIgnoreMissing();
         $this->mockOmisePaymentOffline = Mockery::mock('overload:Omise_Payment_Offline');
         $this->mockOmiseCharge = Mockery::mock('overload:OmiseCharge');
         $this->mockFileGetContent = Mockery::mock('overload:File_Get_Contents_Wrapper');
@@ -77,6 +75,11 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
         function wp_localize_script($scriptName, $object, $params) {
             return $GLOBALS['mock_wp_localize_script']->call($scriptName, $object, $params);
         }
+
+        Monkey\Functions\when('wc_get_order')->justReturn($this->mockOrder);
+        $this->mockOrder->shouldReceive('get_order_key')
+            ->once()
+            ->andReturn('wc_order_12345');
 
         $obj = new Omise_Payment_Promptpay();
         $result = $obj->display_qrcode($this->mockOrder, 'view');


### PR DESCRIPTION
## Description

Fix payment method form on [Pay for Order page](https://woocommerce.com/document/managing-orders/paying-for-orders/)

### More information 

Previously the customer might face the issue where the payment form is not loaded on the Pay for Order page. The JS form we currently have and was revisited in this PR are:
  - Credit card
  - installment
  - Atome

With this PR, the customer should now see the form properly on Pay for Order Page.

https://github.com/user-attachments/assets/5a002d84-effc-4b1d-ba2c-0fd7469f7e8e

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3387
- https://opn-ooo.atlassian.net/browse/MIT-3479 - 📝 Proof of work in the ticket 

## Rollback procedure

`default rollback procedure`
