### PR TITLE
add UI customization to UPA

### DIFF
--- a/assets/javascripts/card-form-customization.js
+++ b/assets/javascripts/card-form-customization.js
@@ -1,6 +1,6 @@
 function setDesignFormValues() {
   Object.keys(DEFAULT_FORM_DESIGN).forEach(function (componentKey) {
-    componentValues = DEFAULT_FORM_DESIGN[componentKey];
+    const componentValues = DEFAULT_FORM_DESIGN[componentKey];
     Object.keys(componentValues).forEach(function (key) {
       setInputValue(`${componentKey}\\[${key}\\]`, componentValues[key])
     })
@@ -8,15 +8,25 @@ function setDesignFormValues() {
 }
 
 function setInputValue(name, val) {
-  document.querySelector(`[name=${name}]`).value = val
+  const input = document.querySelector(`[name=${name}]`);
+  if (!input) {
+    return;
+  }
+
+  input.value = val;
 }
 
 function getInputValue(name) {
-  return document.querySelector(`[name=${name}]`).value
+  const input = document.querySelector(`[name=${name}]`);
+  return input ? input.value : null;
 }
 
 function setColorInputValue(element) {
-  valueElement = element.nextElementSibling
+  if (!element) {
+    return;
+  }
+
+  const valueElement = element.nextElementSibling
   if (!valueElement) {
     element.insertAdjacentHTML('afterend', `<span>${element.value}</span>`);
   } else {
@@ -30,29 +40,48 @@ function handleColorInputChanges() {
   colorInputs.forEach((element) => {
     const input = element.querySelector('.color-input')
 
+    if (!input) {
+      return;
+    }
+
     setColorInputValue(input)
     input.addEventListener('change', (event) => {
       setColorInputValue(event.target)
     });
 
     element.addEventListener('click', (event) => {
-      let input = event.target.querySelector('.color-input')
-      if (!input) {
-        input = event.target.previousElementSibling
+      if (event.target.classList && event.target.classList.contains('color-input')) {
+        return;
       }
+
+      let targetInput = null;
+      if (typeof event.target.querySelector === 'function') {
+        targetInput = event.target.querySelector('.color-input')
+      }
+
+      if (!targetInput) {
+        targetInput = element.querySelector('.color-input');
+      }
+
+      if (!targetInput) {
+        return;
+      }
+
       var clickEvent = new MouseEvent('click');
-      input.dispatchEvent(clickEvent);
+      targetInput.dispatchEvent(clickEvent);
     });
   })
 }
 
 function getDesignFormValues() {
-  let formValues = DEFAULT_FORM_DESIGN
+  let formValues = JSON.parse(JSON.stringify(DEFAULT_FORM_DESIGN))
   Object.keys(DEFAULT_FORM_DESIGN).forEach(function (componentKey) {
-    componentValues = DEFAULT_FORM_DESIGN[componentKey];
+    const componentValues = DEFAULT_FORM_DESIGN[componentKey];
     Object.keys(componentValues).forEach(function (key) {
       const val = getInputValue(`${componentKey}\\[${key}\\]`)
-      formValues[componentKey][key] = val;
+      if (val !== null) {
+        formValues[componentKey][key] = val;
+      }
     })
   });
   return formValues;
@@ -60,14 +89,22 @@ function getDesignFormValues() {
 
 function handleFontChange() {
   const fontName = document.getElementById('omise_sf_font_name');
+  const customFontName = document.getElementById('omise_sf_custom_font_name');
+
+  if (!fontName || !customFontName) {
+    return;
+  }
 
   if (fontName.value === OMISE_CUSTOM_FONT_OTHER) {
-    document.getElementById('omise_sf_custom_font_name').style.display = null
+    customFontName.style.display = null
   }
 
   fontName.addEventListener('change', (event) => {
-    const customFontName = document.getElementById('omise_sf_custom_font_name');
     const inputCustomFont = customFontName.querySelector('input')
+
+    if (!inputCustomFont) {
+      return;
+    }
 
     if (event.target.value === OMISE_CUSTOM_FONT_OTHER) {
       customFontName.style.display = null;

--- a/includes/admin/class-omise-page-card-form-customization.php
+++ b/includes/admin/class-omise-page-card-form-customization.php
@@ -100,6 +100,48 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 	}
 
 	/**
+	 * Retrieve style payload for UPA session customization.
+	 *
+	 * @return array
+	 */
+	public function get_upa_style_settings()
+	{
+		$formDesign = $this->get_design_setting();
+
+		$themeColor = isset($formDesign['checkbox']['theme_color'])
+			? $formDesign['checkbox']['theme_color']
+			: '#1451cc';
+		$textColor = isset($formDesign['checkbox']['text_color'])
+			? $formDesign['checkbox']['text_color']
+			: '#1c2433';
+
+		return [
+			'theme_color' => $this->sanitize_hex_color($themeColor, '#1451cc'),
+			'text_color' => $this->sanitize_hex_color($textColor, '#1c2433')
+		];
+	}
+
+	/**
+	 * @param mixed  $value
+	 * @param string $fallback
+	 *
+	 * @return string
+	 */
+	private function sanitize_hex_color($value, $fallback)
+	{
+		if (!is_string($value)) {
+			return $fallback;
+		}
+
+		$value = trim($value);
+		if (preg_match('/^#(?:[A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/', $value)) {
+			return $value;
+		}
+
+		return $fallback;
+	}
+
+	/**
 	 * @param array $data
 	 *
 	 * @since  3.1

--- a/includes/admin/class-omise-page-card-form-customization.php
+++ b/includes/admin/class-omise-page-card-form-customization.php
@@ -9,6 +9,8 @@ if (class_exists('Omise_Page_Settings')) {
 class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 {
 	private static $instance;
+	const DEFAULT_UPA_THEME_COLOR = '#173799';
+	const DEFAULT_UPA_TEXT_COLOR  = '#FFFFFF';
 
 	public static function get_instance()
 	{
@@ -42,6 +44,10 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 			'checkbox' => [
 				'text_color' => '#1c2433',
 				'theme_color' => '#1451cc',
+			],
+			'upa' => [
+				'theme_color' => self::DEFAULT_UPA_THEME_COLOR,
+				'text_color' => self::DEFAULT_UPA_TEXT_COLOR,
 			]
 		];
 	}
@@ -67,13 +73,21 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 			'checkbox' => [
 				'text_color' => '#E6EAF2',
 				'theme_color' => '#1451CC',
+			],
+			'upa' => [
+				'theme_color' => self::DEFAULT_UPA_THEME_COLOR,
+				'text_color' => self::DEFAULT_UPA_TEXT_COLOR,
 			]
 		];
 	}
 
 	protected function get_default_design_setting()
 	{
-		$theme = (new Omise_Payment_Creditcard())->get_option('card_form_theme');
+		$theme = 'light';
+		if (class_exists('Omise_Payment_Creditcard')) {
+			$theme = (new Omise_Payment_Creditcard())->get_option('card_form_theme');
+		}
+
 		return (empty($theme) || $theme == 'light')
 			? $this->get_light_theme()
 			: $this->get_dark_theme();
@@ -85,15 +99,21 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 	public function get_design_setting()
 	{
 		$formDesign = get_option(self::PAGE_NAME);
-		if (empty($formDesign)) {
-			$formDesign = $this->get_default_design_setting();
+		if (!is_array($formDesign)) {
+			$formDesign = [];
 		}
 
-		// Old saved settings might not have the newer fields. Make sure
-		// we add the missing field
-		// TODO: Find a better way to handle this
-		if (!in_array('custom_name', $formDesign['font'])) {
-			$formDesign['font']['custom_name'] = '';
+		$defaultValues = $this->get_default_design_setting();
+		foreach ($defaultValues as $componentKey => $componentValues) {
+			if (!isset($formDesign[$componentKey]) || !is_array($formDesign[$componentKey])) {
+				$formDesign[$componentKey] = [];
+			}
+
+			foreach ($componentValues as $key => $defaultValue) {
+				if (!array_key_exists($key, $formDesign[$componentKey])) {
+					$formDesign[$componentKey][$key] = $defaultValue;
+				}
+			}
 		}
 
 		return $formDesign;
@@ -107,20 +127,23 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 	public function get_upa_style_settings()
 	{
 		$formDesign = $this->get_design_setting();
+		$themeColor = self::DEFAULT_UPA_THEME_COLOR;
+		$textColor = self::DEFAULT_UPA_TEXT_COLOR;
 
-		if (!isset($formDesign['checkbox']) || !is_array($formDesign['checkbox'])) {
-			return [];
-		}
+		if (isset($formDesign['upa']) && is_array($formDesign['upa'])) {
+			if (isset($formDesign['upa']['theme_color'])) {
+				$sanitizedThemeColor = $this->sanitize_hex_color($formDesign['upa']['theme_color']);
+				if ('' !== $sanitizedThemeColor) {
+					$themeColor = $sanitizedThemeColor;
+				}
+			}
 
-		$themeColor = isset($formDesign['checkbox']['theme_color'])
-			? $this->sanitize_hex_color($formDesign['checkbox']['theme_color'])
-			: '';
-		$textColor = isset($formDesign['checkbox']['text_color'])
-			? $this->sanitize_hex_color($formDesign['checkbox']['text_color'])
-			: '';
-
-		if ('' === $themeColor || '' === $textColor) {
-			return [];
+			if (isset($formDesign['upa']['text_color'])) {
+				$sanitizedTextColor = $this->sanitize_hex_color($formDesign['upa']['text_color']);
+				if ('' !== $sanitizedTextColor) {
+					$textColor = $sanitizedTextColor;
+				}
+			}
 		}
 
 		return [
@@ -168,13 +191,15 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 		}
 		$options = [];
 		$defaultValues = $this->get_default_design_setting();
+		$existingValues = $this->get_design_setting();
 
 		// Sanitize the field POST params
 		// the fist loop get the component name. i.e input, checkout, font
 		// and send loop get the styling key of the component. i.e name, size, border, color
 		foreach ($defaultValues as $componentKey => $componentValue) {
 			foreach ($componentValue as $key => $val) {
-				$options[$componentKey][$key] = sanitize_text_field($data[$componentKey][$key]);
+				$value = isset($data[$componentKey][$key]) ? $data[$componentKey][$key] : $existingValues[$componentKey][$key];
+				$options[$componentKey][$key] = sanitize_text_field($value);
 			}
 		}
 

--- a/includes/admin/class-omise-page-card-form-customization.php
+++ b/includes/admin/class-omise-page-card-form-customization.php
@@ -108,37 +108,52 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 	{
 		$formDesign = $this->get_design_setting();
 
+		if (!isset($formDesign['checkbox']) || !is_array($formDesign['checkbox'])) {
+			return [];
+		}
+
 		$themeColor = isset($formDesign['checkbox']['theme_color'])
-			? $formDesign['checkbox']['theme_color']
-			: '#1451cc';
+			? $this->sanitize_hex_color($formDesign['checkbox']['theme_color'])
+			: '';
 		$textColor = isset($formDesign['checkbox']['text_color'])
-			? $formDesign['checkbox']['text_color']
-			: '#1c2433';
+			? $this->sanitize_hex_color($formDesign['checkbox']['text_color'])
+			: '';
+
+		if ('' === $themeColor || '' === $textColor) {
+			return [];
+		}
 
 		return [
-			'theme_color' => $this->sanitize_hex_color($themeColor, '#1451cc'),
-			'text_color' => $this->sanitize_hex_color($textColor, '#1c2433')
+			'theme_color' => $themeColor,
+			'text_color' => $textColor
 		];
 	}
 
 	/**
-	 * @param mixed  $value
-	 * @param string $fallback
+	 * @param mixed $value
 	 *
 	 * @return string
 	 */
-	private function sanitize_hex_color($value, $fallback)
+	private function sanitize_hex_color($value)
 	{
 		if (!is_string($value)) {
-			return $fallback;
+			return '';
 		}
 
 		$value = trim($value);
+		if (function_exists('sanitize_hex_color')) {
+			$sanitized = sanitize_hex_color($value);
+
+			if (is_string($sanitized) && '' !== $sanitized) {
+				return $sanitized;
+			}
+		}
+
 		if (preg_match('/^#(?:[A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/', $value)) {
 			return $value;
 		}
 
-		return $fallback;
+		return '';
 	}
 
 	/**

--- a/includes/admin/class-omise-page-card-form-customization.php
+++ b/includes/admin/class-omise-page-card-form-customization.php
@@ -127,24 +127,8 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 	public function get_upa_style_settings()
 	{
 		$formDesign = $this->get_design_setting();
-		$themeColor = self::DEFAULT_UPA_THEME_COLOR;
-		$textColor = self::DEFAULT_UPA_TEXT_COLOR;
-
-		if (isset($formDesign['upa']) && is_array($formDesign['upa'])) {
-			if (isset($formDesign['upa']['theme_color'])) {
-				$sanitizedThemeColor = $this->sanitize_hex_color($formDesign['upa']['theme_color']);
-				if ('' !== $sanitizedThemeColor) {
-					$themeColor = $sanitizedThemeColor;
-				}
-			}
-
-			if (isset($formDesign['upa']['text_color'])) {
-				$sanitizedTextColor = $this->sanitize_hex_color($formDesign['upa']['text_color']);
-				if ('' !== $sanitizedTextColor) {
-					$textColor = $sanitizedTextColor;
-				}
-			}
-		}
+		$themeColor = $this->sanitize_hex_color($formDesign['upa']['theme_color']) ?: self::DEFAULT_UPA_THEME_COLOR;
+		$textColor = $this->sanitize_hex_color($formDesign['upa']['text_color']) ?: self::DEFAULT_UPA_TEXT_COLOR;
 
 		return [
 			'theme_color' => $themeColor,
@@ -163,13 +147,7 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 			return '';
 		}
 
-		$value = trim($value);
-		$sanitized = sanitize_hex_color($value);
-		if (is_string($sanitized) && '' !== $sanitized) {
-			return $sanitized;
-		}
-
-		return '';
+		return sanitize_hex_color(trim($value)) ?: '';
 	}
 
 	/**

--- a/includes/admin/class-omise-page-card-form-customization.php
+++ b/includes/admin/class-omise-page-card-form-customization.php
@@ -164,19 +164,41 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 		}
 
 		$value = trim($value);
-		if (function_exists('sanitize_hex_color')) {
-			$sanitized = sanitize_hex_color($value);
-
-			if (is_string($sanitized) && '' !== $sanitized) {
-				return $sanitized;
-			}
-		}
-
-		if (preg_match('/^#(?:[A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/', $value)) {
-			return $value;
+		$sanitized = sanitize_hex_color($value);
+		if (is_string($sanitized) && '' !== $sanitized) {
+			return $sanitized;
 		}
 
 		return '';
+	}
+
+	/**
+	 * Sanitize UPA color settings on save to ensure persisted values are valid hex colors.
+	 *
+	 * @param string $componentKey
+	 * @param string $key
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	private function sanitize_upa_color_setting($componentKey, $key, $value)
+	{
+		if ('upa' !== $componentKey) {
+			return $value;
+		}
+
+		if ('theme_color' !== $key && 'text_color' !== $key) {
+			return $value;
+		}
+
+		$sanitized = $this->sanitize_hex_color($value);
+		if ('' !== $sanitized) {
+			return $sanitized;
+		}
+
+		return 'theme_color' === $key
+			? self::DEFAULT_UPA_THEME_COLOR
+			: self::DEFAULT_UPA_TEXT_COLOR;
 	}
 
 	/**
@@ -199,7 +221,8 @@ class Omise_Page_Card_From_Customization extends Omise_Admin_Page
 		foreach ($defaultValues as $componentKey => $componentValue) {
 			foreach ($componentValue as $key => $val) {
 				$value = isset($data[$componentKey][$key]) ? $data[$componentKey][$key] : $existingValues[$componentKey][$key];
-				$options[$componentKey][$key] = sanitize_text_field($value);
+				$sanitizedValue = sanitize_text_field($value);
+				$options[$componentKey][$key] = $this->sanitize_upa_color_setting($componentKey, $key, $sanitizedValue);
 			}
 		}
 

--- a/includes/admin/views/omise-page-card-form-customization.php
+++ b/includes/admin/views/omise-page-card-form-customization.php
@@ -173,7 +173,7 @@
           <td class="text-bold">UPA theme color</td>
           <td>
             <div class="color-input-container">
-              <input class="color-input" name="upa[theme_color]" type="color" value="#173799">
+              <input class="color-input" name="upa[theme_color]" type="color" value="<?php echo esc_attr( isset( $formDesign['upa']['theme_color'] ) ? $formDesign['upa']['theme_color'] : Omise_Page_Card_From_Customization::DEFAULT_UPA_THEME_COLOR ); ?>">
             </div>
             <div class="description">Select your theme color to apply with your UPA checkout page</div>
           </td>
@@ -183,7 +183,7 @@
           <td class="text-bold">UPA text color</td>
           <td>
             <div class="color-input-container">
-              <input class="color-input" name="upa[text_color]" type="color" value="#FFFFFF">
+              <input class="color-input" name="upa[text_color]" type="color" value="<?php echo esc_attr( isset( $formDesign['upa']['text_color'] ) ? $formDesign['upa']['text_color'] : Omise_Page_Card_From_Customization::DEFAULT_UPA_TEXT_COLOR ); ?>">
             </div>
             <div class="description">Select your text color to apply with your UPA checkout page</div>
           </td>

--- a/includes/admin/views/omise-page-card-form-customization.php
+++ b/includes/admin/views/omise-page-card-form-customization.php
@@ -4,6 +4,7 @@
   $cardFormTheme = $omiseCardGateway->get_option('card_form_theme');
   $cardIcons = $omiseCardGateway->get_card_icons();
   $publicKey = Omise()->settings()->public_key();
+  $isUpaEnabled = Omise_Setting::instance()->is_upa_enabled();
   $customFontOther = 'Other';
 ?>
 
@@ -162,6 +163,32 @@
           <div class="description">Select your theme color to apply with your checkbox</div>
         </td>
       </tr>
+
+      <?php if ($isUpaEnabled) : ?>
+        <tr>
+          <td class="text-extra-bold" colspan="2">UPA</td>
+        </tr>
+
+        <tr>
+          <td class="text-bold">UPA theme color</td>
+          <td>
+            <div class="color-input-container">
+              <input class="color-input" name="upa[theme_color]" type="color" value="#173799">
+            </div>
+            <div class="description">Select your theme color to apply with your UPA checkout page</div>
+          </td>
+        </tr>
+
+        <tr>
+          <td class="text-bold">UPA text color</td>
+          <td>
+            <div class="color-input-container">
+              <input class="color-input" name="upa[text_color]" type="color" value="#FFFFFF">
+            </div>
+            <div class="description">Select your text color to apply with your UPA checkout page</div>
+          </td>
+        </tr>
+      <?php endif; ?>
 
       <tr>
         <td>

--- a/includes/omise-upa/class-omise-upa-callback.php
+++ b/includes/omise-upa/class-omise-upa-callback.php
@@ -233,7 +233,7 @@ class Omise_UPA_Callback {
 
 		$action_hook = 'woocommerce_order_action_' . $payment_method . '_charge_capture';
 
-		return (bool) has_action( $action_hook );
+		return false !== has_action( $action_hook );
 	}
 
 	/**

--- a/includes/omise-upa/class-omise-upa-callback.php
+++ b/includes/omise-upa/class-omise-upa-callback.php
@@ -165,13 +165,29 @@ class Omise_UPA_Callback {
 		self::set_transaction_id( $order, $charge );
 
 		$order->payment_complete();
-		$order->add_order_note(
-			sprintf(
-				wp_kses( __( 'Omise UPA: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ), array( 'br' => array() ) ),
-				$order->get_total(),
-				$order->get_currency()
-			)
-		);
+		$is_paid            = isset( $charge['paid'] ) && (bool) $charge['paid'];
+		$is_authorized_only = isset( $charge['authorized'] ) && (bool) $charge['authorized'] && ! $is_paid;
+
+		if ( $is_authorized_only ) {
+			$order->add_order_note(
+				sprintf(
+					wp_kses( __( 'Omise UPA: Payment processing.<br/>An amount of %1$s %2$s has been authorized', 'omise' ), array( 'br' => array() ) ),
+					$order->get_total(),
+					$order->get_currency()
+				)
+			);
+			if ( self::supports_manual_capture_action( $order ) ) {
+				$order->update_meta_data( 'is_awaiting_capture', 'yes' );
+			}
+		} else {
+			$order->add_order_note(
+				sprintf(
+					wp_kses( __( 'Omise UPA: Payment successful.<br/>An amount of %1$s %2$s has been paid', 'omise' ), array( 'br' => array() ) ),
+					$order->get_total(),
+					$order->get_currency()
+				)
+			);
+		}
 		$order->update_meta_data( 'is_omise_payment_resolved', 'yes' );
 		$order->update_meta_data( Omise_UPA_Session_Service::META_RESOLVED, 'yes' );
 		$order->delete_meta_data( self::META_RETRY_ATTEMPTS );
@@ -185,6 +201,39 @@ class Omise_UPA_Callback {
 		if ( $should_redirect ) {
 			self::redirect_to_thank_you( $order, true );
 		}
+	}
+
+	/**
+	 * @param WC_Order $order
+	 *
+	 * @return bool
+	 */
+	private static function supports_manual_capture_action( $order ) {
+		if ( ! is_object( $order ) ) {
+			return false;
+		}
+
+		$payment_method = $order->get_payment_method();
+		if ( ! is_string( $payment_method ) || '' === $payment_method ) {
+			return false;
+		}
+		if ( function_exists( 'sanitize_key' ) ) {
+			$payment_method = sanitize_key( $payment_method );
+		} else {
+			$payment_method = sanitize_text_field( $payment_method );
+		}
+
+		if ( '' === $payment_method ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'has_action' ) ) {
+			return false;
+		}
+
+		$action_hook = 'woocommerce_order_action_' . $payment_method . '_charge_capture';
+
+		return (bool) has_action( $action_hook );
 	}
 
 	/**

--- a/includes/omise-upa/class-omise-upa-session-service.php
+++ b/includes/omise-upa/class-omise-upa-session-service.php
@@ -204,30 +204,25 @@ class Omise_UPA_Session_Service {
 	 * @return array
 	 */
 	private static function get_default_style_payload() {
-		$defaults = array(
-			'theme_color' => '#173799',
-			'text_color'  => '#FFFFFF',
+		$theme_color = defined( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_THEME_COLOR' )
+			? constant( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_THEME_COLOR' )
+			: '#173799';
+		$text_color = defined( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_TEXT_COLOR' )
+			? constant( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_TEXT_COLOR' )
+			: '#FFFFFF';
+
+		if ( ! is_string( $theme_color ) || '' === $theme_color ) {
+			$theme_color = '#173799';
+		}
+
+		if ( ! is_string( $text_color ) || '' === $text_color ) {
+			$text_color = '#FFFFFF';
+		}
+
+		return array(
+			'theme_color' => $theme_color,
+			'text_color'  => $text_color,
 		);
-
-		if ( ! class_exists( 'Omise_Page_Card_From_Customization' ) ) {
-			return $defaults;
-		}
-
-		if ( defined( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_THEME_COLOR' ) ) {
-			$theme = constant( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_THEME_COLOR' );
-			if ( is_string( $theme ) && '' !== $theme ) {
-				$defaults['theme_color'] = $theme;
-			}
-		}
-
-		if ( defined( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_TEXT_COLOR' ) ) {
-			$text = constant( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_TEXT_COLOR' );
-			if ( is_string( $text ) && '' !== $text ) {
-				$defaults['text_color'] = $text;
-			}
-		}
-
-		return $defaults;
 	}
 
 	/**
@@ -258,31 +253,15 @@ class Omise_UPA_Session_Service {
 	}
 
 	/**
-	 * Resolve canonical payment-action values while reusing gateway constants
-	 * when available.
+	 * Resolve canonical payment-action values used by UPA.
 	 *
 	 * @return array
 	 */
 	private static function get_payment_action_values() {
-		$values = array(
-			'auto_capture' => array( self::PAYMENT_ACTION_AUTO_CAPTURE ),
+		return array(
+			'auto_capture'   => array( self::PAYMENT_ACTION_AUTO_CAPTURE ),
 			'manual_capture' => array( self::PAYMENT_ACTION_MANUAL_CAPTURE ),
 		);
-
-		if ( class_exists( 'Omise_Payment_Base_Card' ) ) {
-			$values['auto_capture'][] = Omise_Payment_Base_Card::PAYMENT_ACTION_AUTHORIZE_CAPTURE;
-			$values['manual_capture'][] = Omise_Payment_Base_Card::PAYMENT_ACTION_AUTHORIZE;
-		}
-
-		if ( class_exists( 'Omise_Payment_RabbitLinePay' ) ) {
-			$values['auto_capture'][] = Omise_Payment_RabbitLinePay::PAYMENT_ACTION_AUTO_CAPTURE;
-			$values['manual_capture'][] = Omise_Payment_RabbitLinePay::PAYMENT_ACTION_MANUAL_CAPTURE;
-		}
-
-		$values['auto_capture'] = array_unique( $values['auto_capture'] );
-		$values['manual_capture'] = array_unique( $values['manual_capture'] );
-
-		return $values;
 	}
 
 	/**

--- a/includes/omise-upa/class-omise-upa-session-service.php
+++ b/includes/omise-upa/class-omise-upa-session-service.php
@@ -179,23 +179,7 @@ class Omise_UPA_Session_Service {
 			return $defaults;
 		}
 
-		$style = $page->get_upa_style_settings();
-		if ( ! is_array( $style ) ) {
-			return $defaults;
-		}
-
-		if ( empty( $style['theme_color'] ) || ! is_string( $style['theme_color'] ) ) {
-			$style['theme_color'] = $defaults['theme_color'];
-		}
-
-		if ( empty( $style['text_color'] ) || ! is_string( $style['text_color'] ) ) {
-			$style['text_color'] = $defaults['text_color'];
-		}
-
-		return array(
-			'theme_color' => $style['theme_color'],
-			'text_color'  => $style['text_color'],
-		);
+		return $page->get_upa_style_settings();
 	}
 
 	/**

--- a/includes/omise-upa/class-omise-upa-session-service.php
+++ b/includes/omise-upa/class-omise-upa-session-service.php
@@ -142,8 +142,12 @@ class Omise_UPA_Session_Service {
 				'order_id'  => (string) $order_id,
 				'order_key' => (string) $order->get_order_key(),
 			),
-			'style'           => self::resolve_style_payload(),
 		);
+
+		$style = self::resolve_style_payload();
+		if ( ! empty( $style ) ) {
+			$payload['style'] = $style;
+		}
 
 		$locale = substr( strtolower( get_locale() ), 0, 2 );
 		if ( ! empty( $locale ) ) {
@@ -164,31 +168,26 @@ class Omise_UPA_Session_Service {
 	 * @return array
 	 */
 	private static function resolve_style_payload() {
-		$defaults = array(
-			'theme_color' => '#1451cc',
-			'text_color'  => '#1c2433',
-		);
-
 		if ( ! class_exists( 'Omise_Page_Card_From_Customization' ) ) {
-			return $defaults;
+			return array();
 		}
 
 		$page = Omise_Page_Card_From_Customization::get_instance();
 		if ( ! $page ) {
-			return $defaults;
+			return array();
 		}
 
 		$style = $page->get_upa_style_settings();
 		if ( ! is_array( $style ) ) {
-			return $defaults;
+			return array();
 		}
 
 		if ( empty( $style['theme_color'] ) || ! is_string( $style['theme_color'] ) ) {
-			$style['theme_color'] = $defaults['theme_color'];
+			return array();
 		}
 
 		if ( empty( $style['text_color'] ) || ! is_string( $style['text_color'] ) ) {
-			$style['text_color'] = $defaults['text_color'];
+			return array();
 		}
 
 		return array(

--- a/includes/omise-upa/class-omise-upa-session-service.php
+++ b/includes/omise-upa/class-omise-upa-session-service.php
@@ -179,7 +179,21 @@ class Omise_UPA_Session_Service {
 			return $defaults;
 		}
 
-		return $page->get_upa_style_settings();
+		$style = $page->get_upa_style_settings();
+		if (
+			! is_array( $style ) ||
+			empty( $style['theme_color'] ) ||
+			! is_string( $style['theme_color'] ) ||
+			empty( $style['text_color'] ) ||
+			! is_string( $style['text_color'] )
+		) {
+			return $defaults;
+		}
+
+		return array(
+			'theme_color' => $style['theme_color'],
+			'text_color'  => $style['text_color'],
+		);
 	}
 
 	/**

--- a/includes/omise-upa/class-omise-upa-session-service.php
+++ b/includes/omise-upa/class-omise-upa-session-service.php
@@ -9,6 +9,9 @@ class Omise_UPA_Session_Service {
 	const META_FLOW           = 'omise_upa_flow';
 	const META_RESOLVED       = 'omise_upa_resolved';
 
+	const PAYMENT_ACTION_AUTO_CAPTURE   = 'auto_capture';
+	const PAYMENT_ACTION_MANUAL_CAPTURE = 'manual_capture';
+
 	const FLOW_OFFSITE = 'offsite';
 	const FLOW_OFFLINE = 'offline';
 
@@ -40,7 +43,7 @@ class Omise_UPA_Session_Service {
 		$state = Omise_UPA_State_Token::create();
 		$client = self::create_client();
 
-		$payload = self::build_payload( $order, $order_id, $source_type, $state );
+		$payload = self::build_payload( $gateway, $order, $order_id, $source_type, $state );
 		$session = $client->create_session( $payload );
 		$session_id = self::extract_session_id( $session );
 
@@ -115,14 +118,15 @@ class Omise_UPA_Session_Service {
 	}
 
 	/**
-	 * @param WC_Order $order
-	 * @param string   $order_id
-	 * @param string   $source_type
-	 * @param string   $state
+	 * @param Omise_Payment $gateway
+	 * @param WC_Order      $order
+	 * @param string        $order_id
+	 * @param string        $source_type
+	 * @param string        $state
 	 *
 	 * @return array
 	 */
-	private static function build_payload( $order, $order_id, $source_type, $state ) {
+	private static function build_payload( $gateway, $order, $order_id, $source_type, $state ) {
 		$currency = strtoupper( $order->get_currency() );
 		$payload = array(
 			'amount'          => Omise_Money::to_subunit( $order->get_total(), $currency ),
@@ -138,6 +142,7 @@ class Omise_UPA_Session_Service {
 				'order_id'  => (string) $order_id,
 				'order_key' => (string) $order->get_order_key(),
 			),
+			'style'           => self::resolve_style_payload(),
 		);
 
 		$locale = substr( strtolower( get_locale() ), 0, 2 );
@@ -145,7 +150,106 @@ class Omise_UPA_Session_Service {
 			$payload['locale'] = $locale;
 		}
 
+		$auto_capture = self::resolve_auto_capture_flag( $gateway );
+		if ( ! is_null( $auto_capture ) ) {
+			$payload['auto_capture'] = $auto_capture;
+		}
+
 		return $payload;
+	}
+
+	/**
+	 * Resolve UPA style configuration from merchant card customization settings.
+	 *
+	 * @return array
+	 */
+	private static function resolve_style_payload() {
+		$defaults = array(
+			'theme_color' => '#1451cc',
+			'text_color'  => '#1c2433',
+		);
+
+		if ( ! class_exists( 'Omise_Page_Card_From_Customization' ) ) {
+			return $defaults;
+		}
+
+		$page = Omise_Page_Card_From_Customization::get_instance();
+		if ( ! $page ) {
+			return $defaults;
+		}
+
+		$style = $page->get_upa_style_settings();
+		if ( ! is_array( $style ) ) {
+			return $defaults;
+		}
+
+		if ( empty( $style['theme_color'] ) || ! is_string( $style['theme_color'] ) ) {
+			$style['theme_color'] = $defaults['theme_color'];
+		}
+
+		if ( empty( $style['text_color'] ) || ! is_string( $style['text_color'] ) ) {
+			$style['text_color'] = $defaults['text_color'];
+		}
+
+		return array(
+			'theme_color' => $style['theme_color'],
+			'text_color'  => $style['text_color'],
+		);
+	}
+
+	/**
+	 * Resolve auto-capture behavior from gateway payment action.
+	 *
+	 * @param Omise_Payment $gateway
+	 *
+	 * @return bool|null
+	 */
+	private static function resolve_auto_capture_flag( $gateway ) {
+		$payment_action = isset( $gateway->payment_action ) ? $gateway->payment_action : null;
+
+		if ( ! is_string( $payment_action ) ) {
+			return null;
+		}
+
+		$payment_action = sanitize_text_field( $payment_action );
+		$action_values = self::get_payment_action_values();
+		if ( in_array( $payment_action, $action_values['auto_capture'], true ) ) {
+			return true;
+		}
+
+		if ( in_array( $payment_action, $action_values['manual_capture'], true ) ) {
+			return false;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve canonical payment-action values while reusing gateway constants
+	 * when available.
+	 *
+	 * @return array
+	 */
+	private static function get_payment_action_values() {
+		$values = array(
+			'auto_capture' => array( self::PAYMENT_ACTION_AUTO_CAPTURE ),
+			'manual_capture' => array( self::PAYMENT_ACTION_MANUAL_CAPTURE ),
+		);
+
+		if ( class_exists( 'Omise_Payment_Base_Card' ) ) {
+			$values['auto_capture'][] = Omise_Payment_Base_Card::PAYMENT_ACTION_AUTHORIZE_CAPTURE;
+			$values['manual_capture'][] = Omise_Payment_Base_Card::PAYMENT_ACTION_AUTHORIZE;
+		}
+
+		if ( class_exists( 'Omise_Payment_RabbitLinePay' ) ) {
+			$values['auto_capture'][] = Omise_Payment_RabbitLinePay::PAYMENT_ACTION_AUTO_CAPTURE;
+			$values['manual_capture'][] = Omise_Payment_RabbitLinePay::PAYMENT_ACTION_MANUAL_CAPTURE;
+		}
+
+		$values['auto_capture'] = array_unique( $values['auto_capture'] );
+		$values['manual_capture'] = array_unique( $values['manual_capture'] );
+
+		return $values;
 	}
 
 	/**

--- a/includes/omise-upa/class-omise-upa-session-service.php
+++ b/includes/omise-upa/class-omise-upa-session-service.php
@@ -168,32 +168,66 @@ class Omise_UPA_Session_Service {
 	 * @return array
 	 */
 	private static function resolve_style_payload() {
+		$defaults = self::get_default_style_payload();
+
 		if ( ! class_exists( 'Omise_Page_Card_From_Customization' ) ) {
-			return array();
+			return $defaults;
 		}
 
 		$page = Omise_Page_Card_From_Customization::get_instance();
 		if ( ! $page ) {
-			return array();
+			return $defaults;
 		}
 
 		$style = $page->get_upa_style_settings();
 		if ( ! is_array( $style ) ) {
-			return array();
+			return $defaults;
 		}
 
 		if ( empty( $style['theme_color'] ) || ! is_string( $style['theme_color'] ) ) {
-			return array();
+			$style['theme_color'] = $defaults['theme_color'];
 		}
 
 		if ( empty( $style['text_color'] ) || ! is_string( $style['text_color'] ) ) {
-			return array();
+			$style['text_color'] = $defaults['text_color'];
 		}
 
 		return array(
 			'theme_color' => $style['theme_color'],
 			'text_color'  => $style['text_color'],
 		);
+	}
+
+	/**
+	 * Resolve default UPA style colors.
+	 *
+	 * @return array
+	 */
+	private static function get_default_style_payload() {
+		$defaults = array(
+			'theme_color' => '#173799',
+			'text_color'  => '#FFFFFF',
+		);
+
+		if ( ! class_exists( 'Omise_Page_Card_From_Customization' ) ) {
+			return $defaults;
+		}
+
+		if ( defined( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_THEME_COLOR' ) ) {
+			$theme = constant( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_THEME_COLOR' );
+			if ( is_string( $theme ) && '' !== $theme ) {
+				$defaults['theme_color'] = $theme;
+			}
+		}
+
+		if ( defined( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_TEXT_COLOR' ) ) {
+			$text = constant( 'Omise_Page_Card_From_Customization::DEFAULT_UPA_TEXT_COLOR' );
+			if ( is_string( $text ) && '' !== $text ) {
+				$defaults['text_color'] = $text;
+			}
+		}
+
+		return $defaults;
 	}
 
 	/**

--- a/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
+++ b/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
@@ -10,7 +10,23 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
     protected function setUp(): void
     {
         Brain\Monkey\setUp();
-        Mockery::mock('alias:Omise_Admin_Page');
+        Brain\Monkey\Functions\stubs(
+            [
+                'sanitize_hex_color' => function ($value) {
+                    if (!is_string($value)) {
+                        return null;
+                    }
+
+                    $value = trim($value);
+                    if (preg_match('/^#(?:[A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/', $value)) {
+                        return $value;
+                    }
+
+                    return null;
+                }
+            ]
+        );
+        Mockery::mock('alias:Omise_Admin_Page')->shouldIgnoreMissing();
         require_once __DIR__ . '/../../../../includes/admin/class-omise-page-card-form-customization.php';
     }
 
@@ -280,6 +296,75 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
             ],
             $obj->get_upa_style_settings()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveSanitizesUpaColorsBeforePersisting()
+    {
+        $savedSettings = [
+            'font' => [
+                'name' => 'Poppins',
+                'size' => 16,
+                'custom_name' => '',
+            ],
+            'input' => [
+                'height' => '44px',
+                'border_radius' => '4px',
+                'border_color' => '#475266',
+                'active_border_color' => '#475266',
+                'background_color' => '#131926',
+                'label_color' => '#E6EAF2',
+                'text_color' => '#ffffff',
+                'placeholder_color' => '#DBDBDB',
+            ],
+            'checkbox' => [
+                'theme_color' => '#1451CC',
+                'text_color' => '#E6EAF2',
+            ],
+            'upa' => [
+                'theme_color' => '#1451CC',
+                'text_color' => '#FFFFFF',
+            ],
+        ];
+
+        $capturedOptions = null;
+
+        Brain\Monkey\Functions\stubs([
+            'get_option' => $savedSettings,
+            'wp_verify_nonce' => true,
+            'sanitize_text_field' => function ($value) {
+                return is_scalar($value) ? (string) $value : '';
+            },
+            'update_option' => function ($key, $value) use (&$capturedOptions) {
+                $capturedOptions = $value;
+                return true;
+            },
+        ]);
+
+        $obj = new class extends Omise_Page_Card_From_Customization {
+            public function runSave($data)
+            {
+                return $this->save($data);
+            }
+
+            protected function add_message($type, $message)
+            {
+            }
+        };
+
+        $obj->runSave([
+            'omise_setting_page_nonce' => 'nonce',
+            'upa' => [
+                'theme_color' => '#invalid',
+                'text_color' => '#abc',
+            ],
+        ]);
+
+        $this->assertIsArray($capturedOptions);
+        $this->assertSame('#173799', $capturedOptions['upa']['theme_color']);
+        $this->assertSame('#abc', $capturedOptions['upa']['text_color']);
     }
 
     /**

--- a/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
+++ b/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
@@ -44,6 +44,10 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
 			'checkbox' => [
 				'text_color' => '#1c2433',
 				'theme_color' => '#1451cc',
+			],
+			'upa' => [
+				'theme_color' => '#173799',
+				'text_color' => '#FFFFFF',
 			]
 		];
 
@@ -79,6 +83,10 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
 			'checkbox' => [
 				'text_color' => '#E6EAF2',
 				'theme_color' => '#1451CC',
+			],
+			'upa' => [
+				'theme_color' => '#173799',
+				'text_color' => '#FFFFFF',
 			]
 		];
 
@@ -128,14 +136,19 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
 
         $expected = $savedSettings;
         $expected['font']['custom_name'] = '';
+        $expected['upa'] = [
+            'theme_color' => '#173799',
+            'text_color' => '#FFFFFF',
+        ];
         $this->assertEqualsCanonicalizing($expected, $designValues);
         $this->assertArrayHasKey('custom_name', $designValues['font']);
+        $this->assertArrayHasKey('upa', $designValues);
     }
 
     /**
      * @test
      */
-    public function testGetUpaStyleSettingsReturnsCheckboxColors()
+    public function testGetUpaStyleSettingsReturnsUpaColorsAndIgnoresCheckboxColors()
     {
         $savedSettings = [
             'font' => [
@@ -154,6 +167,10 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
                 'placeholder_color' => '#DBDBDB',
             ],
             'checkbox' => [
+                'text_color' => '#111111',
+                'theme_color' => '#222222',
+            ],
+            'upa' => [
                 'text_color' => '#fff',
                 'theme_color' => '#096B68',
             ]
@@ -177,7 +194,7 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
     /**
      * @test
      */
-    public function testGetUpaStyleSettingsReturnsEmptyForInvalidColors()
+    public function testGetUpaStyleSettingsReturnsDefaultColorsForInvalidValues()
     {
         $savedSettings = [
             'font' => [
@@ -196,6 +213,10 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
                 'placeholder_color' => '#DBDBDB',
             ],
             'checkbox' => [
+                'text_color' => '#E6EAF2',
+                'theme_color' => '#1451CC',
+            ],
+            'upa' => [
                 'text_color' => 'invalid',
                 'theme_color' => '#invalid',
             ]
@@ -208,7 +229,10 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
         $obj = Omise_Page_Card_From_Customization::get_instance();
 
         $this->assertSame(
-            [],
+            [
+                'theme_color' => '#173799',
+                'text_color' => '#FFFFFF',
+            ],
             $obj->get_upa_style_settings()
         );
     }
@@ -216,7 +240,7 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
     /**
      * @test
      */
-    public function testGetUpaStyleSettingsReturnsEmptyWhenColorKeyMissing()
+    public function testGetUpaStyleSettingsReturnsDefaultsWhenColorKeyMissing()
     {
         $savedSettings = [
             'font' => [
@@ -236,6 +260,10 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
             ],
             'checkbox' => [
                 'theme_color' => '#1451CC',
+                'text_color' => '#E6EAF2',
+            ],
+            'upa' => [
+                'theme_color' => '#1451CC',
             ]
         ];
 
@@ -246,7 +274,10 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
         $obj = Omise_Page_Card_From_Customization::get_instance();
 
         $this->assertSame(
-            [],
+            [
+                'theme_color' => '#1451CC',
+                'text_color' => '#FFFFFF',
+            ],
             $obj->get_upa_style_settings()
         );
     }

--- a/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
+++ b/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
@@ -133,6 +133,90 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function testGetUpaStyleSettingsReturnsCheckboxColors()
+    {
+        $savedSettings = [
+            'font' => [
+                'name' => 'Poppins',
+                'size' => 16,
+                'custom_name' => '',
+            ],
+            'input' => [
+                'height' => '44px',
+                'border_radius' => '4px',
+                'border_color' => '#475266',
+                'active_border_color' => '#475266',
+                'background_color' => '#131926',
+                'label_color' => '#E6EAF2',
+                'text_color' => '#ffffff',
+                'placeholder_color' => '#DBDBDB',
+            ],
+            'checkbox' => [
+                'text_color' => '#fff',
+                'theme_color' => '#096B68',
+            ]
+        ];
+
+        Brain\Monkey\Functions\stubs([
+            'get_option' => $savedSettings,
+        ]);
+
+        $obj = Omise_Page_Card_From_Customization::get_instance();
+
+        $this->assertSame(
+            [
+                'theme_color' => '#096B68',
+                'text_color' => '#fff',
+            ],
+            $obj->get_upa_style_settings()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testGetUpaStyleSettingsFallsBackForInvalidColors()
+    {
+        $savedSettings = [
+            'font' => [
+                'name' => 'Poppins',
+                'size' => 16,
+                'custom_name' => '',
+            ],
+            'input' => [
+                'height' => '44px',
+                'border_radius' => '4px',
+                'border_color' => '#475266',
+                'active_border_color' => '#475266',
+                'background_color' => '#131926',
+                'label_color' => '#E6EAF2',
+                'text_color' => '#ffffff',
+                'placeholder_color' => '#DBDBDB',
+            ],
+            'checkbox' => [
+                'text_color' => 'invalid',
+                'theme_color' => '#invalid',
+            ]
+        ];
+
+        Brain\Monkey\Functions\stubs([
+            'get_option' => $savedSettings,
+        ]);
+
+        $obj = Omise_Page_Card_From_Customization::get_instance();
+
+        $this->assertSame(
+            [
+                'theme_color' => '#1451cc',
+                'text_color' => '#1c2433',
+            ],
+            $obj->get_upa_style_settings()
+        );
+    }
+
+    /**
      * Call protected/private method of a class.
      *
      * @param object $object    Instantiated object that we will run method on.

--- a/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
+++ b/tests/unit/includes/admin/class-omise-page-card-form-customization-test.php
@@ -177,7 +177,7 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
     /**
      * @test
      */
-    public function testGetUpaStyleSettingsFallsBackForInvalidColors()
+    public function testGetUpaStyleSettingsReturnsEmptyForInvalidColors()
     {
         $savedSettings = [
             'font' => [
@@ -208,10 +208,45 @@ class Omise_Page_Card_From_Customization_Test extends TestCase
         $obj = Omise_Page_Card_From_Customization::get_instance();
 
         $this->assertSame(
-            [
-                'theme_color' => '#1451cc',
-                'text_color' => '#1c2433',
+            [],
+            $obj->get_upa_style_settings()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testGetUpaStyleSettingsReturnsEmptyWhenColorKeyMissing()
+    {
+        $savedSettings = [
+            'font' => [
+                'name' => 'Poppins',
+                'size' => 16,
+                'custom_name' => '',
             ],
+            'input' => [
+                'height' => '44px',
+                'border_radius' => '4px',
+                'border_color' => '#475266',
+                'active_border_color' => '#475266',
+                'background_color' => '#131926',
+                'label_color' => '#E6EAF2',
+                'text_color' => '#ffffff',
+                'placeholder_color' => '#DBDBDB',
+            ],
+            'checkbox' => [
+                'theme_color' => '#1451CC',
+            ]
+        ];
+
+        Brain\Monkey\Functions\stubs([
+            'get_option' => $savedSettings,
+        ]);
+
+        $obj = Omise_Page_Card_From_Customization::get_instance();
+
+        $this->assertSame(
+            [],
             $obj->get_upa_style_settings()
         );
     }

--- a/tests/unit/includes/omise-upa/class-omise-upa-callback-coverage-test.php
+++ b/tests/unit/includes/omise-upa/class-omise-upa-callback-coverage-test.php
@@ -163,6 +163,116 @@ class Omise_UPA_Callback_Coverage_Test extends Omise_Test_Case {
 		Omise_UPA_Callback::complete();
 	}
 
+	public function test_complete_processes_authorized_result_and_sets_awaiting_capture() {
+		$_GET = array(
+			'order_id'        => '44',
+			'omise_upa_state' => 'state_123',
+		);
+
+		Omise_UPA_Payment_Resolver::$responses = array(
+			array(
+				'state' => Omise_UPA_Payment_Resolver::STATE_SUCCESSFUL,
+				'charge' => array(
+					'id'         => 'chrg_auth_123',
+					'authorized' => true,
+					'paid'       => false,
+				),
+			),
+		);
+
+		$order_received_url = 'https://shop.test/checkout/order-received/44/?key=wc_order_abc';
+		$guarded_url        = $order_received_url . '&omise_upa_guard=1';
+
+		$order = Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_meta' )
+			->once()
+			->with( Omise_UPA_Session_Service::META_STATE )
+			->andReturn( 'state_123' );
+		$order->shouldReceive( 'is_paid' )->once()->andReturn( false );
+		$order->shouldReceive( 'get_transaction_id' )->once()->andReturn( '' );
+		$order->shouldReceive( 'set_transaction_id' )->once()->with( 'chrg_auth_123' );
+		$order->shouldReceive( 'payment_complete' )->once();
+		$order->shouldReceive( 'add_order_note' )
+			->once()
+			->with( Mockery::on( function( $note ) {
+				return false !== strpos( $note, 'has been authorized' );
+			} ) );
+		$order->shouldReceive( 'get_total' )->once()->andReturn( '1000.00' );
+		$order->shouldReceive( 'get_currency' )->once()->andReturn( 'THB' );
+		$order->shouldReceive( 'get_payment_method' )->once()->andReturn( 'omise_rabbit_linepay' );
+		$order->shouldReceive( 'update_meta_data' )->once()->with( 'is_awaiting_capture', 'yes' );
+		$order->shouldReceive( 'update_meta_data' )->once()->with( 'is_omise_payment_resolved', 'yes' );
+		$order->shouldReceive( 'update_meta_data' )->once()->with( Omise_UPA_Session_Service::META_RESOLVED, 'yes' );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( Omise_UPA_Callback::META_RETRY_ATTEMPTS );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( Omise_UPA_Session_Service::META_STATE );
+		$order->shouldReceive( 'save' )->once();
+		$order->shouldReceive( 'get_checkout_order_received_url' )->once()->andReturn( $order_received_url );
+
+		$cart = Mockery::mock( 'WC_Cart' );
+		$cart->shouldReceive( 'empty_cart' )->once();
+
+		$wc = Mockery::mock( 'WooCommerce' );
+		$wc->cart = $cart;
+		self::$wc_instance = $wc;
+
+		Monkey\Functions\expect( 'wc_get_order' )
+			->once()
+			->with( 44 )
+			->andReturn( $order );
+		Monkey\Functions\expect( 'add_query_arg' )
+			->once()
+			->with( 'omise_upa_guard', '1', $order_received_url )
+			->andReturn( $guarded_url );
+		Monkey\Functions\expect( 'has_action' )
+			->once()
+			->with( 'woocommerce_order_action_omise_rabbit_linepay_charge_capture' )
+			->andReturn( 10 );
+		Monkey\Functions\expect( 'nocache_headers' )->once();
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->once()
+			->with( $guarded_url )
+			->andThrow( new Exception( 'redirected' ) );
+
+		$this->expectExceptionMessage( 'redirected' );
+		Omise_UPA_Callback::complete();
+	}
+
+	public function test_complete_authorized_result_skips_awaiting_capture_when_capture_action_is_unavailable() {
+		$charge = array(
+			'id'         => 'chrg_auth_456',
+			'authorized' => true,
+			'paid'       => false,
+		);
+		$order = Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_transaction_id' )->once()->andReturn( '' );
+		$order->shouldReceive( 'set_transaction_id' )->once()->with( 'chrg_auth_456' );
+		$order->shouldReceive( 'payment_complete' )->once();
+		$order->shouldReceive( 'add_order_note' )
+			->once()
+			->with( Mockery::on( function( $note ) {
+				return false !== strpos( $note, 'has been authorized' );
+			} ) );
+		$order->shouldReceive( 'get_total' )->once()->andReturn( '1000.00' );
+		$order->shouldReceive( 'get_currency' )->once()->andReturn( 'THB' );
+		$order->shouldReceive( 'get_payment_method' )->once()->andReturn( 'omise_mobilebanking' );
+		$order->shouldReceive( 'update_meta_data' )->never()->with( 'is_awaiting_capture', 'yes' );
+		$order->shouldReceive( 'update_meta_data' )->once()->with( 'is_omise_payment_resolved', 'yes' );
+		$order->shouldReceive( 'update_meta_data' )->once()->with( Omise_UPA_Session_Service::META_RESOLVED, 'yes' );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( Omise_UPA_Callback::META_RETRY_ATTEMPTS );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( Omise_UPA_Session_Service::META_STATE );
+		$order->shouldReceive( 'save' )->once();
+		Monkey\Functions\expect( 'has_action' )
+			->once()
+			->with( 'woocommerce_order_action_omise_mobilebanking_charge_capture' )
+			->andReturn( 0 );
+
+		$method = new ReflectionMethod( Omise_UPA_Callback::class, 'handle_successful_payment' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( null, $order, array( 'charge' => $charge ), false );
+	}
+
 	public function test_complete_processes_pending_result_and_schedules_recheck() {
 		$_GET = array(
 			'order_id'        => '44',

--- a/tests/unit/includes/omise-upa/class-omise-upa-callback-coverage-test.php
+++ b/tests/unit/includes/omise-upa/class-omise-upa-callback-coverage-test.php
@@ -264,7 +264,7 @@ class Omise_UPA_Callback_Coverage_Test extends Omise_Test_Case {
 		Monkey\Functions\expect( 'has_action' )
 			->once()
 			->with( 'woocommerce_order_action_omise_mobilebanking_charge_capture' )
-			->andReturn( 0 );
+			->andReturn( false );
 
 		$method = new ReflectionMethod( Omise_UPA_Callback::class, 'handle_successful_payment' );
 		if ( PHP_VERSION_ID < 80100 ) {

--- a/tests/unit/includes/omise-upa/class-omise-upa-session-service-test.php
+++ b/tests/unit/includes/omise-upa/class-omise-upa-session-service-test.php
@@ -250,7 +250,7 @@ class Omise_UPA_Session_Service_Test extends Omise_Test_Case {
 		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
 	}
 
-	public function test_create_checkout_session_omits_style_when_customization_returns_empty_array() {
+	public function test_create_checkout_session_uses_default_style_when_customization_returns_empty_array() {
 		$order = Mockery::mock( 'WC_Order' );
 		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );
 		$order->shouldReceive( 'get_total' )->andReturn( '1000.00' );
@@ -276,7 +276,9 @@ class Omise_UPA_Session_Service_Test extends Omise_Test_Case {
 		$client->shouldReceive( 'create_session' )->once()->with(
 			Mockery::on(
 				function( $payload ) {
-					return ! isset( $payload['style'] );
+					return isset( $payload['style']['theme_color'], $payload['style']['text_color'] )
+						&& '#173799' === $payload['style']['theme_color']
+						&& '#FFFFFF' === $payload['style']['text_color'];
 				}
 			)
 		)->andReturn(
@@ -302,7 +304,7 @@ class Omise_UPA_Session_Service_Test extends Omise_Test_Case {
 		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
 	}
 
-	public function test_create_checkout_session_omits_style_when_customization_class_not_available() {
+	public function test_create_checkout_session_uses_default_style_when_customization_class_not_available() {
 		$order = Mockery::mock( 'WC_Order' );
 		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );
 		$order->shouldReceive( 'get_total' )->andReturn( '1000.00' );
@@ -324,7 +326,9 @@ class Omise_UPA_Session_Service_Test extends Omise_Test_Case {
 		$client->shouldReceive( 'create_session' )->once()->with(
 			Mockery::on(
 				function( $payload ) {
-					return ! isset( $payload['style'] );
+					return isset( $payload['style']['theme_color'], $payload['style']['text_color'] )
+						&& '#173799' === $payload['style']['theme_color']
+						&& '#FFFFFF' === $payload['style']['text_color'];
 				}
 			)
 		)->andReturn(

--- a/tests/unit/includes/omise-upa/class-omise-upa-session-service-test.php
+++ b/tests/unit/includes/omise-upa/class-omise-upa-session-service-test.php
@@ -190,6 +190,164 @@ class Omise_UPA_Session_Service_Test extends Omise_Test_Case {
 		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
 	}
 
+	public function test_create_checkout_session_includes_style_from_card_customization_settings() {
+		$order = Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );
+		$order->shouldReceive( 'get_total' )->andReturn( '1000.00' );
+		$order->shouldReceive( 'get_order_key' )->andReturn( 'wc_order_abc' );
+		$order->shouldReceive( 'update_meta_data' )->times( 5 );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( 'omise_upa_retry_attempts' );
+		$order->shouldReceive( 'save' )->once();
+		$order->shouldReceive( 'add_order_note' )->once();
+
+		$gateway = new Omise_Payment_Offsite();
+		$gateway->source_type = 'truemoney';
+
+		$setting = Mockery::mock( 'alias:Omise_Setting' );
+		$setting->shouldReceive( 'instance' )->andReturn( $setting );
+		$setting->shouldReceive( 'get_upa_api_base_url' )->andReturn( 'https://upa.example.com' );
+		$setting->shouldReceive( 'secret_key' )->andReturn( 'skey_test_123' );
+
+		$customization = Mockery::mock( 'alias:Omise_Page_Card_From_Customization' );
+		$customization->shouldReceive( 'get_instance' )->andReturn( $customization );
+		$customization->shouldReceive( 'get_upa_style_settings' )->andReturn(
+			array(
+				'theme_color' => '#096B68',
+				'text_color'  => '#fff',
+			)
+		);
+
+		$client = Mockery::mock( 'overload:Omise_UPA_Client' );
+		$client->shouldReceive( 'create_session' )->once()->with(
+			Mockery::on(
+				function( $payload ) {
+					return isset( $payload['style']['theme_color'], $payload['style']['text_color'] )
+						&& '#096B68' === $payload['style']['theme_color']
+						&& '#fff' === $payload['style']['text_color']
+						&& ! isset( $payload['auto_capture'] );
+				}
+			)
+		)->andReturn(
+			array(
+				'id'           => 'sess_123',
+				'redirect_url' => 'https://upa.example.com/pay/sess_123',
+			)
+		);
+		$client->shouldReceive( 'get_base_url' )->andReturn( 'https://upa.example.com' );
+
+		Monkey\Functions\expect( 'wp_http_validate_url' )->andReturn( true );
+		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://shop.test/' );
+		Monkey\Functions\expect( 'add_query_arg' )->andReturnUsing(
+			function( $args, $url ) {
+				return $url . '?' . http_build_query( $args );
+			}
+		);
+		Monkey\Functions\expect( 'get_locale' )->andReturn( 'en_US' );
+
+		$result = Omise_UPA_Session_Service::create_checkout_session( $gateway, '99', $order );
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
+	}
+
+	public function test_create_checkout_session_sets_auto_capture_true_when_payment_action_is_auto_capture() {
+		$order = Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );
+		$order->shouldReceive( 'get_total' )->andReturn( '1000.00' );
+		$order->shouldReceive( 'get_order_key' )->andReturn( 'wc_order_abc' );
+		$order->shouldReceive( 'update_meta_data' )->times( 5 );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( 'omise_upa_retry_attempts' );
+		$order->shouldReceive( 'save' )->once();
+		$order->shouldReceive( 'add_order_note' )->once();
+
+		$gateway = new Omise_Payment_Offsite();
+		$gateway->source_type = 'rabbit_linepay';
+		$gateway->payment_action = 'auto_capture';
+
+		$setting = Mockery::mock( 'alias:Omise_Setting' );
+		$setting->shouldReceive( 'instance' )->andReturn( $setting );
+		$setting->shouldReceive( 'get_upa_api_base_url' )->andReturn( 'https://upa.example.com' );
+		$setting->shouldReceive( 'secret_key' )->andReturn( 'skey_test_123' );
+
+		$client = Mockery::mock( 'overload:Omise_UPA_Client' );
+		$client->shouldReceive( 'create_session' )->once()->with(
+			Mockery::on(
+				function( $payload ) {
+					return isset( $payload['auto_capture'] ) && true === $payload['auto_capture'];
+				}
+			)
+		)->andReturn(
+			array(
+				'id'           => 'sess_123',
+				'redirect_url' => 'https://upa.example.com/pay/sess_123',
+			)
+		);
+		$client->shouldReceive( 'get_base_url' )->andReturn( 'https://upa.example.com' );
+
+		Monkey\Functions\expect( 'wp_http_validate_url' )->andReturn( true );
+		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://shop.test/' );
+		Monkey\Functions\expect( 'add_query_arg' )->andReturnUsing(
+			function( $args, $url ) {
+				return $url . '?' . http_build_query( $args );
+			}
+		);
+		Monkey\Functions\expect( 'get_locale' )->andReturn( 'en_US' );
+
+		$result = Omise_UPA_Session_Service::create_checkout_session( $gateway, '99', $order );
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
+	}
+
+	public function test_create_checkout_session_sets_auto_capture_false_when_payment_action_is_manual_capture() {
+		$order = Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );
+		$order->shouldReceive( 'get_total' )->andReturn( '1000.00' );
+		$order->shouldReceive( 'get_order_key' )->andReturn( 'wc_order_abc' );
+		$order->shouldReceive( 'update_meta_data' )->times( 5 );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( 'omise_upa_retry_attempts' );
+		$order->shouldReceive( 'save' )->once();
+		$order->shouldReceive( 'add_order_note' )->once();
+
+		$gateway = new Omise_Payment_Offsite();
+		$gateway->source_type = 'rabbit_linepay';
+		$gateway->payment_action = 'manual_capture';
+
+		$setting = Mockery::mock( 'alias:Omise_Setting' );
+		$setting->shouldReceive( 'instance' )->andReturn( $setting );
+		$setting->shouldReceive( 'get_upa_api_base_url' )->andReturn( 'https://upa.example.com' );
+		$setting->shouldReceive( 'secret_key' )->andReturn( 'skey_test_123' );
+
+		$client = Mockery::mock( 'overload:Omise_UPA_Client' );
+		$client->shouldReceive( 'create_session' )->once()->with(
+			Mockery::on(
+				function( $payload ) {
+					return isset( $payload['auto_capture'] ) && false === $payload['auto_capture'];
+				}
+			)
+		)->andReturn(
+			array(
+				'id'           => 'sess_123',
+				'redirect_url' => 'https://upa.example.com/pay/sess_123',
+			)
+		);
+		$client->shouldReceive( 'get_base_url' )->andReturn( 'https://upa.example.com' );
+
+		Monkey\Functions\expect( 'wp_http_validate_url' )->andReturn( true );
+		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://shop.test/' );
+		Monkey\Functions\expect( 'add_query_arg' )->andReturnUsing(
+			function( $args, $url ) {
+				return $url . '?' . http_build_query( $args );
+			}
+		);
+		Monkey\Functions\expect( 'get_locale' )->andReturn( 'en_US' );
+
+		$result = Omise_UPA_Session_Service::create_checkout_session( $gateway, '99', $order );
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
+	}
+
 	public function test_create_checkout_session_throws_when_source_type_empty() {
 		$gateway = new Omise_Payment_Offsite();
 		$gateway->source_type = '';

--- a/tests/unit/includes/omise-upa/class-omise-upa-session-service-test.php
+++ b/tests/unit/includes/omise-upa/class-omise-upa-session-service-test.php
@@ -250,6 +250,106 @@ class Omise_UPA_Session_Service_Test extends Omise_Test_Case {
 		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
 	}
 
+	public function test_create_checkout_session_omits_style_when_customization_returns_empty_array() {
+		$order = Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );
+		$order->shouldReceive( 'get_total' )->andReturn( '1000.00' );
+		$order->shouldReceive( 'get_order_key' )->andReturn( 'wc_order_abc' );
+		$order->shouldReceive( 'update_meta_data' )->times( 5 );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( 'omise_upa_retry_attempts' );
+		$order->shouldReceive( 'save' )->once();
+		$order->shouldReceive( 'add_order_note' )->once();
+
+		$gateway = new Omise_Payment_Offsite();
+		$gateway->source_type = 'truemoney';
+
+		$setting = Mockery::mock( 'alias:Omise_Setting' );
+		$setting->shouldReceive( 'instance' )->andReturn( $setting );
+		$setting->shouldReceive( 'get_upa_api_base_url' )->andReturn( 'https://upa.example.com' );
+		$setting->shouldReceive( 'secret_key' )->andReturn( 'skey_test_123' );
+
+		$customization = Mockery::mock( 'alias:Omise_Page_Card_From_Customization' );
+		$customization->shouldReceive( 'get_instance' )->andReturn( $customization );
+		$customization->shouldReceive( 'get_upa_style_settings' )->andReturn( array() );
+
+		$client = Mockery::mock( 'overload:Omise_UPA_Client' );
+		$client->shouldReceive( 'create_session' )->once()->with(
+			Mockery::on(
+				function( $payload ) {
+					return ! isset( $payload['style'] );
+				}
+			)
+		)->andReturn(
+			array(
+				'id'           => 'sess_123',
+				'redirect_url' => 'https://upa.example.com/pay/sess_123',
+			)
+		);
+		$client->shouldReceive( 'get_base_url' )->andReturn( 'https://upa.example.com' );
+
+		Monkey\Functions\expect( 'wp_http_validate_url' )->andReturn( true );
+		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://shop.test/' );
+		Monkey\Functions\expect( 'add_query_arg' )->andReturnUsing(
+			function( $args, $url ) {
+				return $url . '?' . http_build_query( $args );
+			}
+		);
+		Monkey\Functions\expect( 'get_locale' )->andReturn( 'en_US' );
+
+		$result = Omise_UPA_Session_Service::create_checkout_session( $gateway, '99', $order );
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
+	}
+
+	public function test_create_checkout_session_omits_style_when_customization_class_not_available() {
+		$order = Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );
+		$order->shouldReceive( 'get_total' )->andReturn( '1000.00' );
+		$order->shouldReceive( 'get_order_key' )->andReturn( 'wc_order_abc' );
+		$order->shouldReceive( 'update_meta_data' )->times( 5 );
+		$order->shouldReceive( 'delete_meta_data' )->once()->with( 'omise_upa_retry_attempts' );
+		$order->shouldReceive( 'save' )->once();
+		$order->shouldReceive( 'add_order_note' )->once();
+
+		$gateway = new Omise_Payment_Offsite();
+		$gateway->source_type = 'truemoney';
+
+		$setting = Mockery::mock( 'alias:Omise_Setting' );
+		$setting->shouldReceive( 'instance' )->andReturn( $setting );
+		$setting->shouldReceive( 'get_upa_api_base_url' )->andReturn( 'https://upa.example.com' );
+		$setting->shouldReceive( 'secret_key' )->andReturn( 'skey_test_123' );
+
+		$client = Mockery::mock( 'overload:Omise_UPA_Client' );
+		$client->shouldReceive( 'create_session' )->once()->with(
+			Mockery::on(
+				function( $payload ) {
+					return ! isset( $payload['style'] );
+				}
+			)
+		)->andReturn(
+			array(
+				'id'           => 'sess_123',
+				'redirect_url' => 'https://upa.example.com/pay/sess_123',
+			)
+		);
+		$client->shouldReceive( 'get_base_url' )->andReturn( 'https://upa.example.com' );
+
+		Monkey\Functions\expect( 'wp_http_validate_url' )->andReturn( true );
+		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://shop.test/' );
+		Monkey\Functions\expect( 'add_query_arg' )->andReturnUsing(
+			function( $args, $url ) {
+				return $url . '?' . http_build_query( $args );
+			}
+		);
+		Monkey\Functions\expect( 'get_locale' )->andReturn( 'en_US' );
+
+		$result = Omise_UPA_Session_Service::create_checkout_session( $gateway, '99', $order );
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( 'https://upa.example.com/pay/sess_123', $result['redirect'] );
+	}
+
 	public function test_create_checkout_session_sets_auto_capture_true_when_payment_action_is_auto_capture() {
 		$order = Mockery::mock( 'WC_Order' );
 		$order->shouldReceive( 'get_currency' )->andReturn( 'THB' );


### PR DESCRIPTION
## Description
- Passes merchant card customization colors to UPA session payload:
  - `style.theme_color`
  - `style.text_color`
- Maps WooCommerce `payment_action` to UPA `auto_capture`:
  - `auto_capture = true` for auto capture
  - `auto_capture = false` for manual capture
  - omits `auto_capture` when the gateway has no `payment_action`
- Updates UPA successful callback handling:
  - keeps paid flow behavior for fully paid charges
  - handles authorized-only charges as manual-capture flow
  - sets `is_awaiting_capture = yes` only when capture action is available for the order payment method


### More information (if any)

This keeps UPA behavior consistent with existing admin capture actions (`<payment_method>_charge_capture`) and avoids false awaiting-capture metadata for methods that cannot be captured manually.

### Related links:

- Reference PRs: https://github.com/omise/omise-woocommerce/pull/554
- Reference PRs: https://github.com/omise/omise-woocommerce/pull/555

## Decision(s)
N/A 

## Business impact (if any)
N/A

## Pre- or post-deployment steps (if any)
N/A 

## Rollback procedure

default rollback procedure