### PR TITLE
[MIT-3444][MC TAS] Add Passkey in the plugin settings

### DIFF
--- a/includes/blocks/gateways/omise-block-credit-card.php
+++ b/includes/blocks/gateways/omise-block-credit-card.php
@@ -95,6 +95,7 @@ class Omise_Block_Credit_Card extends AbstractPaymentMethodType {
             'locale'      => get_locale(),
             'public_key'  => Omise_Setting::instance()->public_key(),
             'is_active'   => $this->is_active(),
+            'is_passkey_enabled' => wc_string_to_bool($this->get_setting( 'is_passkey_enabled', 'no' )),
         ]);
     }
 }

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -42,6 +42,20 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 	 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
 	 */
 	function init_form_fields() {
+		$passkey_settings = array();
+
+		if (getenv('OMISE_FEATURE_PASSKEY') === 'true') {
+			$passkey_settings = array(
+				'is_passkey_enabled' => array(
+					'title'       => __( 'Authentication', 'omise' ),
+					'type'        => 'checkbox',
+					'label'       => __( 'Enable Passkey Authentication', 'omise' ),
+					'default'     => 'no',
+					'description' => __( 'This option will enable Passkey authentication for card payments on checkout page when available.', 'omise' ),
+				),
+			);
+		}
+
 		$this->form_fields = array_merge(
 			array(
 				'enabled' => array(
@@ -63,15 +77,8 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 					'type'        => 'textarea',
 					'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
 				),
-
-				'is_passkey_enabled' => array(
-					'title'       => __( 'Authentication', 'omise' ),
-					'type'        => 'checkbox',
-					'label'       => __( 'Enable Passkey Authentication', 'omise' ),
-					'default'     => 'no',
-					'description' => __( 'This option will enable Passkey authentication for card payments on checkout page when available.', 'omise' ),
-				),
 			),
+			$passkey_settings,
 			array(
 				'advanced' => array(
 					'title'       => __( 'Advanced Settings', 'omise' ),

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -65,7 +65,7 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 				),
 
 				'is_passkey_enabled' => array(
-					'title'			 => __( 'Authentication', 'omise' ),
+					'title'       => __( 'Authentication', 'omise' ),
 					'type'        => 'checkbox',
 					'label'       => __( 'Enable Passkey Authentication', 'omise' ),
 					'default'     => 'no',

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -44,7 +44,7 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 	function init_form_fields() {
 		$passkey_settings = array();
 
-		if (defined('OMISE_FEATURE_PASSKEY') && OMISE_FEATURE_PASSKEY) {
+		if (defined('OMISE_FEATURE_PASSKEY') && OMISE_FEATURE_PASSKEY === true) {
 			$passkey_settings = array(
 				'is_passkey_enabled' => array(
 					'title'       => __( 'Authentication', 'omise' ),

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -63,6 +63,14 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 					'type'        => 'textarea',
 					'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
 				),
+
+				'is_passkey_enabled' => array(
+					'title'			 => __( 'Authentication', 'omise' ),
+					'type'        => 'checkbox',
+					'label'       => __( 'Enable Passkey Authentication', 'omise' ),
+					'default'     => 'no',
+					'description' => __( 'This option will enable Passkey authentication for card payments on checkout page when available.', 'omise' ),
+				),
 			),
 			array(
 				'advanced' => array(

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -44,7 +44,7 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 	function init_form_fields() {
 		$passkey_settings = array();
 
-		if (getenv('OMISE_FEATURE_PASSKEY') === 'true') {
+		if (defined('OMISE_FEATURE_PASSKEY') && OMISE_FEATURE_PASSKEY) {
 			$passkey_settings = array(
 				'is_passkey_enabled' => array(
 					'title'       => __( 'Authentication', 'omise' ),

--- a/includes/gateway/class-omise-payment-installment.php
+++ b/includes/gateway/class-omise-payment-installment.php
@@ -132,10 +132,14 @@ class Omise_Payment_Installment extends Omise_Payment_Offsite
 		$requestData['source'] = isset($_POST['omise_source']) ? wc_clean($_POST['omise_source']) : '';
 		$requestData['card'] = isset($_POST['omise_token']) ? wc_clean($_POST['omise_token']) : '';
 
-		$custom_wlb_desc = getenv('OMISE_CUSTOM_WLB_ORDER_DESC');
-		if (!empty($custom_wlb_desc) && !empty($requestData['card'])) {
-			$custom_wlb_desc = sanitize_text_field($custom_wlb_desc);
-			$requestData['description'] = str_replace('{description}', $requestData['description'], $custom_wlb_desc);
+		// Use OMISE_CUSTOM_WLB_ORDER_DESC to define the custom order description.
+		// '{description}' can be used as a placeholder for the original order description.
+		if (defined('OMISE_CUSTOM_WLB_ORDER_DESC') && !empty(OMISE_CUSTOM_WLB_ORDER_DESC) && !empty($requestData['card'])) {
+			$requestData['description'] = str_replace(
+				'{description}',
+				$requestData['description'],
+				sanitize_text_field(OMISE_CUSTOM_WLB_ORDER_DESC)
+			);
 		}
 
 		return OmiseCharge::create($requestData);

--- a/omise-util.php
+++ b/omise-util.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Omise_Util' ) ) {
 			if ( preg_match( "/(Android)/i", $userAgent ) ) {
 				return "ANDROID";
 			}
-			
+
 			if ( preg_match( "/(iPad|iPhone|iPod)/i", $userAgent ) ) {
 				return 'IOS';
 			}

--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -351,7 +351,7 @@ class Omise
 	 *                  with WooCommerce's order id together in a
 	 *                  customed-post-type, 'omise_charge_items'.
 	 *
-	 *                  Since Omise-WooCoomerce v3.0, now the plugin stores
+	 *                  Since Omise-WooCommerce v3.0, now the plugin stores
 	 *                  Omise's charge id as a 'customed-post-meta' in the
 	 *                  WooCommerce's 'order' post-type instead.
 	 */

--- a/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
+++ b/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
@@ -51,8 +51,8 @@ class Omise_Block_Credit_Card_Test extends Omise_Test_Case {
 			);
 
 		$this->obj->initialize();
-
 		$is_active = $this->obj->is_active();
+
 		$this->assertTrue( $is_active );
 	}
 

--- a/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
+++ b/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
@@ -1,107 +1,134 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Brain\Monkey;
 
 require_once __DIR__ . '/traits/mock-gateways.php';
 
-class Omise_Block_Credit_Card_Test extends TestCase
-{
-    // Adds Mockery expectations to the PHPUnit assertions count.
-    use MockeryPHPUnitIntegration, MockPaymentGateways;
+class Omise_Block_Credit_Card_Test extends Omise_Test_Case {
+	use MockPaymentGateways;
 
-    public $obj;
+	public $obj;
 
-    protected $omiseSettingMock;
+	protected $omise_setting_mock;
 
-    // @runInSeparateProcess
-    protected function setUp() : void
-    {
-        parent::setUp();
-        $this->mockWcGateways();
-        require_once __DIR__ . '/../../../../../includes/blocks/gateways/omise-block-credit-card.php';
-        $this->omiseSettingMock = Mockery::mock('alias:Omise_Setting');
-        $this->obj = new Omise_Block_Credit_Card;
-    }
+	protected function setUp(): void {
+		parent::setUp();
+		$this->mockWcGateways();
+		require_once __DIR__ . '/../../../../../includes/blocks/gateways/omise-block-credit-card.php';
+		$this->omise_setting_mock = Mockery::mock( 'alias:Omise_Setting' );
+		$this->obj = new Omise_Block_Credit_Card();
 
-    /**
-     * @test
-     */
-    public function initialize()
-    {
-        Monkey\Functions\expect('get_option')->andReturn(null);
+		Monkey\Functions\stubs(
+			[
+				'wc_string_to_bool' => function ( $val ) {
+					return $val === 'yes' ? true : false;
+				},
+			]
+		);
+	}
 
-        $this->obj->initialize();
+	public function test_initialize() {
+		Monkey\Functions\expect( 'get_option' )->andReturn( null );
 
-        $reflection = new \ReflectionClass($this->obj);
-        $gateway_property = $reflection->getProperty('gateway');
-        $gateway_property->setAccessible(true);
-        $gateway_val = $gateway_property->getValue($this->obj);
+		$this->obj->initialize();
 
-        $this->assertEquals('object', gettype($gateway_val));
-    }
+		$reflection = new \ReflectionClass( $this->obj );
+		$gateway_property = $reflection->getProperty( 'gateway' );
+		$gateway_property->setAccessible( true );
+		$gateway_val = $gateway_property->getValue( $this->obj );
 
-    /**
-     * @test
-     */ 
-    public function is_active()
-    {
-        Monkey\Functions\expect('wc_string_to_bool')->andReturn(true);
-        $this->obj->initialize();
+		$this->assertEquals( 'object', gettype( $gateway_val ) );
+	}
 
-        $is_active = $this->obj->is_active();
-        $this->assertTrue($is_active);
-    }
+	public function test_is_active() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'woocommerce_omise_settings', [] )
+			->andReturn(
+				[
+					'enabled' => 'yes',
+				]
+			);
 
-    /**
-     * @test
-     */
-    public function get_payment_method_data()
-    {
-        // Calling initialize() to set $gateway value
-        $reflection = new \ReflectionClass($this->obj);
-        $name_property = $reflection->getProperty('name');
-        $name_property->setAccessible(true);
-        $name_property->setValue($this->obj, 'omise');
+		$this->obj->initialize();
 
-        if (!defined('OMISE_WOOCOMMERCE_PLUGIN_VERSION')) {
-            define('OMISE_WOOCOMMERCE_PLUGIN_VERSION', '9.1.0');
-        }
+		$is_active = $this->obj->is_active();
+		$this->assertTrue( $is_active );
+	}
 
-        Monkey\Functions\expect('wc_string_to_bool');
-        Monkey\Functions\expect('get_locale')->andReturn('thb');
+	public function test_get_payment_method_data() {
+		$mock_settings = [
+			'title' => 'Credit Card',
+			'description' => 'This is Credit Card payment method.',
+			'enabled' => 'yes',
+			'is_passkey_enabled' => 'no',
+		];
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'woocommerce_omise_settings', [] )
+			->andReturn( $mock_settings );
+		Monkey\Functions\expect( 'get_locale' )->andReturn( 'th' );
+		$this->omise_setting_mock->shouldReceive( 'instance' )->andReturn( $this->omise_setting_mock );
+		$this->omise_setting_mock->shouldReceive( 'public_key' )->andReturn( 'pkey_xxx' );
 
-        $this->omiseSettingMock->shouldReceive('instance')->andReturn($this->omiseSettingMock);
-		$this->omiseSettingMock->shouldReceive('public_key')->andReturn('pkey_xxx');
+		$this->obj->initialize();
+		$data = $this->obj->get_payment_method_data();
 
-        $this->obj->initialize();
+		$this->assertEquals( 'omise', $data['name'] );
+		$this->assertEquals( $mock_settings['title'], $data['title'] );
+		$this->assertEquals( $mock_settings['description'], $data['description'] );
+		$this->assertEquals( 'array', gettype( $data['features'] ) );
+		$this->assertEquals( 'th', $data['locale'] );
+		$this->assertEquals( 'pkey_xxx', $data['public_key'] );
+		$this->assertEquals( true, $data['is_active'] );
+		$this->assertEquals( false, $data['is_passkey_enabled'] );
+	}
 
-        $data = $this->obj->get_payment_method_data();
+	public function test_get_payment_method_script_handles() {
+		if ( ! defined( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION' ) ) {
+			define( 'OMISE_WOOCOMMERCE_PLUGIN_VERSION', '9.1.0' );
+		}
 
-        $this->assertArrayHasKey('title', $data);
-        $this->assertArrayHasKey('description', $data);
-        $this->assertArrayHasKey('features', $data);
-        $this->assertEquals('array', gettype($data['features']));
-        $this->assertEquals('omise', $data['name']);
-    }
+		Monkey\Functions\stubs(
+			[
+				'plugins_url' => null,
+				'plugin_dir_url' => '',
+				'is_checkout' => true,
+			]
+		);
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'woocommerce_omise_settings', [] )
+			->andReturn(
+				[
+					'enabled' => 'yes',
+				]
+			);
+		// Expect the scripts are enqueued correctly.
+		Monkey\Functions\expect( 'wp_enqueue_script' )
+			->once()
+			->with(
+				'embedded-js',
+				'../../../assets/javascripts/omise-embedded-card.js',
+				[ 'omise-js' ],
+				'9.1.0',
+				true
+			);
+		Monkey\Functions\expect( 'wp_enqueue_script' )
+			->once()
+			->with(
+				'omise-payments-blocks',
+				'assets/js/build/credit_card.js',
+				// The dependencies are defined in the actual script.
+				// We just want to make sure 'embedded-js' is included.
+				Mockery::contains( 'embedded-js' ),
+				Mockery::any(),
+				true
+			);
 
-    /**
-     * @test
-     */
-    public function get_payment_method_script_handles()
-    {
-        Monkey\Functions\expect('wp_script_is');
-        Monkey\Functions\expect('wp_enqueue_script');
-        Monkey\Functions\expect('plugin_dir_url');
-        Monkey\Functions\expect('plugins_url');
-        Monkey\Functions\expect('is_checkout')->andReturn(true);
-        Monkey\Functions\expect('wc_string_to_bool')->andReturn(null);
+		$this->obj->initialize();
+		$result = $this->obj->get_payment_method_script_handles();
 
-        $this->obj->initialize();
-
-        $result = $this->obj->get_payment_method_script_handles();
-
-        $this->assertEquals([ 'omise-payments-blocks' ], $result);
-    }
+		$this->assertEquals( [ 'omise-payments-blocks' ], $result );
+	}
 }

--- a/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
+++ b/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
@@ -21,7 +21,7 @@ class Omise_Block_Credit_Card_Test extends Omise_Test_Case {
 		Monkey\Functions\stubs(
 			[
 				'wc_string_to_bool' => function ( $val ) {
-					return $val === 'yes' ? true : false;
+					return $val === 'yes';
 				},
 			]
 		);

--- a/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
@@ -107,6 +107,33 @@ class Omise_Payment_CreditCard_Test extends TestCase
         $this->assertArrayHasKey('user_logged_in', $data);
     }
 
+    public function test_form_fields() {
+        $credit_card = new Omise_Payment_Creditcard;
+
+        $this->assertEquals([
+            'enabled',
+            'title',
+            'description',
+            'advanced',
+            'payment_action',
+            'card_form_theme',
+            'accept_visa',
+            'accept_mastercard',
+            'accept_jcb',
+            'accept_diners',
+            'accept_discover',
+            'accept_amex',
+        ], array_keys($credit_card->form_fields));
+    }
+
+    public function test_form_fields_include_passkey_setting_when_passkey_feature_is_enabled() {
+        putenv('OMISE_FEATURE_PASSKEY=true');
+
+        $credit_card = new Omise_Payment_Creditcard;
+
+        $this->assertArrayHasKey('is_passkey_enabled', $credit_card->form_fields);
+    }
+
     public function get_existing_cards_for_user_not_logged_in() {
         Monkey\Functions\expect('is_user_logged_in')->andReturn(false);
 

--- a/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
@@ -127,7 +127,7 @@ class Omise_Payment_CreditCard_Test extends TestCase
     }
 
     public function test_form_fields_include_passkey_setting_when_passkey_feature_is_enabled() {
-        putenv('OMISE_FEATURE_PASSKEY=true');
+        define('OMISE_FEATURE_PASSKEY', true);
 
         $credit_card = new Omise_Payment_Creditcard;
 

--- a/tests/unit/includes/gateway/class-omise-payment-installment-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-installment-test.php
@@ -54,7 +54,7 @@ class Omise_Payment_Installment_Test extends Omise_Payment_Offsite_Test
 
     public function test_installment_charge()
     {
-        putenv('OMISE_CUSTOM_WLB_ORDER_DESC=test');
+        define('OMISE_CUSTOM_WLB_ORDER_DESC', 'test');
 
         $order = $this->getOrderMock(4353, 'THB', [ 'id' => 1293 ]);
         $_POST['omise_source'] = 'source_test_12345';
@@ -78,8 +78,6 @@ class Omise_Payment_Installment_Test extends Omise_Payment_Offsite_Test
 
     public function test_installment_wlb_charge()
     {
-        putenv('OMISE_CUSTOM_WLB_ORDER_DESC');
-
         $order = $this->getOrderMock(250.5, 'THB', [ 'id' => 400 ]);
         $_POST['omise_source'] = 'source_test_12345';
         $_POST['omise_token'] = 'tokn_test_67890';
@@ -103,7 +101,7 @@ class Omise_Payment_Installment_Test extends Omise_Payment_Offsite_Test
 
     public function test_installment_wlb_charge_with_custom_description()
     {
-        putenv('OMISE_CUSTOM_WLB_ORDER_DESC={description} - test');
+        define('OMISE_CUSTOM_WLB_ORDER_DESC', '{description} - test');
 
         $order = $this->getOrderMock(250.5, 'THB', [ 'id' => 400 ]);
         $_POST['omise_source'] = 'source_test_12345';
@@ -118,7 +116,7 @@ class Omise_Payment_Installment_Test extends Omise_Payment_Offsite_Test
 
     public function test_installment_wlb_charge_with_custom_description_fully_overridden()
     {
-        putenv('OMISE_CUSTOM_WLB_ORDER_DESC=My order description');
+        define('OMISE_CUSTOM_WLB_ORDER_DESC', 'My order description');
 
         $order = $this->getOrderMock(250.5, 'THB', [ 'id' => 400 ]);
         $_POST['omise_source'] = 'source_test_12345';


### PR DESCRIPTION
## Description

- Add a checkbox to enable passkey in the plugin settings
- Pass the settings to the view

<img width="500" height="525" alt="Screenshot 2025-09-01 at 4 17 23 PM" src="https://github.com/user-attachments/assets/3ce19f1d-45ae-46ac-990c-b128b7c1be4d" />

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3444

## Decision(s)

- We're no longer maintain WC ShortCode, Here the change will be only on WC Block. To use this feature, please use Block.
 
## Rollback procedure

`default rollback procedure`
