### PR TITLE
[MIT-3538] Display actual Paynow QR expiration

### DIFF
--- a/assets/css/omise-css.css
+++ b/assets/css/omise-css.css
@@ -97,6 +97,7 @@ fieldset.card-exists,
  * Omise PayNow
  */
 .omise-paynow-details {
+	margin-top: 3em;
 	margin-bottom: 4em;
 	text-align: center;
 }

--- a/assets/javascripts/omise-countdown.js
+++ b/assets/javascripts/omise-countdown.js
@@ -16,7 +16,7 @@
     }
 
     function updateCountdown(fromInterval = true) {
-        const countdownDisplay = document.getElementById('countdown');
+        const countdownDisplay = document.getElementById(omise.countdown_id);
         if(!countdownDisplay) {
             return;
         }

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -122,7 +122,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 					'get_order_status_url' => $get_order_status_url,
 					'qrcode' => $qrcode,
 					'qrcode_id' => $qrcode_id,
-					'is_qrcode_expired' => $is_qrcode_expired === true ? 'true' : 'false',
+					'is_qrcode_expired' => $is_qrcode_expired ? 'true' : 'false',
 				)
 			);
 		} elseif ( 'email' === $context && ! $order->has_status( 'failed' ) ) { ?>
@@ -135,7 +135,9 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 	}
 
 	/**
-	 * register scripts for count down
+	 * Registers the countdown script for PayNow QR code expiration.
+	 *
+	 * @param string $expires_at The expiration datetime in ISO 8601 format for the QR code.
 	 */
 	private function register_omise_countdown_script( $expires_at ) {
 		wp_enqueue_script(

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -93,7 +93,6 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 
 		$qrcode = $charge['source']['scannable_code']['image']['download_uri'];
 		$qrcode_id = $charge['source']['scannable_code']['image']['id'];
-		$qrcode_expires_at = $charge['expires_at'];
 
 		if ( 'view' === $context ) {
 			$expires_at_datetime = new DateTime( $charge['expires_at'] );

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -94,8 +94,14 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 		$qrcode = $charge['source']['scannable_code']['image']['download_uri'];
 		$qrcode_expires_at = $charge['expires_at'];
 
+		$expires_at_datetime = new DateTime( $charge['expires_at'] );
+		$qrcode_expires_at = $expires_at_datetime->format( 'c' );
+		$is_qrcode_expired = new DateTime() >= $expires_at_datetime;
+
 		if ( 'view' === $context ) {
-				$this->register_omise_countdown_script($qrcode_expires_at);
+			if ( ! $is_qrcode_expired ) {
+				$this->register_omise_countdown_script( $qrcode_expires_at );
+			}
 
 				$qrcode_id = $charge['source']['scannable_code']['image']['id'];
 				$order_key = $order->get_order_key();
@@ -114,6 +120,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 						'get_order_status_url' => $get_order_status_url,
 						'qrcode' => $qrcode,
 						'qrcode_id' => $qrcode_id,
+						'is_qrcode_expired' => $is_qrcode_expired === true ? 'true' : 'false',
 					)
 				);
 		} elseif ( 'email' === $context && ! $order->has_status( 'failed' ) ) { ?>
@@ -128,17 +135,19 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 	/**
 	 * register scripts for count down
 	 */
-	private function register_omise_countdown_script($expires_at) {
+	private function register_omise_countdown_script( $expires_at ) {
 		wp_enqueue_script(
 			'omise-paynow-countdown',
-			plugins_url( '../assets/javascripts/omise-countdown.js', dirname( __FILE__ ) ),
+			plugins_url( '../assets/javascripts/omise-countdown.js', __DIR__ ),
 			array(),
 			WC_VERSION,
 			true
 		);
-		wp_localize_script('omise-paynow-countdown', 'omise', [
-			'countdown_id' => 'timer',
-			'qr_expires_at' => $expires_at
-		]);
+		wp_localize_script(
+			'omise-paynow-countdown', 'omise', [
+				'countdown_id' => 'timer',
+				'qr_expires_at' => $expires_at,
+			]
+		);
 	}
 }

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -92,18 +92,17 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 		}
 
 		$qrcode = $charge['source']['scannable_code']['image']['download_uri'];
+		$qrcode_id = $charge['source']['scannable_code']['image']['id'];
 		$qrcode_expires_at = $charge['expires_at'];
 
-		$expires_at_datetime = new DateTime( $charge['expires_at'] );
-		$qrcode_expires_at = $expires_at_datetime->format( 'c' );
-		$is_qrcode_expired = new DateTime() >= $expires_at_datetime;
-
 		if ( 'view' === $context ) {
+			$expires_at_datetime = new DateTime( $charge['expires_at'] );
+			$qrcode_expires_at = $expires_at_datetime->format( 'c' );
+			$is_qrcode_expired = new DateTime() >= $expires_at_datetime;
+
 			if ( ! $is_qrcode_expired ) {
 				$this->register_omise_countdown_script( $qrcode_expires_at );
-			}
 
-				$qrcode_id = $charge['source']['scannable_code']['image']['id'];
 				$order_key = $order->get_order_key();
 				$get_order_status_url = add_query_arg(
 					[
@@ -113,16 +112,19 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 					],
 					get_rest_url( null, 'omise/order-status' )
 				);
+			} else {
+				$get_order_status_url = '';
+			}
 
-				Omise_Util::render_view(
-					'templates/payment/paynow/qr.php',
-					array(
-						'get_order_status_url' => $get_order_status_url,
-						'qrcode' => $qrcode,
-						'qrcode_id' => $qrcode_id,
-						'is_qrcode_expired' => $is_qrcode_expired === true ? 'true' : 'false',
-					)
-				);
+			Omise_Util::render_view(
+				'templates/payment/paynow/qr.php',
+				array(
+					'get_order_status_url' => $get_order_status_url,
+					'qrcode' => $qrcode,
+					'qrcode_id' => $qrcode_id,
+					'is_qrcode_expired' => $is_qrcode_expired === true ? 'true' : 'false',
+				)
+			);
 		} elseif ( 'email' === $context && ! $order->has_status( 'failed' ) ) { ?>
 			<p>
 				<?php echo __( 'Scan the QR code to complete', 'omise' ); ?>

--- a/includes/gateway/class-omise-payment-paynow.php
+++ b/includes/gateway/class-omise-payment-paynow.php
@@ -40,7 +40,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 				'title'   => __( 'Enable/Disable', 'omise' ),
 				'type'    => 'checkbox',
 				'label'   => __( 'Enable Omise PayNow Payment', 'omise' ),
-				'default' => 'no'
+				'default' => 'no',
 			),
 
 			'title' => array(
@@ -54,7 +54,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 				'title'       => __( 'Description', 'omise' ),
 				'type'        => 'textarea',
 				'description' => __( 'This controls the description the user sees during checkout.', 'omise' ),
-				'default'     => __( 'You will not be charged yet. The PayNow QR code will be displayed at the next page.', 'omise' )
+				'default'     => __( 'You will not be charged yet. The PayNow QR code will be displayed at the next page.', 'omise' ),
 			),
 		);
 	}
