### PR TITLE
[MIT-3651] Remove passkey settings

### DIFF
--- a/includes/blocks/gateways/omise-block-credit-card.php
+++ b/includes/blocks/gateways/omise-block-credit-card.php
@@ -95,7 +95,6 @@ class Omise_Block_Credit_Card extends AbstractPaymentMethodType {
             'locale'      => get_locale(),
             'public_key'  => Omise_Setting::instance()->public_key(),
             'is_active'   => $this->is_active(),
-            'is_passkey_enabled' => wc_string_to_bool($this->get_setting( 'is_passkey_enabled', 'no' )),
         ]);
     }
 }

--- a/includes/gateway/abstract-omise-payment-base-card.php
+++ b/includes/gateway/abstract-omise-payment-base-card.php
@@ -81,10 +81,6 @@ abstract class Omise_Payment_Base_Card extends Omise_Payment
 			]);
 		}
 
-		if ( $is_wc_block && wc_string_to_bool( $this->get_option( 'is_passkey_enabled', 'no' ) ) ) {
-			$data['authentication'] = 'PASSKEY';
-		}
-
 		if (!empty($omise_customer_id) && ! empty($card_id)) {
 			$data['customer'] = $omise_customer_id;
 			$data['card'] = $card_id;

--- a/includes/gateway/class-omise-payment-creditcard.php
+++ b/includes/gateway/class-omise-payment-creditcard.php
@@ -42,20 +42,6 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 	 * @see woocommerce/includes/abstracts/abstract-wc-settings-api.php
 	 */
 	function init_form_fields() {
-		$passkey_settings = array();
-
-		if (defined('OMISE_FEATURE_PASSKEY') && OMISE_FEATURE_PASSKEY === true) {
-			$passkey_settings = array(
-				'is_passkey_enabled' => array(
-					'title'       => __( 'Authentication', 'omise' ),
-					'type'        => 'checkbox',
-					'label'       => __( 'Enable Passkey Authentication', 'omise' ),
-					'default'     => 'no',
-					'description' => __( 'This option will enable Passkey authentication for card payments on checkout page when available.', 'omise' ),
-				),
-			);
-		}
-
 		$this->form_fields = array_merge(
 			array(
 				'enabled' => array(
@@ -78,7 +64,6 @@ class Omise_Payment_Creditcard extends Omise_Payment_Base_Card {
 					'description' => __( 'This controls the description the user sees during checkout.', 'omise' )
 				),
 			),
-			$passkey_settings,
 			array(
 				'advanced' => array(
 					'title'       => __( 'Advanced Settings', 'omise' ),

--- a/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
+++ b/tests/unit/includes/blocks/gateways/omise-block-credit-card-test.php
@@ -61,7 +61,6 @@ class Omise_Block_Credit_Card_Test extends Omise_Test_Case {
 			'title' => 'Credit Card',
 			'description' => 'This is Credit Card payment method.',
 			'enabled' => 'yes',
-			'is_passkey_enabled' => 'no',
 		];
 		Monkey\Functions\expect( 'get_option' )
 			->once()
@@ -81,7 +80,6 @@ class Omise_Block_Credit_Card_Test extends Omise_Test_Case {
 		$this->assertEquals( 'th', $data['locale'] );
 		$this->assertEquals( 'pkey_xxx', $data['public_key'] );
 		$this->assertEquals( true, $data['is_active'] );
-		$this->assertEquals( false, $data['is_passkey_enabled'] );
 	}
 
 	public function test_get_payment_method_script_handles() {

--- a/tests/unit/includes/gateway/abstract-omise-payment-base-card-test.php
+++ b/tests/unit/includes/gateway/abstract-omise-payment-base-card-test.php
@@ -87,7 +87,7 @@ class Omise_Payment_Base_Card_Test extends Omise_Test_Case {
 		$_POST['omise_token'] = 'tokn_123';
 		$_POST['omise_save_customer_card'] = '';
 
-		$klass = $this->new_instance( [ 'is_passkey_enabled' => 'no' ] );
+		$klass = $this->new_instance();
 		$klass->payment_action = 'auto_capture';
 		$result = $klass->charge( $order_mock->get_id(), $order_mock );
 
@@ -104,58 +104,6 @@ class Omise_Payment_Base_Card_Test extends Omise_Test_Case {
 		);
 		$this->assertEquals( 'charge', $result['object'] );
 		$this->assertEquals( 'chrg_test_no1t4tnemucod0e51mo', $result['id'] );
-	}
-
-	public function test_base_card_charge_with_wc_block_and_passkey_enabled() {
-		$charge_mock = Mockery::mock( 'overload:OmiseCharge' );
-		$charge_mock->shouldReceive( 'create' )->once()->andReturn( [ 'object' => 'charge' ] );
-		$order_mock = $this->get_order_mock( 2000, 'thb' );
-
-		$_POST['omise_token'] = 'tokn_567';
-		$_POST['omise_save_customer_card'] = '';
-		$_POST['wc_block_payment'] = '1';
-
-		$klass = $this->new_instance( [ 'is_passkey_enabled' => 'yes' ] );
-		$klass->payment_action = 'auto_capture';
-		$klass->charge( $order_mock->get_id(), $order_mock );
-
-		$charge_mock->shouldHaveReceived( 'create' )->once()->with(
-			[
-				'amount' => 200000,
-				'currency' => 'THB',
-				'description' => 'WooCommerce Order id 123',
-				'return_uri' => 'https://abc.com/order/complete',
-				'metadata' => [ 'order_id' => 123 ],
-				'card' => 'tokn_567',
-				'capture' => true,
-				'authentication' => 'PASSKEY',
-			]
-		);
-	}
-
-	public function test_base_card_charge_with_wc_shortcode_and_passkey_enabled() {
-		$charge_mock = Mockery::mock( 'overload:OmiseCharge' );
-		$charge_mock->shouldReceive( 'create' )->once()->andReturn( [ 'object' => 'charge' ] );
-		$order_mock = $this->get_order_mock( 100.50, 'thb' );
-
-		$_POST['omise_token'] = 'tokn_567';
-		$_POST['omise_save_customer_card'] = '';
-
-		$klass = $this->new_instance( [ 'is_passkey_enabled' => 'yes' ] );
-		$klass->payment_action = 'auto_capture';
-		$klass->charge( $order_mock->get_id(), $order_mock );
-
-		$charge_mock->shouldHaveReceived( 'create' )->once()->with(
-			[
-				'amount' => 10050,
-				'currency' => 'THB',
-				'description' => 'WooCommerce Order id 123',
-				'return_uri' => 'https://abc.com/order/complete',
-				'metadata' => [ 'order_id' => 123 ],
-				'card' => 'tokn_567',
-				'capture' => true,
-			]
-		);
 	}
 
 	public function test_base_card_result_with_paid_charge() {

--- a/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
+++ b/tests/unit/includes/gateway/class-omise-payment-creditcard-test.php
@@ -125,12 +125,4 @@ class Omise_Payment_CreditCard_Test extends Omise_Test_Case
             'accept_amex',
         ], array_keys($credit_card->form_fields));
     }
-
-    public function test_form_fields_include_passkey_setting_when_passkey_feature_is_enabled() {
-        define('OMISE_FEATURE_PASSKEY', true);
-
-        $credit_card = new Omise_Payment_Creditcard;
-
-        $this->assertArrayHasKey('is_passkey_enabled', $credit_card->form_fields);
-    }
 }


### PR DESCRIPTION
## Description

Remove passkey feature variable that is controlling passkey settings on WooCommerce. We're going to completely rely on the account settings.

However, the order note for passkey is still being kept. If the transaction uses passkey, merchant will be able to see it in the order note.

### Related links:

- https://opn-ooo.atlassian.net/browse/MIT-3651

## Rollback procedure

 `default rollback procedure`