### PR TITLE
Hot fix/omise js cdn url rollback

### DIFF
--- a/omise-woocommerce.php
+++ b/omise-woocommerce.php
@@ -41,7 +41,7 @@ class Omise
 	 */
 	protected static $can_initiate = false;
 
-	CONST OMISE_JS_LINK = 'https://cdn.staging-omise.co/omise.js';
+	CONST OMISE_JS_LINK = 'https://cdn.omise.co/omise.js';
 
 	/**
 	 * @since  3.0

--- a/readme.txt
+++ b/readme.txt
@@ -36,9 +36,6 @@ From there:
 
 = 7.2.0 =
 
-- Add Omise UPA checkout-session flow for supported offline and offsite payment methods with controlled rollout, callback validation, redirect host validation, and pending payment rechecks. (PR: [#554](https://github.com/omise/omise-woocommerce/pull/554))
-- Support UPA installment redirection while keeping WLB installment on the legacy flow. (PR: [#555](https://github.com/omise/omise-woocommerce/pull/555))
-- Pass card form customization colors and capture behavior into UPA sessions. (PR: [#556](https://github.com/omise/omise-woocommerce/pull/556))
 - Fix Block checkout card brand icons to follow the Omise card form settings. (PR: [#562](https://github.com/omise/omise-woocommerce/pull/562))
 
 = 7.1.0 =

--- a/tests/unit/omise-woocommerce-test.php
+++ b/tests/unit/omise-woocommerce-test.php
@@ -81,6 +81,55 @@ class Omise_Test extends TestCase {
 		$this->assertEmpty( $output );
 	}
 
+	public function test_omise_js_link_uses_production_cdn() {
+		$this->assertSame( 'https://cdn.omise.co/omise.js', Omise::OMISE_JS_LINK );
+	}
+
+	public function test_production_omise_urls_are_used_in_committed_runtime_files() {
+		$root = realpath( __DIR__ . '/../..' );
+		$files = [
+			'omise-woocommerce.php' => [
+				'https://cdn.omise.co/omise.js',
+			],
+			'includes/class-omise-setting.php' => [
+				'https://checkout-page.omise.co/api',
+			],
+			'includes/gateway/abstract-omise-payment-base-card.php' => [
+				'Omise::OMISE_JS_LINK',
+			],
+			'includes/libraries/omise-php/lib/omise/res/OmiseApiResource.php' => [
+				'https://api.omise.co/',
+				'https://vault.omise.co/',
+			],
+		];
+		$violations = [];
+
+		foreach ( $files as $relativePath => $expectedValues ) {
+			$content = file_get_contents( $root . DIRECTORY_SEPARATOR . $relativePath );
+
+			foreach ( $expectedValues as $expectedValue ) {
+				if ( strpos( $content, $expectedValue ) === false ) {
+					$violations[] = $relativePath . ': missing ' . $expectedValue;
+				}
+			}
+
+			preg_match_all( '#https://[^\\s\'"]*omise[^\\s\'"]*#', $content, $matches );
+
+			foreach ( $matches[0] as $url ) {
+				$host = parse_url( $url, PHP_URL_HOST );
+
+				if (
+					preg_match( '/^(cdn|api|vault|checkout-page)\./', $host )
+					&& ! preg_match( '/(^|\.)omise\.co$/', $host )
+				) {
+					$violations[] = $relativePath . ': unexpected Omise URL ' . $url;
+				}
+			}
+		}
+
+		$this->assertSame( [], $violations, 'Committed runtime files must use omise.co URLs.' );
+	}
+
 	public function test_upgrade_plugin_updates_omise_version() {
 		$currentVersion = '7.1.0';
 		$updateVersion = '7.2.0';


### PR DESCRIPTION
## Description
- over looked Omise CND URL changed making OmiseJS not to be able to load in the production. 
- this PR revert the omise url and adding automation smoke tests on the url assertions to prevent the same from happening.

### Documentation (if any)
N/A

### Related links:
- CS reported 


## Business impact (if any)
- end user should be able to make payment using Card payment
  
## Pre- or post-deployment steps (if any)
- POST-DEP to verify if OmiseJS is loading in production mode using the latest release plugin.
 
## Rollback procedure
`default rollback procedure` 