@@ -67,7 +67,7 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 	 */
 	public function email_qrcode( $order, $sent_to_admin = false ) {
 		// Avoid sending QR code if email is sent to admin or if order is processing
-		if ( $sent_to_admin || is_a($order, 'WC_Order') && $order->get_status() == 'processing') {
+		if ( $sent_to_admin || is_a( $order, 'WC_Order' ) && $order->get_status() == 'processing' ) {
 			return;
 		}
 
@@ -91,101 +91,54 @@ class Omise_Payment_Paynow extends Omise_Payment_Offline {
 			return;
 		}
 
-		$qrcode    = $charge['source']['scannable_code']['image']['download_uri'];
+		$qrcode = $charge['source']['scannable_code']['image']['download_uri'];
+		$qrcode_expires_at = $charge['expires_at'];
 
-		if ( 'view' === $context ) : ?>
-			<?php
+		if ( 'view' === $context ) {
+				$this->register_omise_countdown_script($qrcode_expires_at);
+
+				$qrcode_id = $charge['source']['scannable_code']['image']['id'];
 				$order_key = $order->get_order_key();
 				$get_order_status_url = add_query_arg(
 					[
 						'key' => $order_key,
 						'_nonce' => wp_create_nonce( 'get_order_status_' . $order_key ),
-						'_wpnonce' => wp_create_nonce('wp_rest'),
+						'_wpnonce' => wp_create_nonce( 'wp_rest' ),
 					],
-					get_rest_url( null, 'omise/order-status')
+					get_rest_url( null, 'omise/order-status' )
 				);
-			?>
-			<div class="omise omise-paynow-details" <?php echo 'email' === $context ? 'style="margin-bottom: 4em; text-align:center;"' : ''; ?>>
-				<div class="omise omise-paynow-logo"></div>
-				<p>
-					<?php echo __( 'Scan the QR code to pay', 'omise' ); ?>
-				</p>
-				<div class="omise omise-paynow-qrcode">
-					<img src="<?php echo $qrcode; ?>" alt="Omise QR code ID: <?php echo $charge['source']['scannable_code']['image']['id']; ?>">
-				</div>
-				<div class="omise-paynow-payment-status">
-					<div class="pending">
-						<?php echo __( 'Payment session will time out in <span id="timer">10:00</span> minutes.', 'omise' ); ?>
-					</div>
-					<div class="completed" style="display:none">
-						<div class="green-check"></div>
-						<?php echo __( 'We\'ve received your payment.', 'omise' ); ?>
-					</div>
-					<div class="timeout" style="display:none">
-						<?php echo __( 'Payment session timed out. You can still complete QR payment by scanning the code sent to your email address.', 'omise' ); ?>
-					</div>
-				</div>
-			</div>
-			<script type="text/javascript">
-				<!--
-				var classPaymentPending   = document.getElementsByClassName("pending");
-				var classPaymentCompleted = document.getElementsByClassName("completed");
-				var classPaymentTimeout   = document.getElementsByClassName("timeout");
-				var classQrImage          = document.querySelector(".omise.omise-paynow-qrcode > img");
 
-				var refreshPaymentStatus = function(intervalIterator) {
-					var xmlhttp = new XMLHttpRequest();
-					xmlhttp.addEventListener("load", function() {
-						if (this.status == 200) {
-							var chargeState = JSON.parse(this.responseText);
-							if (chargeState.status == "processing") {
-								classQrImage.style.display = "none";
-								classPaymentPending[0].style.display = "none";
-								classPaymentCompleted[0].style.display = "block";
-								clearInterval(intervalIterator);
-							}
-						} else if (this.status == 403) {
-							clearInterval(intervalIterator);
-						}
-					});
-					xmlhttp.open('GET', '<?php echo $get_order_status_url ?>', true);
-					xmlhttp.send();
-				},
-				intervalTime = function(duration, display) {
-					var timer    = duration, minutes, seconds;
-					intervalIterator = setInterval(function () {
-						minutes      = parseInt(timer / 60, 10);
-						seconds      = parseInt(timer % 60, 10);
-						minutes = minutes < 10 ? "0" + minutes : minutes;
-						seconds = seconds < 10 ? "0" + seconds : seconds;
-						display.textContent = minutes + ":" + seconds;
-						if (--timer < 0) {
-							timer = duration;
-						}
-						if((timer % 5) == 0 && timer >= 5) {
-							refreshPaymentStatus(intervalIterator);
-						}
-						if(timer == 0) {
-							classPaymentPending[0].style.display = "none";
-							classPaymentTimeout[0].style.display = "block";
-							classQrImage.style.display = "none";
-							clearInterval(intervalIterator);
-						}
-					}, 1000);
-				};
-
-				window.onload = function () {
-					var duration = 60 * 10,
-					    display  = document.querySelector('#timer');
-					intervalTime(duration, display);
-				};
-			//-->
-			</script>
-		<?php elseif ( 'email' === $context && !$order->has_status('failed')) : ?>
+				Omise_Util::render_view(
+					'templates/payment/paynow/qr.php',
+					array(
+						'get_order_status_url' => $get_order_status_url,
+						'qrcode' => $qrcode,
+						'qrcode_id' => $qrcode_id,
+					)
+				);
+		} elseif ( 'email' === $context && ! $order->has_status( 'failed' ) ) { ?>
 			<p>
 				<?php echo __( 'Scan the QR code to complete', 'omise' ); ?>
 			</p>
 			<p><img src="<?php echo $qrcode; ?>"/></p>
-		<?php endif;
+			<?php
+		}
+	}
+
+	/**
+	 * register scripts for count down
+	 */
+	private function register_omise_countdown_script($expires_at) {
+		wp_enqueue_script(
+			'omise-paynow-countdown',
+			plugins_url( '../assets/javascripts/omise-countdown.js', dirname( __FILE__ ) ),
+			array(),
+			WC_VERSION,
+			true
+		);
+		wp_localize_script('omise-paynow-countdown', 'omise', [
+			'countdown_id' => 'timer',
+			'qr_expires_at' => $expires_at
+		]);
 	}
 }

--- a/includes/gateway/class-omise-payment-promptpay.php
+++ b/includes/gateway/class-omise-payment-promptpay.php
@@ -53,13 +53,14 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 	 */
 	private function register_omise_promptpay_count_down_script($expiresAt) {
 		wp_enqueue_script(
-			'omise-promptpay-count-down',
-			plugins_url( '../assets/javascripts/omise-promptpay-count-down.js', dirname( __FILE__ ) ),
+			'omise-promptpay-countdown',
+			plugins_url( '../assets/javascripts/omise-countdown.js', dirname( __FILE__ ) ),
 			array(),
 			WC_VERSION,
 			true
 		);
-		wp_localize_script('omise-promptpay-count-down', 'omise', [
+		wp_localize_script('omise-promptpay-countdown', 'omise', [
+			'countdown_id' => 'countdown',
 			// Format `c` is used to format as ISO string
 			'qr_expires_at' => $expiresAt->format('c')
 		]);
@@ -189,24 +190,7 @@ class Omise_Payment_Promptpay extends Omise_Payment_Offline {
 						validatePaymentResultTimerId = setInterval( validatePaymentResult, intervalTime );
 						setTimeout( function() { clearInterval( validatePaymentResultTimerId ); }, maxIntervalTime );
 
-						// 10 minutes
-						watch( 60, $( '#omise-timer' ) );
 						return validatePaymentResultTimerId;
-					}
-
-					let watch = function( duration, display ) {
-						let timer = duration, minutes, seconds;
-							timeInterval = setInterval( function () {
-								minutes = parseInt( timer / 60, 10 )
-								seconds = parseInt( timer % 60, 10 );
-
-								minutes = minutes < 10 ? "0" + minutes : minutes;
-								seconds = seconds < 10 ? "0" + seconds : seconds;
-
-								display.text( minutes + ":" + seconds );
-
-								if ( --timer < 0 ) { clearInterval(timeInterval); }
-							}, 1000);
 					}
 
 					let elementRefreshButton         = $( '#omise-offline-payment-refresh-status' ),

--- a/omise-util.php
+++ b/omise-util.php
@@ -6,7 +6,7 @@ if ( ! class_exists( 'Omise_Util' ) ) {
 		/**
 		 * Renders php template
 		 * @param string $viewPath
-		 * @param Array $viewData
+		 * @param array $viewData
 		 */
 		public static function render_view( $viewPath, $viewData ) {
 			require_once( plugin_dir_path( __FILE__ ) . $viewPath );

--- a/templates/payment/paynow/qr.php
+++ b/templates/payment/paynow/qr.php
@@ -65,8 +65,8 @@
 	window.onload = function () {
 		const display = document.querySelector('#timer');
 		const isExpired = '<?php echo $viewData['is_qrcode_expired']; ?>' === 'true';
-		const refreshIntervalInSeconds = 10; // refresh every 10 seconds
-		const maxIntervalTimeInSeconds = 10 * 60; // stop refreshing after 10 minutes
+		const refreshIntervalInSeconds = 10; // Refresh every 10 seconds
+		const maxIntervalTimeInSeconds = 10 * 60; // Stop refreshing after 10 minutes
 
 		if ( isExpired ) {
 			displayTimeout();
@@ -77,7 +77,7 @@
 		setTimeout( () => clearInterval(interval), maxIntervalTimeInSeconds * 1000 );
 
 		window.addEventListener('beforeunload', function() {
-		clearInterval(interval);
+			clearInterval(interval);
 		});
 	};
 </script>

--- a/templates/payment/paynow/qr.php
+++ b/templates/payment/paynow/qr.php
@@ -1,7 +1,7 @@
 <div class="omise omise-paynow-details">
 	<div class="omise omise-paynow-logo"></div>
-	<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
 	<div class="omise omise-paynow-qrcode">
+		<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
 		<img src="<?php echo $viewData['qrcode']; ?>" alt="Omise QR code ID: <?php echo $viewData['qrcode_id']; ?>">
 	</div>
 	<div class="omise-paynow-payment-status">
@@ -22,7 +22,7 @@
 	var classPaymentPending = document.getElementsByClassName("pending");
 	var classPaymentCompleted = document.getElementsByClassName("completed");
 	var classPaymentTimeout = document.getElementsByClassName("timeout");
-	var classQrImage = document.querySelector(".omise.omise-paynow-qrcode > img");
+	var classQrImage = document.querySelector(".omise.omise-paynow-qrcode");
 
 	const refreshPaymentStatus = function (intervalIterator) {
 		var xmlhttp = new XMLHttpRequest();
@@ -43,15 +43,18 @@
 		xmlhttp.send();
 	};
 
+	const displayTimeout = function () {
+		classPaymentPending[0].style.display = "none";
+		classPaymentTimeout[0].style.display = "block";
+		classQrImage.style.display = "none";
+	};
+
 	const refreshPaymentInterval = function (intervalTimeInSeconds) {
 		const interval = setInterval(function () {
-			console.log('Interval executed');
 			refreshPaymentStatus(interval);
 
 			if (timer == 0) {
-				classPaymentPending[0].style.display = "none";
-				classPaymentTimeout[0].style.display = "block";
-				classQrImage.style.display = "none";
+				displayTimeout();
 				clearInterval(interval);
 			}
 		}, intervalTimeInSeconds * 1000);
@@ -61,10 +64,20 @@
 
 	window.onload = function () {
 		const display = document.querySelector('#timer');
+		const isExpired = '<?php echo $viewData['is_qrcode_expired']; ?>' === 'true';
 		const refreshIntervalInSeconds = 10; // refresh every 10 seconds
 		const maxIntervalTimeInSeconds = 10 * 60; // stop refreshing after 10 minutes
 
+		if ( isExpired ) {
+			displayTimeout();
+			return;
+		}
+
 		const interval = refreshPaymentInterval(refreshIntervalInSeconds);
 		setTimeout( () => clearInterval(interval), maxIntervalTimeInSeconds * 1000 );
+
+		window.addEventListener('beforeunload', function() {
+		clearInterval(interval);
+		});
 	};
 </script>

--- a/templates/payment/paynow/qr.php
+++ b/templates/payment/paynow/qr.php
@@ -1,5 +1,5 @@
 <?php
-$is_qrcode_expired = $viewData['is_qrcode_expired'] === 'true' ? true : false;
+$is_qrcode_expired = $viewData['is_qrcode_expired'] === 'true';
 
 function display_class( $visible ) {
 	return $visible ? 'display:block' : 'display:none';
@@ -60,11 +60,6 @@ function display_class( $visible ) {
 	const refreshPaymentInterval = function (intervalTimeInSeconds) {
 		const interval = setInterval(function () {
 			refreshPaymentStatus(interval);
-
-			if (timer == 0) {
-				displayTimeout();
-				clearInterval(interval);
-			}
 		}, intervalTimeInSeconds * 1000);
 
 		return interval;

--- a/templates/payment/paynow/qr.php
+++ b/templates/payment/paynow/qr.php
@@ -1,18 +1,26 @@
+<?php
+$is_qrcode_expired = $viewData['is_qrcode_expired'] === 'true' ? true : false;
+
+function display_class( $visible ) {
+	return $visible ? 'display:block' : 'display:none';
+}
+?>
+
 <div class="omise omise-paynow-details">
 	<div class="omise omise-paynow-logo"></div>
-	<div class="omise omise-paynow-qrcode">
+	<div class="omise omise-paynow-qrcode" style="<?php echo display_class( ! $is_qrcode_expired ); ?>">
 		<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
 		<img src="<?php echo $viewData['qrcode']; ?>" alt="Omise QR code ID: <?php echo $viewData['qrcode_id']; ?>">
 	</div>
 	<div class="omise-paynow-payment-status">
-		<div class="pending">
+		<div class="pending" style="<?php echo display_class( ! $is_qrcode_expired ); ?>">
 			<?php echo __( 'Payment session will time out in: <span id="timer"></span>', 'omise' ); ?>
 		</div>
 		<div class="completed" style="display:none">
 			<div class="green-check"></div>
 			<?php echo __( 'We\'ve received your payment.', 'omise' ); ?>
 		</div>
-		<div class="timeout" style="display:none">
+		<div class="timeout" style="<?php echo display_class( $is_qrcode_expired ); ?>">
 			<?php echo __( 'Payment session timed out.', 'omise' ); ?>
 		</div>
 	</div>

--- a/templates/payment/paynow/qr.php
+++ b/templates/payment/paynow/qr.php
@@ -1,0 +1,70 @@
+<div class="omise omise-paynow-details">
+	<div class="omise omise-paynow-logo"></div>
+	<p><?php echo __( 'Scan the QR code to pay', 'omise' ); ?></p>
+	<div class="omise omise-paynow-qrcode">
+		<img src="<?php echo $viewData['qrcode']; ?>" alt="Omise QR code ID: <?php echo $viewData['qrcode_id']; ?>">
+	</div>
+	<div class="omise-paynow-payment-status">
+		<div class="pending">
+			<?php echo __( 'Payment session will time out in: <span id="timer"></span>', 'omise' ); ?>
+		</div>
+		<div class="completed" style="display:none">
+			<div class="green-check"></div>
+			<?php echo __( 'We\'ve received your payment.', 'omise' ); ?>
+		</div>
+		<div class="timeout" style="display:none">
+			<?php echo __( 'Payment session timed out.', 'omise' ); ?>
+		</div>
+	</div>
+</div>
+
+<script type="text/javascript">
+	var classPaymentPending = document.getElementsByClassName("pending");
+	var classPaymentCompleted = document.getElementsByClassName("completed");
+	var classPaymentTimeout = document.getElementsByClassName("timeout");
+	var classQrImage = document.querySelector(".omise.omise-paynow-qrcode > img");
+
+	const refreshPaymentStatus = function (intervalIterator) {
+		var xmlhttp = new XMLHttpRequest();
+		xmlhttp.addEventListener("load", function () {
+			if (this.status == 200) {
+				var chargeState = JSON.parse(this.responseText);
+				if (chargeState.status == "processing") {
+					classQrImage.style.display = "none";
+					classPaymentPending[0].style.display = "none";
+					classPaymentCompleted[0].style.display = "block";
+					clearInterval(intervalIterator);
+				}
+			} else if (this.status == 403) {
+				clearInterval(intervalIterator);
+			}
+		});
+		xmlhttp.open('GET', '<?php echo $viewData['get_order_status_url']; ?>', true);
+		xmlhttp.send();
+	};
+
+	const refreshPaymentInterval = function (intervalTimeInSeconds) {
+		const interval = setInterval(function () {
+			console.log('Interval executed');
+			refreshPaymentStatus(interval);
+
+			if (timer == 0) {
+				classPaymentPending[0].style.display = "none";
+				classPaymentTimeout[0].style.display = "block";
+				classQrImage.style.display = "none";
+				clearInterval(interval);
+			}
+		}, intervalTimeInSeconds * 1000);
+
+		return interval;
+	};
+
+	window.onload = function () {
+		const display = document.querySelector('#timer');
+		const refreshIntervalInSeconds = 10; // refresh every 10 seconds
+		const maxIntervalTimeInSeconds = 10 * 60; // stop refreshing after 10 minutes
+
+		const interval = refreshPaymentInterval(refreshIntervalInSeconds);
+		setTimeout( () => clearInterval(interval), maxIntervalTimeInSeconds * 1000 );
+	};
+</script>

--- a/tests/unit/includes/gateway/class-omise-payment-paynow-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-paynow-test.php
@@ -44,7 +44,13 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 		require_once __DIR__ . '/../../../../includes/gateway/class-omise-payment-paynow.php';
 		require_once __DIR__ . '/../../../../omise-woocommerce.php';
 
-		Monkey\Functions\stubs( [ 'wp_kses' => null ] );
+		Monkey\Functions\stubs(
+			[
+				'wp_kses' => null,
+				'plugins_url' => null,
+				'plugin_dir_path' => __DIR__ . '/../../../../',
+			]
+		);
 
 		$this->mockOmiseSetting( 'pkey_xxx', 'skey_xxx' );
 		$this->order = Mockery::mock( 'WC_Order' );
@@ -70,6 +76,7 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 			'omise-charge-get',
 			[
 				'status' => 'pending',
+				'expires_at' => '2025-09-22T16:20:14Z',
 				'source' => $this->paynow_source,
 			]
 		);
@@ -88,6 +95,21 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 				},
 			]
 		);
+		Monkey\Functions\expect( 'wp_enqueue_script' )
+			->once()
+			->with(
+				'omise-paynow-countdown',
+				'../assets/javascripts/omise-countdown.js',
+				[], WC_VERSION, true
+			);
+		Monkey\Functions\expect( 'wp_localize_script' )
+			->once()
+			->with(
+				'omise-paynow-countdown', 'omise', [
+					'countdown_id' => 'timer',
+					'qr_expires_at' => '2025-09-22T16:20:14Z',
+				]
+			);
 		Monkey\Functions\expect( 'wp_create_nonce' )->twice();
 		Monkey\Functions\expect( 'wp_create_nonce' )
 			->with( 'get_order_status_wc_order_kSwj6Gcnut4dU' )
@@ -104,7 +126,8 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 		$expected_qrcode_img = $this->paynow_source['scannable_code']['image']['download_uri'];
 		$this->assertEquals( 'Scan the QR code to pay', $page->findOneOrFalse( '.omise-paynow-details p' )->text() );
 		$this->assertEquals( $expected_qrcode_img, $page->findOneOrFalse( '.omise-paynow-qrcode img' )->getAttribute( 'src' ) );
-		$this->assertMatchesRegularExpression( '/Payment session will time out in 10:00 minutes./', $page->findOneOrFalse( '.omise-paynow-payment-status' )->text() );
+		$this->assertMatchesRegularExpression( '/Payment session will time out in:/', $page->findOneOrFalse( '.omise-paynow-payment-status' )->text() );
+		$this->assertNotFalse( $page->findOneOrFalse( '#timer' ) );
 	}
 
 	public function test_paynow_display_qrcode_skips_if_order_not_found() {

--- a/tests/unit/includes/gateway/class-omise-payment-paynow-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-paynow-test.php
@@ -65,6 +65,8 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 	}
 
 	public function test_paynow_display_qrcode_returns_qrcode_content() {
+		$charge_expires_at = ( new DateTime() )->modify( '+1 hour' )->format( 'c' );
+
 		$this->order->allows(
 			[
 				'get_id' => 123,
@@ -76,7 +78,7 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 			'omise-charge-get',
 			[
 				'status' => 'pending',
-				'expires_at' => '2025-09-22T16:20:14Z',
+				'expires_at' => $charge_expires_at,
 				'source' => $this->paynow_source,
 			]
 		);
@@ -107,7 +109,7 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 			->with(
 				'omise-paynow-countdown', 'omise', [
 					'countdown_id' => 'timer',
-					'qr_expires_at' => '2025-09-22T16:20:14Z',
+					'qr_expires_at' => $charge_expires_at,
 				]
 			);
 		Monkey\Functions\expect( 'wp_create_nonce' )->twice();
@@ -128,6 +130,47 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 		$this->assertEquals( $expected_qrcode_img, $page->findOneOrFalse( '.omise-paynow-qrcode img' )->getAttribute( 'src' ) );
 		$this->assertMatchesRegularExpression( '/Payment session will time out in:/', $page->findOneOrFalse( '.omise-paynow-payment-status' )->text() );
 		$this->assertNotFalse( $page->findOneOrFalse( '#timer' ) );
+	}
+
+	public function test_paynow_display_qrcode_returns_timeout_content_if_qrcode_is_expired() {
+		$charge_expires_at = ( new DateTime( 'yesterday' ) )->format( 'c' );
+
+		$this->order->allows(
+			[
+				'get_id' => 123,
+				'get_order_key' => 'wc_order_kSwj6Gcnut4dU',
+				'get_transaction_id' => 'chrg_test_1234567890',
+			]
+		);
+		$this->mockApiCall(
+			'omise-charge-get',
+			[
+				'status' => 'pending',
+				'expires_at' => $charge_expires_at,
+				'source' => $this->paynow_source,
+			]
+		);
+
+		$order = $this->order;
+		Monkey\Functions\stubs(
+			[
+				'wc_get_order' => function ( $id ) use ( $order ) {
+					return $id === 123 ? $order : null;
+				},
+			]
+		);
+		Monkey\Functions\expect( 'wp_enqueue_script' )->never();
+		Monkey\Functions\expect( 'wp_localize_script' )->never();
+		Monkey\Functions\expect( 'wp_create_nonce' )->never();
+
+		ob_start();
+		$this->omise_paynow->display_qrcode( $this->order->get_id() );
+		$output = ob_get_clean();
+		$page = HtmlDomParser::str_get_html( $output );
+
+		// Displayed content is controlled by JS script.
+		$this->assertNotFalse( $page->findOneOrFalse( '.timeout' ) );
+		$this->assertMatchesRegularExpression( '/const isExpired = \'true\'/', $page->findOneOrFalse( 'script' ) );
 	}
 
 	public function test_paynow_display_qrcode_skips_if_order_not_found() {

--- a/tests/unit/includes/gateway/class-omise-payment-paynow-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-paynow-test.php
@@ -130,6 +130,12 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 		$this->assertEquals( $expected_qrcode_img, $page->findOneOrFalse( '.omise-paynow-qrcode img' )->getAttribute( 'src' ) );
 		$this->assertMatchesRegularExpression( '/Payment session will time out in:/', $page->findOneOrFalse( '.omise-paynow-payment-status' )->text() );
 		$this->assertNotFalse( $page->findOneOrFalse( '#timer' ) );
+
+		$paynow_detail = $page->findOneOrFalse( '.omise-paynow-details' );
+		$this->assertMatchesRegularExpression( '/class="omise omise-paynow-qrcode" style="display:block"/', $paynow_detail );
+		$this->assertMatchesRegularExpression( '/class="pending" style="display:block"/', $paynow_detail );
+		$this->assertMatchesRegularExpression( '/class="completed" style="display:none"/', $paynow_detail );
+		$this->assertMatchesRegularExpression( '/class="timeout" style="display:none"/', $paynow_detail );
 	}
 
 	public function test_paynow_display_qrcode_returns_timeout_content_if_qrcode_is_expired() {
@@ -168,9 +174,13 @@ class Omise_Payment_Paynow_Test extends Bootstrap_Test_Setup {
 		$output = ob_get_clean();
 		$page = HtmlDomParser::str_get_html( $output );
 
-		// Displayed content is controlled by JS script.
-		$this->assertNotFalse( $page->findOneOrFalse( '.timeout' ) );
 		$this->assertMatchesRegularExpression( '/const isExpired = \'true\'/', $page->findOneOrFalse( 'script' ) );
+
+		$paynow_detail = $page->findOneOrFalse( '.omise-paynow-details' );
+		$this->assertMatchesRegularExpression( '/class="omise omise-paynow-qrcode" style="display:none"/', $paynow_detail );
+		$this->assertMatchesRegularExpression( '/class="pending" style="display:none"/', $paynow_detail );
+		$this->assertMatchesRegularExpression( '/class="completed" style="display:none"/', $paynow_detail );
+		$this->assertMatchesRegularExpression( '/class="timeout" style="display:block"/', $paynow_detail );
 	}
 
 	public function test_paynow_display_qrcode_skips_if_order_not_found() {

--- a/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-promptpay-test.php
@@ -64,9 +64,10 @@ class Omise_Payment_Promptpay_Test extends Omise_Payment_Offline_Test
             ]
         ]);
 
-        // check that qr_expires_at is passed to `omise-promptpay-count-down` script with omise object
+        // check that qr_expires_at is passed to `omise-promptpay-countdown` script with omise object
         $this->mockLocalizeScript->shouldReceive('call')
-            ->with('omise-promptpay-count-down', 'omise', [
+            ->with('omise-promptpay-countdown', 'omise', [
+                'countdown_id' => 'countdown',
                 'qr_expires_at' => $expiresAt
             ]);
 


### PR DESCRIPTION
## Description

- Remove 10 minutes hard-coded and use charge's `expires_at` for QR payment countdown timer.

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3538 (Please check Proof of Work in the ticket)

## Decision(s)

#### Behavior Changes
- Update order status request polling every 10 seconds.
- The polling will be run 10 minutes maximum. After 10 minutes, please manual refresh the page. This is to prevent the excessive server resource consumption. (Same behavior to PromptPay QR)

#### UI Changes
- Removed `You can still complete QR payment by scanning the code sent to your email address.` text from the timeout state as we're now countdown to the actual expiry time. When it is timed out, QR in the email also can't be used.
- Hide `Scan QR code to pay` along with QR image. The text is not necessary If QR image is not shown.
 
|Countdown timer|Successful Payment|Timeout|
|---|---|---|
|<img width="480" height="454" alt="image" src="https://github.com/user-attachments/assets/23933aeb-b58e-4388-9482-dc479056a24a" />|<img width="388" height="192" alt="image" src="https://github.com/user-attachments/assets/53097968-57eb-4619-bfe8-171c753b070e" />|<img width="592" height="256" alt="image" src="https://github.com/user-attachments/assets/0eee44e7-c064-48c9-bf59-821dfa6bc405" />|
  
## Rollback procedure

`default rollback procedure`
